### PR TITLE
Updating state management to keep client in error conditions

### DIFF
--- a/src/mqtt_interface.rs
+++ b/src/mqtt_interface.rs
@@ -98,9 +98,23 @@ where
         // present.
         let mut client = self.client.take().unwrap();
 
+        let connected = match client.is_connected() {
+            Ok(connected) => connected,
+            Err(other) => {
+                self.client.replace(client);
+                return Err(other.into())
+            }
+        };
+
         // If we are not yet subscribed to the necessary topics, subscribe now.
-        if !self.subscribed && client.is_connected()? {
-            client.subscribe(&self.settings_topic, &[])?;
+        if !self.subscribed && connected {
+            match client.subscribe(&self.settings_topic, &[]) {
+                Err(error) => {
+                    self.client.replace(client);
+                    return Err(error.into())
+                }
+                Ok(_) => {}
+            }
             self.subscribed = true;
         }
 

--- a/src/mqtt_interface.rs
+++ b/src/mqtt_interface.rs
@@ -102,7 +102,7 @@ where
             Ok(connected) => connected,
             Err(other) => {
                 self.client.replace(client);
-                return Err(other.into())
+                return Err(other.into());
             }
         };
 
@@ -111,7 +111,7 @@ where
             match client.subscribe(&self.settings_topic, &[]) {
                 Err(error) => {
                     self.client.replace(client);
-                    return Err(error.into())
+                    return Err(error.into());
                 }
                 Ok(_) => {}
             }


### PR DESCRIPTION
This PR fixes #33 by updating the error handlers to replace the `client` into the internal option whenever an error occurs.

Alternative approach would be to keep internal state within `RefCell`s