### PR TITLE
Adding MQTT-based interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,12 +104,14 @@ jobs:
           args: --examples
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
       - name: Start Mosquitto
-        uses: namoshek/mosquitto-github-action@v0.1.0
+        run: |
+          sudo apt-get install mosquitto
+          sudo service mosquitto start
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,23 @@ jobs:
         with:
           command: build
           args: --examples
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Start Mosquitto
+        uses: namoshek/mosquitto-github-action@v0.1.0
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          toolchain: stable
+          profile: minimal
+
+      - name: Cargo Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,15 @@ version = "0.1.0"
 authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@vertigo-designs.com"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 derive_stringset = {path="derive_stringset"}
 serde-json-core = "0.2.0"
 serde = {version = "1.0.120", features = ["derive"], default-features = false }
-minimq = {git = "https://github.com/quartiq/minimq.git"}
 heapless = "0.5"
+minimq = {git = "https://github.com/quartiq/minimq.git", branch = "feature/nb-update"}
 
 [dev-dependencies]
 machine = "0.3"
 std-embedded-nal = "=0.0.1"
 env_logger = "0.7"
+log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,10 @@ edition = "2018"
 derive_stringset = {path="derive_stringset"}
 serde-json-core = "0.2.0"
 serde = {version = "1.0.120", features = ["derive"], default-features = false }
+minimq = {git = "https://github.com/quartiq/minimq.git"}
+heapless = "0.5"
+
+[dev-dependencies]
+machine = "0.3"
+std-embedded-nal = "=0.0.1"
+env_logger = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@ve
 edition = "2018"
 
 [dependencies]
-derive_stringset = {path="derive_stringset"}
+derive_stringset = { path="derive_stringset" }
 serde-json-core = "0.2.0"
-serde = {version = "1.0.120", features = ["derive"], default-features = false }
+serde = { version = "1.0.120", features = ["derive"], default-features = false }
 heapless = "0.5"
-minimq = {git = "https://github.com/quartiq/minimq.git", branch = "feature/nb-update"}
+minimq = { git = "https://github.com/quartiq/minimq.git" }
 
 [dev-dependencies]
 machine = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 
 mod mqtt_interface;
 
-pub use mqtt_interface::{Error as MqttError, Action, MqttInterface};
 pub use minimq::{self, embedded_nal};
+pub use mqtt_interface::{Action, Error as MqttError, MqttInterface};
 
 pub use serde::de::{Deserialize, DeserializeOwned};
 pub use serde_json_core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
 #![no_std]
+
+mod mqtt_interface;
+
+pub use mqtt_interface::{Error as MqttError, Action, MqttInterface};
+pub use minimq::{self, embedded_nal};
+
 pub use serde::de::{Deserialize, DeserializeOwned};
 pub use serde_json_core;
 

--- a/src/mqtt_interface.rs
+++ b/src/mqtt_interface.rs
@@ -1,25 +1,25 @@
-use minimq::{
-    embedded_nal::{TcpStack, IpAddr, Ipv4Addr},
-    QoS, Property, MqttClient
-};
-use heapless::{String, consts};
-use core::fmt::Write;
 use super::StringSet;
+use core::fmt::Write;
+use heapless::{consts, String};
+use minimq::{
+    embedded_nal::{IpAddr, TcpStack},
+    MqttClient, Property, QoS,
+};
 
 #[derive(Debug)]
