### PR TITLE
Updating dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,5 @@ edition = "2018"
 
 [dependencies]
 derive_miniconf = { path="derive_miniconf" }
-serde-json-core = "0.2.0"
+serde-json-core = "0.3.0"
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
-heapless = ">=0.6.1"
-minimq = { version = "0.2.0", optional = true }
-
-[features]
-minimq-support = ["minimq"]


### PR DESCRIPTION
This PR updates the dependencies to remote old features and dependencies that are no longer used. It also updates `serde-json-core` to 0.3.0 to utilize safer heapless versions.