### PR TITLE
Updating derive trait path

### DIFF
--- a/derive_stringset/src/lib.rs
+++ b/derive_stringset/src/lib.rs
@@ -39,8 +39,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
     });
 
     let expanded = quote! {
-
-        impl StringSet for #name {
+        impl miniconf::StringSet for #name {
             fn string_set(&mut self, mut topic_parts:
             core::iter::Peekable<core::str::Split<char>>, value: &[u8]) ->
             Result<(), miniconf::Error> {


### PR DESCRIPTION
This PR fixes #19 by updating the derive macro to ue the fully-specified miniconf::StringSet trait path. This ensures that generated code can always find the `StringSet` trait even when it isn't directly imported into the current scope.