### PR TITLE
Fixing configuring terminal array elements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,10 +63,10 @@ macro_rules! impl_array {
                 mut topic_parts: core::iter::Peekable<core::str::Split<char>>,
                 value: &[u8],
             ) -> Result<(), Error> {
-                let index = topic_parts.next();
-                if let Some(next) = index {
+                let next = topic_parts.next();
+                if let Some(index) = next {
                     // Parse what should be the index value
-                    let i: usize = serde_json_core::from_str(next).or(Err(Error::BadIndex))?.0;
+                    let i: usize = serde_json_core::from_str(index).or(Err(Error::BadIndex))?.0;
 
                     if i >= self.len() {
                         return Err(Error::BadIndex)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,8 @@ macro_rules! impl_array {
                 mut topic_parts: core::iter::Peekable<core::str::Split<char>>,
                 value: &[u8],
             ) -> Result<(), Error> {
-                if let Some(next) = topic_parts.next() {
+                let index = topic_parts.next();
+                if let Some(next) = index {
                     // Parse what should be the index value
                     let i: usize = serde_json_core::from_str(next).or(Err(Error::BadIndex))?.0;
 
@@ -71,7 +72,12 @@ macro_rules! impl_array {
                         return Err(Error::BadIndex)
                     }
 
-                    self[i].string_set(topic_parts, value)?;
+                    if topic_parts.peek().is_some() {
+                        self[i].string_set(topic_parts, value)?;
+                    } else {
+                        self[i] = serde_json_core::from_slice(value)?.0;
+                    }
+
                     Ok(())
                 }
                 else {

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -90,4 +90,8 @@ fn array_of_structs_indexing() {
     };
 
     assert_eq!(expected, s);
+
+    let field = "a/1".split('/').peekable();
+    s.string_set(field, "{\"b\": 5}".as_bytes()).unwrap();
+    assert_eq!(s.a[1].b, 5);
 }


### PR DESCRIPTION
This PR fixes #21 by checking if there is remaining topic data for array elements before recursing into `string_set()`.