### PR TITLE
Locking down dev dependency revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,7 @@ mqtt-client = ["minimq"]
 [dev-dependencies]
 machine = "0.3"
 env_logger = "0.9"
-std-embedded-nal = { git = "https://gitlab.com/ryan-summers/std-embedded-nal", branch = "feature/nal-update" }
+
+# TODO: When https://gitlab.com/chrysn/std-embedded-nal/-/merge_requests/2 lands, update dev
+# dependency to latest release of std-embedded-nal
+std-embedded-nal = { git = "https://gitlab.com/ryan-summers/std-embedded-nal", rev = "d42c05b7" }


### PR DESCRIPTION
This PR locks down the `std-embedded-nal` revision, so we aren't dependent on a moving target. This was my fault originally - we should never track branches as dependencies without a lock file.