-pub enum Error<S: TcpStack> where S::Error: core::fmt::Debug {
+pub enum Error<E: core::fmt::Debug> {
     /// The provided device ID is too long.
     IdTooLong,
 
     /// MQTT encountered an internal error.
-    Mqtt(minimq::Error<S::Error>),
+    Mqtt(minimq::Error<E>),
 
     /// The network stack encountered an error.
-    Network(S::Error)
+    Network(E),
 }
 
-impl<S: TcpStack> From<minimq::Error<S::Error>> for Error<S> {
-    fn from(err: minimq::Error<S::Error>) -> Self {
+impl<E: core::fmt::Debug> From<minimq::Error<E>> for Error<E> {
+    fn from(err: minimq::Error<E>) -> Self {
         match err {
             minimq::Error::Network(err) => Error::Network(err),
             other => Error::Mqtt(other),
@@ -42,7 +42,10 @@ pub enum Action {
 //
 // # Returns
 // The string - otherwise, an error indicating the generated string was too long.
-fn generate_topic<'a, 'b>(device_id: &'a str, topic: &'b str) -> Result<String<minimq::consts::U128>, ()> {
+fn generate_topic<'a, 'b>(
+    device_id: &'a str,
+    topic: &'b str,
+) -> Result<String<minimq::consts::U128>, ()> {
     let mut string: String<consts::U128> = String::new();
     write!(&mut string, "{}/{}", device_id, topic).or(Err(()))?;
     Ok(string)
@@ -74,16 +77,19 @@ where
     /// # Args
     /// * `stack` - The TCP network stack to use for communication.
     /// * `id` - The ID for uniquely identifying the device.
+    /// * `broker` - The IpAddress of the MQTT broker.
     /// * `settings` - The initial settings of the interface.
     ///
     /// # Returns
     /// A new `MqttInterface` object that can be used for settings configuration and telemtry.
-    pub fn new<'a>(stack: S, id: &'a str, settings: T) -> Result<Self, Error<S>> {
+    pub fn new<'a>(
+        stack: S,
+        id: &'a str,
+        broker: IpAddr,
+        settings: T,
+    ) -> Result<Self, Error<S::Error>> {
         // TODO: Allow the user to specify broker IP or allow support for DNS.
-        let client: MqttClient<minimq::consts::U256, _> = MqttClient::new(
-                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-                id,
-                stack)?;
+        let client: MqttClient<minimq::consts::U256, _> = MqttClient::new(broker, id, stack)?;
 
         let settings_topic = generate_topic(id, "settings/#").or(Err(Error::IdTooLong))?;
         let commit_topic = generate_topic(id, "commit").or(Err(Error::IdTooLong))?;
@@ -108,14 +114,14 @@ where
     ///
     /// # Returns
     /// An `Action` indicating what action should be taken by the user application.
-    pub fn update(&mut self) -> Result<Action, Error<S>> {
-
+    pub fn update(&mut self) -> Result<Action, Error<S::Error>> {
         let mut client = self.client.take().unwrap();
 
         // If we are not yet subscribed to the necessary topics, subscribe now.
         if !self.subscribed && client.is_connected()? {
             client.subscribe(&self.settings_topic, &[])?;
             client.subscribe(&self.commit_topic, &[])?;
+            self.subscribed = true;
         }
 
         let mut result = Action::Continue;
@@ -140,31 +146,38 @@ where
                     };
 
                     response
-                },
+                }
                 "commit" => {
                     result = Action::CommitSettings;
                     String::from("Committing pending settings")
-                },
+                }
                 _ => String::from("Unknown topic"),
             };
 
             // Publish the response to the request over MQTT using the ResponseTopic property if
             // possible. Otherwise, default to a logging topic.
-            if let Property::ResponseTopic(topic) = properties.iter().find(|&prop| {
-                if let Property::ResponseTopic(_) = *prop {
-                    true
-                } else {
-                    false
-                }
-            }).or(Some(&Property::ResponseTopic(&self.default_response_topic))).unwrap() {
-                client.publish(topic, &response.into_bytes(), QoS::AtMostOnce, &[]).unwrap();
+            if let Property::ResponseTopic(topic) = properties
+                .iter()
+                .find(|&prop| {
+                    if let Property::ResponseTopic(_) = *prop {
+                        true
+                    } else {
+                        false
+                    }
+                })
+                .or(Some(&Property::ResponseTopic(&self.default_response_topic)))
+                .unwrap()
+            {
+                client
+                    .publish(topic, &response.into_bytes(), QoS::AtMostOnce, &[])
+                    .unwrap();
             }
         }) {
             Ok(_) => Ok(result),
             Err(minimq::Error::Disconnected) => {
                 self.subscribed = false;
                 Ok(result)
-            },
+            }
             Err(other) => Err(Error::Mqtt(other)),
         };
 
@@ -187,7 +200,7 @@ where
 
     pub fn client<F, R>(&mut self, mut func: F) -> R
     where
-        F: FnMut(&mut minimq::MqttClient<minimq::consts::U256, S>) -> R
+        F: FnMut(&mut minimq::MqttClient<minimq::consts::U256, S>) -> R,
     {
         let mut client = self.client.take().unwrap();
         let result = func(&mut client);

--- a/src/mqtt_interface.rs
+++ b/src/mqtt_interface.rs
@@ -6,7 +6,8 @@ use heapless::{String, consts};
 use core::fmt::Write;
 use super::StringSet;
 
-pub enum Error<S: TcpStack> {
+#[derive(Debug)]
+pub enum Error<S: TcpStack> where S::Error: core::fmt::Debug {
     /// The provided device ID is too long.
     IdTooLong,
 
@@ -27,6 +28,7 @@ impl<S: TcpStack> From<minimq::Error<S::Error>> for Error<S> {
 }
 
 /// An action that applications should act upon.
+#[derive(PartialEq)]
 pub enum Action {
     /// There is nothing to do except continue normal execution.
     Continue,
@@ -47,7 +49,11 @@ fn generate_topic<'a, 'b>(device_id: &'a str, topic: &'b str) -> Result<String<m
 }
 
 /// An interface for managing MQTT settings.
-pub struct MqttInterface<T: StringSet, S: TcpStack> {
+pub struct MqttInterface<T, S>
+where
+    T: StringSet,
+    S: TcpStack,
+{
     // TODO: Allow the user to specify buffer size.
     client: Option<MqttClient<minimq::consts::U256, S>>,
     pub settings: T,

--- a/src/mqtt_interface.rs
+++ b/src/mqtt_interface.rs
@@ -129,8 +129,10 @@ where
 
             // Publish the response to the request over MQTT using the ResponseTopic property if
             // possible. Otherwise, default to a logging topic.
-            let response_topic = if let Some(Property::ResponseTopic(topic)) =
-                properties.iter().find(|&prop| matches!(*prop, Property::ResponseTopic(_))) {
+            let response_topic = if let Some(Property::ResponseTopic(topic)) = properties
+                .iter()
+                .find(|&prop| matches!(*prop, Property::ResponseTopic(_)))
+            {
                 *topic
             } else {
                 &self.default_response_topic

--- a/src/mqtt_interface.rs
+++ b/src/mqtt_interface.rs
@@ -40,7 +40,7 @@ pub enum Action {
 //
 // # Returns
 // The string - otherwise, an error indicating the generated string was too long.
-fn generate_topic<'a, 'b>(device_id: &'a str, topic: &'b str) -> Result<String<consts::U128>, ()> {
+fn generate_topic(device_id: &str, topic: &str) -> Result<String<consts::U128>, ()> {
     let mut string: String<consts::U128> = String::new();
     write!(&mut string, "{}/{}", device_id, topic).or(Err(()))?;
     Ok(string)
@@ -131,13 +131,7 @@ where
             // Publish the response to the request over MQTT using the ResponseTopic property if
             // possible. Otherwise, default to a logging topic.
             let response_topic = if let Some(Property::ResponseTopic(topic)) =
-                properties.iter().find(|&prop| {
-                    if let Property::ResponseTopic(_) = *prop {
-                        true
-                    } else {
-                        false
-                    }
-                }) {
+                properties.iter().find(|&prop| matches!(*prop, Property::ResponseTopic(_))) {
                 *topic
             } else {
                 &self.default_response_topic

--- a/src/mqtt_interface.rs
+++ b/src/mqtt_interface.rs
@@ -74,15 +74,16 @@ where
     ///
     /// # Args
     /// * `stack` - The TCP network stack to use for communication.
-    /// * `id` - The ID for uniquely identifying the device.
+    /// * `id` - The ID for uniquely identifying the device. This must conform with MQTT client-id
+    ///          rules. Specifically, only alpha-numeric values are allowed.
     /// * `broker` - The IpAddress of the MQTT broker.
     /// * `settings` - The initial settings of the interface.
     ///
     /// # Returns
     /// A new `MqttInterface` object that can be used for settings configuration and telemtry.
-    pub fn new<'a>(
+    pub fn new(
         stack: S,
-        id: &'a str,
+        id: &str,
         broker: IpAddr,
         settings: T,
     ) -> Result<Self, Error<S::Error>> {

--- a/src/mqtt_interface.rs
+++ b/src/mqtt_interface.rs
@@ -53,7 +53,6 @@ where
     S: TcpStack,
     MU: ArrayLength<u8>,
 {
-    // TODO: Allow the user to specify buffer size.
     client: Option<MqttClient<MU, S>>,
     pub settings: T,
 

--- a/src/mqtt_interface.rs
+++ b/src/mqtt_interface.rs
@@ -1,0 +1,192 @@
+use minimq::{
+    embedded_nal::{TcpStack, IpAddr, Ipv4Addr},
+    QoS, Property, MqttClient
+};
+use heapless::{String, consts};
+use core::fmt::Write;
+use super::StringSet;
+
+pub enum Error<S: TcpStack> {
+    /// The provided device ID is too long.
+    IdTooLong,
+
+    /// MQTT encountered an internal error.
+    Mqtt(minimq::Error<S::Error>),
+
+    /// The network stack encountered an error.
+    Network(S::Error)
+}
+
+impl<S: TcpStack> From<minimq::Error<S::Error>> for Error<S> {
+    fn from(err: minimq::Error<S::Error>) -> Self {
+        match err {
+            minimq::Error::Network(err) => Error::Network(err),
+            other => Error::Mqtt(other),
+        }
+    }
+}
+
+/// An action that applications should act upon.
+pub enum Action {
+    /// There is nothing to do except continue normal execution.
+    Continue,
+
+    /// The settings are being commit to memory. The application should take steps to make staged
+    /// settings active.
+    CommitSettings,
+}
+
+// Generate an MQTT topic of the form `<device_id>/<topic>`.
+//
+// # Returns
+// The string - otherwise, an error indicating the generated string was too long.
+fn generate_topic<'a, 'b>(device_id: &'a str, topic: &'b str) -> Result<String<minimq::consts::U128>, ()> {
+    let mut string: String<consts::U128> = String::new();
+    write!(&mut string, "{}/{}", device_id, topic).or(Err(()))?;
+    Ok(string)
+}
+
+/// An interface for managing MQTT settings.
+pub struct MqttInterface<T: StringSet, S: TcpStack> {
+    // TODO: Allow the user to specify buffer size.
+    client: Option<MqttClient<minimq::consts::U256, S>>,
+    pub settings: T,
+
+    subscribed: bool,
+    settings_topic: String<minimq::consts::U128>,
+    commit_topic: String<minimq::consts::U128>,
+    default_response_topic: String<minimq::consts::U128>,
+}
+
+impl<T, S> MqttInterface<T, S>
+where
+    T: StringSet,
+    S: TcpStack,
+{
+    /// Construct a new settings interface using the network stack.
+    ///
+    /// # Args
+    /// * `stack` - The TCP network stack to use for communication.
+    /// * `id` - The ID for uniquely identifying the device.
+    /// * `settings` - The initial settings of the interface.
+    ///
+    /// # Returns
+    /// A new `MqttInterface` object that can be used for settings configuration and telemtry.
+    pub fn new<'a>(stack: S, id: &'a str, settings: T) -> Result<Self, Error<S>> {
+        // TODO: Allow the user to specify broker IP or allow support for DNS.
+        let client: MqttClient<minimq::consts::U256, _> = MqttClient::new(
+                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                id,
+                stack)?;
+
+        let settings_topic = generate_topic(id, "settings/#").or(Err(Error::IdTooLong))?;
+        let commit_topic = generate_topic(id, "commit").or(Err(Error::IdTooLong))?;
+        let default_response_topic = generate_topic(id, "log").or(Err(Error::IdTooLong))?;
+
+        Ok(Self {
+            client: Some(client),
+            subscribed: false,
+            settings,
+
+            settings_topic,
+            default_response_topic,
+            commit_topic,
+        })
+    }
+
+    /// Called to periodically service the MQTT telemetry interface.
+    ///
+    /// # Note
+    /// This function should be called whenever the underlying network stack has processed incoming
+    /// or outgoing data.
+    ///
+    /// # Returns
+    /// An `Action` indicating what action should be taken by the user application.
+    pub fn update(&mut self) -> Result<Action, Error<S>> {
+
+        let mut client = self.client.take().unwrap();
+
+        // If we are not yet subscribed to the necessary topics, subscribe now.
+        if !self.subscribed && client.is_connected()? {
+            client.subscribe(&self.settings_topic, &[])?;
+            client.subscribe(&self.commit_topic, &[])?;
+        }
+
+        let mut result = Action::Continue;
+
+        let result = match client.poll(|client, topic, message, properties| {
+            let mut split = topic.split('/');
+
+            // TODO: Verify topic ID against our ID.
+            let _id = split.next().unwrap();
+
+            // Process the command
+            let command = split.next().unwrap();
+            let response: String<consts::U512> = match command {
+                "settings" => {
+                    // Handle settings failures
+                    let mut response: String<consts::U512> = String::new();
+                    match self.settings.string_set(split.peekable(), message) {
+                        Ok(_) => write!(&mut response, "{} written", topic).unwrap(),
+                        Err(error) => {
+                            write!(&mut response, "Settings failure: {:?}", error).unwrap();
+                        }
+                    };
+
+                    response
+                },
+                "commit" => {
+                    result = Action::CommitSettings;
+                    String::from("Committing pending settings")
+                },
+                _ => String::from("Unknown topic"),
+            };
+
+            // Publish the response to the request over MQTT using the ResponseTopic property if
+            // possible. Otherwise, default to a logging topic.
+            if let Property::ResponseTopic(topic) = properties.iter().find(|&prop| {
+                if let Property::ResponseTopic(_) = *prop {
+                    true
+                } else {
+                    false
+                }
+            }).or(Some(&Property::ResponseTopic(&self.default_response_topic))).unwrap() {
+                client.publish(topic, &response.into_bytes(), QoS::AtMostOnce, &[]).unwrap();
+            }
+        }) {
+            Ok(_) => Ok(result),
+            Err(minimq::Error::Disconnected) => {
+                self.subscribed = false;
+                Ok(result)
+            },
+            Err(other) => Err(Error::Mqtt(other)),
+        };
+
+        self.client.replace(client);
+
+        result
+    }
+
+    /// Get mutable access to the underlying network stack.
+    ///
+    /// # Note
+    /// This function is intended to provide a means to the underlying network stack if it needs to
+    /// be periodically updated or serviced.
+    ///
+    /// # Returns
+    /// A temporary mutable reference to the underlying network stack used by MQTT.
+    pub fn network_stack(&mut self) -> &mut S {
+        &mut self.client.as_mut().unwrap().network_stack
+    }
+
+    pub fn client<F, R>(&mut self, mut func: F) -> R
+    where
+        F: FnMut(&mut minimq::MqttClient<minimq::consts::U256, S>) -> R
+    {
+        let mut client = self.client.take().unwrap();
+        let result = func(&mut client);
+        self.client.replace(client);
+
+        result
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,116 @@
+use miniconf::{Deserialize, StringSet, embedded_nal::{self, IpAddr, Ipv4Addr}};
+use machine::*;
+
+#[derive(StringSet, Deserialize)]
+struct AdditionalSettings {
+    inner: u8,
+}
+
+#[derive(StringSet, Deserialize)]
+struct Settings {
+    data: u32,
+    more: AdditionalSettings,
+}
+
+machine! {
+    enum TestState {
+        Started,
+        SentSimpleSetting,
+        SetInnerSetting,
+        CommitSetting,
+        Complete
+    }
+}
+
+transitions! {TestState,
+    [
+      (Started, Advance) => SentSimpleSetting,
+      (SentSimpleSetting, Advance) => SetInnerSetting,
+      (SentInnerSetting, Advance) => CommitSetting,
+      (CommitSetting, Advance) => Complete
+    ]
+}
+
+struct Timer {
+    started: std::time::Instant,
+    duration: std::time::Duration,
+}
+
+impl Timer {
+    pub fn new(timeout: std::time::Duration) -> Self {
+        Self {
+            started: std::time::Instant::now(),
+            duration: timeout,
+        }
+    }
+
+    pub fn restart(&mut self) {
+        self.started = std::time::Instant::now();
+    }
+
+    pub fn is_complete(&self) -> bool {
+        let now = std::time::Instant::now();
+        now.duration_since(self.started) >= self.duration
+    }
+}
+
+#[test]
+fn main() -> std::io::Result<()> {
+    env_logger::init();
+
+    // Construct a Minimq client to the broker for publishing requests.
+    let mut client = {
+        let stack = std_embedded_nal::STACK.clone();
+        let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        minimq::MqttClient::new(localhost, "client", stack).unwrap()
+    };
+
+    let mut interface: miniconf::MqttInterface<Settings, _> = {
+        let stack = std_embedded_nal::STACK.clone();
+        miniconf::MqttInterface::new(stack, "test-device", Settings::default()).unwrap()
+    };
+
+    let mut state = TestState::Started(Started{});
+    let mut timer = Timer::new(std::time::Duration::from_millis(100));
+
+    loop {
+        let action = interface.update().unwrap();
+        match state {
+            TestState::Started(_) => {
+                if client.is_connected().unwrap() && interface.client(|iclient| iclient.is_connected().unwrap()) {
+                    // Send a request to set a property.
+                    client.publish("test-device/settings/data", "500".as_bytes()).unwrap();
+                    state = state.on_advance(Advance);
+                    timer.restart();
+                }
+            },
+            TestState::SentSimpleSetting(_) => {
+                if timer.is_complete() {
+                    client.publish("test-device/settings/more/inner", "100".as_bytes()).unwrap();
+                    state = state.on_advance(Advance);
+                    timer.restart();
+                }
+            },
+            TestState::SentInnerSetting(_) => {
+                if timer.is_complete() {
+                    client.publish("test-device/commit", "".as_bytes()).unwrap();
+                    state = state.on_advance(Advance);
+                    timer.restart();
+                }
+            },
+            TestState::CommitSetting(_) => {
+                if action == miniconf::Action::CommitSettings {
+                    state = state.on_advance(Advance);
+                    timer.restart();
+                }
+                assert!(timer.is_complete() == false);
+            },
+            TestState::Complete(_) => {
+                assert!(interface.settings.data == 500);
+                assert!(interface.settings.more.inner == 100);
+                std::process::exit(0);
+            }
+        }
+    }
+
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -104,9 +104,10 @@ fn main() -> std::io::Result<()> {
     };
 
     // Construct a settings configuration interface.
-    let mut interface: miniconf::MqttInterface<Settings, _> = {
+    let mut interface: miniconf::MqttInterface<Settings, _, minimq::consts::U256> = {
         let stack = std_embedded_nal::STACK.clone();
-        miniconf::MqttInterface::new(stack, "device", localhost, Settings::default()).unwrap()
+        let dut_client = minimq::MqttClient::new(localhost, "clientid", stack).unwrap();
+        miniconf::MqttInterface::new(dut_client, "device", Settings::default()).unwrap()
     };
 
     // We will wait 100ms in between each state to allow the MQTT broker to catch up

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,38 +1,70 @@
-use miniconf::{StringSet, embedded_nal::{IpAddr, Ipv4Addr}};
 use machine::*;
+use miniconf::{
+    embedded_nal::{IpAddr, Ipv4Addr},
+    minimq::QoS,
+    StringSet,
+};
 use serde::Deserialize;
 
-#[derive(Default, StringSet, Deserialize)]
+#[macro_use]
+extern crate log;
+
+#[derive(Debug, Default, StringSet, Deserialize)]
 struct AdditionalSettings {
     inner: u8,
 }
 
-#[derive(Default, StringSet, Deserialize)]
+#[derive(Debug, Default, StringSet, Deserialize)]
 struct Settings {
     data: u32,
     more: AdditionalSettings,
 }
 
-machine! {
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Advance;
+
+machine!(
+    #[derive(Debug)]
     enum TestState {
         Started,
         SentSimpleSetting,
         SentInnerSetting,
         CommitSetting,
-        Complete
+        Complete,
     }
-}
+);
 
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub struct Advance;
-
-transitions! {TestState,
+transitions!(TestState,
     [
       (Started, Advance) => SentSimpleSetting,
       (SentSimpleSetting, Advance) => SentInnerSetting,
       (SentInnerSetting, Advance) => CommitSetting,
       (CommitSetting, Advance) => Complete
     ]
+);
+
+impl Started {
+    pub fn on_advance(self, _: Advance) -> SentSimpleSetting {
+        SentSimpleSetting {}
+    }
+}
+
+impl SentSimpleSetting {
+    pub fn on_advance(self, _: Advance) -> SentInnerSetting {
+        SentInnerSetting {}
+    }
+}
+
+impl SentInnerSetting {
+    pub fn on_advance(self, _: Advance) -> CommitSetting {
+        CommitSetting {}
+    }
+}
+
+impl CommitSetting {
+    pub fn on_advance(self, _: Advance) -> Complete {
+        Complete {}
+    }
 }
 
 struct Timer {
@@ -54,7 +86,8 @@ impl Timer {
 
     pub fn is_complete(&self) -> bool {
         let now = std::time::Instant::now();
-        now.duration_since(self.started) >= self.duration
+        let elapsed = now.duration_since(self.started);
+        elapsed >= self.duration
     }
 }
 
@@ -62,59 +95,105 @@ impl Timer {
 fn main() -> std::io::Result<()> {
     env_logger::init();
 
+    let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+
     // Construct a Minimq client to the broker for publishing requests.
-    let mut client = {
+    let mut client: minimq::MqttClient<minimq::consts::U256, _> = {
         let stack = std_embedded_nal::STACK.clone();
-        let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        minimq::MqttClient::new(localhost, "client", stack).unwrap()
+        minimq::MqttClient::new(localhost, "tester", stack).unwrap()
     };
 
+    // Construct a settings configuration interface.
     let mut interface: miniconf::MqttInterface<Settings, _> = {
         let stack = std_embedded_nal::STACK.clone();
-        miniconf::MqttInterface::new(stack, "test-device", Settings::default()).unwrap()
+        miniconf::MqttInterface::new(stack, "device", localhost, Settings::default()).unwrap()
     };
 
+    // We will wait 100ms in between each state to allow the MQTT broker to catch up
     let mut state = TestState::started();
     let mut timer = Timer::new(std::time::Duration::from_millis(100));
 
     loop {
+        // First, update our client's MQTT state.
+        client
+            .poll(|_, _, msg, _| {
+                let msg = std::str::from_utf8(msg).unwrap();
+                info!("Got: {:?}", msg);
+            })
+            .unwrap();
+
+        // Next, service the settings interface and progress the test.
         let action = interface.update().unwrap();
         match state {
             TestState::Started(_) => {
-                if client.is_connected().unwrap() && interface.client(|iclient| iclient.is_connected().unwrap()) {
+                // When first starting, let both clients connect and the timer elapse. Otherwise,
+                // one may publish before both devices are fully connected.
+                if timer.is_complete()
+                    && client.is_connected().unwrap()
+                    && interface.client(|iclient| iclient.is_connected().unwrap())
+                {
+                    // Subscribe to the default device log topic.
+                    client.subscribe("device/log", &[]).unwrap();
+
                     // Send a request to set a property.
-                    client.publish("test-device/settings/data", "500".as_bytes()).unwrap();
+                    info!("Sending first settings value");
+                    client
+                        .publish(
+                            "device/settings/data",
+                            "500".as_bytes(),
+                            QoS::AtMostOnce,
+                            &[],
+                        )
+                        .unwrap();
                     state = state.on_advance(Advance);
                     timer.restart();
                 }
-            },
+            }
             TestState::SentSimpleSetting(_) => {
+                // Next, set a nested property.
                 if timer.is_complete() {
-                    client.publish("test-device/settings/more/inner", "100".as_bytes()).unwrap();
+                    info!("Sending inner settings value");
+                    client
+                        .publish(
+                            "device/settings/more/inner",
+                            "100".as_bytes(),
+                            QoS::AtMostOnce,
+                            &[],
+                        )
+                        .unwrap();
                     state = state.on_advance(Advance);
                     timer.restart();
                 }
-            },
+            }
             TestState::SentInnerSetting(_) => {
+                // Finally, commit the settings so they become active.
                 if timer.is_complete() {
-                    client.publish("test-device/commit", "".as_bytes()).unwrap();
+                    info!("Committing settings");
+                    client
+                        .publish("device/commit", "".as_bytes(), QoS::AtMostOnce, &[])
+                        .unwrap();
                     state = state.on_advance(Advance);
                     timer.restart();
                 }
-            },
+            }
             TestState::CommitSetting(_) => {
+                // Verify that we received a commit-settings action (e.g. commit was detected).
                 if action == miniconf::Action::CommitSettings {
+                    info!("Settings commit detected");
                     state = state.on_advance(Advance);
                     timer.restart();
                 }
                 assert!(timer.is_complete() == false);
-            },
+            }
             TestState::Complete(_) => {
+                // Verify the settings all have the correct value.
+                info!("Verifying settings: {:?}", interface.settings);
                 assert!(interface.settings.data == 500);
                 assert!(interface.settings.more.inner == 100);
                 std::process::exit(0);
             }
+
+            other => panic!("Undefined state: {:?}", other),
         }
     }
-
 }


### PR DESCRIPTION
This PR adds an MQTT-based settings interface and closes #5.

There is also an integration test added that can run if a broker (e.g. mosquitto) is running on the local machine.