### PR TITLE
Preparing library for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,3 +151,30 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+  examples:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        example:
+          - mqtt
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Start Mosquitto
+        run: |
+          sudo apt-get install mosquitto
+          sudo service mosquitto start
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          toolchain: stable
+          profile: minimal
+
+      - name: Example ${{matrix.example}}
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --example ${{matrix.example}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+### Removed
+
+## [0.1.0] - 2021-08-11
+
+Library initially released on crates.io
+
+[Unreleased]: https://github.com/quartiq/miniconf/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/quartiq/miniconf/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@vertigo-designs.com"]
 edition = "2018"
 license = "MIT"
+description = "Lightweight support for run-time settings configuration"
+repository = "https://github.com/quartiq/miniconf"
+keywords = ["settings", "embedded", "no_std", "configuration", "config", "mqtt"]
+categories = ["no-std", "config", "embedded", "parsing"]
 
 [dependencies]
 derive_miniconf = { path="derive_miniconf" }
@@ -21,3 +25,7 @@ mqtt-client = ["minimq"]
 machine = "0.3"
 env_logger = "0.9"
 std-embedded-nal = "0.1"
+tokio = { version = "1.9", features = ["rt-multi-thread", "time", "macros"] }
+
+[[example]]
+name = "mqtt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["settings", "embedded", "no_std", "configuration", "config", "mqtt"]
 categories = ["no-std", "config", "embedded", "parsing"]
 
 [dependencies]
-derive_miniconf = { path="derive_miniconf" }
+derive_miniconf = { path = "derive_miniconf" , version = "0.1" }
 serde-json-core = "0.4.0"
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
 log = "0.4"

--- a/derive_miniconf/Cargo.toml
+++ b/derive_miniconf/Cargo.toml
@@ -1,14 +1,19 @@
 [package]
 name = "derive_miniconf"
 version = "0.1.0"
-authors = ["James Irwin <irwineffect@gmail.com>"]
+authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@vertigo-designs.com"]
 edition = "2018"
 license = "MIT"
+description = "Derive utilities for Miniconf run-time settings configuration"
+repository = "https://github.com/quartiq/miniconf/derive_miniconf"
+
+keywords = ["settings", "embedded", "no_std", "configuration", "config", "mqtt"]
+categories = ["no-std", "config", "embedded", "parsing"]
 
 [lib]
 proc-macro = true
 
 [dependencies]
-syn = {version="1.0.58", features=["extra-traits"]}
+syn = { version="1.0.58", features=["extra-traits"] }
 quote = "1.0.8"
 proc-macro2 = "1.0.24"

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -1,0 +1,83 @@
+use miniconf::{Miniconf, MqttClient};
+use minimq::{Minimq, QoS};
+use std::time::Duration;
+use std_embedded_nal::Stack;
+
+#[derive(Default, Miniconf, Debug)]
+struct NestedSettings {
+    frame_rate: u32,
+}
+
+#[derive(Default, Miniconf, Debug)]
+struct Settings {
+    inner: NestedSettings,
+    amplitude: [f32; 2],
+    exit: bool,
+}
+
+async fn mqtt_client() {
+    // Construct a Minimq client to the broker for publishing requests.
+    let mut mqtt: Minimq<_, 256> =
+        Minimq::new("127.0.0.1".parse().unwrap(), "tester", Stack::default()).unwrap();
+
+    // Wait for the broker connection
+    while !mqtt.client.is_connected().unwrap() {
+        mqtt.poll(|_client, _topic, _message, _properties| {})
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Wait momentarily for the other client to connect.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Configure settings.
+    mqtt.client
+        .publish(
+            "sample/prefix/settings/amplitude/0",
+            b"32.4",
+            QoS::AtMostOnce,
+            &[],
+        )
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    mqtt.client
+        .publish(
+            "sample/prefix/settings/inner/frame_rate",
+            b"10",
+            QoS::AtMostOnce,
+            &[],
+        )
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    mqtt.client
+        .publish("sample/prefix/settings/exit", b"true", QoS::AtMostOnce, &[])
+        .unwrap();
+}
+
+#[tokio::main]
+async fn main() {
+    // Spawn a task to send MQTT messages.
+    tokio::task::spawn(async move { mqtt_client().await });
+
+    let mut client: MqttClient<Settings, Stack> = MqttClient::new(
+        Stack::default(),
+        "",
+        "sample/prefix",
+        "127.0.0.1".parse().unwrap(),
+    )
+    .unwrap();
+
+    loop {
+        if client.update().unwrap() {
+            println!("Settings updated: {:?}", client.settings());
+        }
+
+        if client.settings().exit {
+            break;
+        }
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,59 @@
 #![no_std]
+//! # Miniconf
+//!
+//! Miniconf is a a lightweight utility to manage run-time configurable settings.
+//!
+//! ## Overview
+//!
+//! Miniconf uses a [Derive macro](derive.Miniconf.html) to automatically assign unique paths to
+//! each setting. All values are transmitted and received in JSON format.
+//!
+//! ## Supported Protocols
+//!
+//! Miniconf is designed to be protocol-agnostic. Any means that you have of receiving input from
+//! some external source can be used to acquire paths and values for updating settings.
+//!
+//! While Miniconf is platform agnostic, there is an [MQTT-based client](MqttClient) provided to
+//! manage settings via the [MQTT protocol](https://mqtt.org).
+//!
+//! ## Example
+//! ```
+//! use miniconf::{Miniconf, MiniconfAtomic};
+//! use serde::Deserialize;
+//!
+//! #[derive(Deserialize, MiniconfAtomic, Default)]
+//! struct Coefficients {
+//!     forward: f32,
+//!     backward: f32,
+//! }
+//!
+//! #[derive(Deserialize, Miniconf, Default)]
+//! struct Settings {
+//!     filter: Coefficients,
+//!     channel_gain: [f32; 2],
+//!     sample_rate: u32,
+//!     force_update: bool,
+//! }
+//!
+//! fn main() {
+//!     let mut settings = Settings::default();
+//!
+//!     // Update sample rate.
+//!     miniconf::update(&mut settings, "sample_rate", b"350").unwrap();
+//!
+//!     // Update filter coefficients.
+//!     miniconf::update(&mut settings, "filter", b"{\"forward\": 35.6, \"backward\": 0.0}").unwrap();
+//!
+//!     // Update channel gain for channel 0.
+//!     miniconf::update(&mut settings, "channel_gain/0", b"15").unwrap();
+//! }
+//! ```
+//!
+//! ## Limitations
+//!
+//! Minconf cannot be used with some of Rust's more complex types. Some unsupported types:
+//! * Complex enums
+//! * Tuples
 
 #[cfg(feature = "mqtt-client")]
 mod mqtt_client;
@@ -111,44 +166,34 @@ macro_rules! impl_single {
     };
 }
 
-macro_rules! impl_array {
-    ($($N:literal),*) => {
-      $(
-        impl<T> Miniconf for [T; $N]
-        where
-            T: Miniconf + core::marker::Copy + DeserializeOwned,
-        {
-            fn string_set(
-                &mut self,
-                mut topic_parts: core::iter::Peekable<core::str::Split<char>>,
-                value: &[u8],
-            ) -> Result<(), Error> {
-                let next = topic_parts.next();
-                if next.is_none() {
-                    return Err(Error::PathTooShort);
-                }
-
-                // Parse what should be the index value
-                let i: usize = serde_json_core::from_str(next.unwrap()).or(Err(Error::BadIndex))?.0;
-
-                if i >= self.len() {
-                    return Err(Error::BadIndex)
-                }
-
-                self[i].string_set(topic_parts, value)?;
-
-                Ok(())
-            }
+impl<T, const N: usize> Miniconf for [T; N]
+where
+    T: Miniconf + core::marker::Copy + DeserializeOwned,
+{
+    fn string_set(
+        &mut self,
+        mut topic_parts: core::iter::Peekable<core::str::Split<char>>,
+        value: &[u8],
+    ) -> Result<(), Error> {
+        let next = topic_parts.next();
+        if next.is_none() {
+            return Err(Error::PathTooShort);
         }
-      )*
+
+        // Parse what should be the index value
+        let i: usize = serde_json_core::from_str(next.unwrap())
+            .or(Err(Error::BadIndex))?
+            .0;
+
+        if i >= self.len() {
+            return Err(Error::BadIndex);
+        }
+
+        self[i].string_set(topic_parts, value)?;
+
+        Ok(())
     }
 }
-
-// This is needed until const generics is stabilized https://github.com/rust-lang/rust/issues/44580
-impl_array!(
-    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-    27, 28, 29, 30, 31, 32
-);
 
 // Implement trait for the primitive types
 impl_single!(u8);

--- a/src/mqtt_client/mqtt_client.rs
+++ b/src/mqtt_client/mqtt_client.rs
@@ -1,11 +1,22 @@
-///! MQTT-based Run-time Settings Client
-///!
-///! # Limitations
-///! The MQTT client logs failures to subscribe to the settings topic, but does not re-attempt to
-///! connect to it when errors occur.
-///!
-///! Responses to settings updates are sent without quality-of-service guarantees, so there's no
-///! guarantee that the requestee will be informed that settings have been applied.
+/// MQTT-based Run-time Settings Client
+///
+/// # Design
+/// The MQTT client places all settings paths behind a `<prefix>/settings/` path prefix, where
+/// `<prefix>` is provided in the client constructor. This prefix is then stripped away to get the
+/// settings path for [Miniconf].
+///
+/// ## Example
+/// With an MQTT client prefix of `dt/sinara/stabilizer` and a settings path of `adc/0/gain`, the
+/// full MQTT path would be `dt/sinara/stabilizer/settings/adc/0/gain`.
+///
+/// # Limitations
+/// The MQTT client logs failures to subscribe to the settings topic, but does not re-attempt to
+/// connect to it when errors occur.
+///
+/// Responses to settings updates are sent without quality-of-service guarantees, so there's no
+/// guarantee that the requestee will be informed that settings have been applied.
+///
+/// The library only supports serialized settings up to 256 bytes currently.
 use serde_json_core::heapless::String;
 
 use minimq::embedded_nal::{IpAddr, TcpClientStack};

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,12 +1,10 @@
 use machine::*;
 use miniconf::{
-    minimq::{
-        embedded_nal::{IpAddr, Ipv4Addr},
-        QoS,
-    },
+    minimq::QoS,
     Miniconf,
 };
 use serde::Deserialize;
+use std_embedded_nal::Stack;
 
 #[macro_use]
 extern crate log;
@@ -89,19 +87,15 @@ impl Timer {
 fn main() -> std::io::Result<()> {
     env_logger::init();
 
-    let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    let localhost = "127.0.0.1".parse().unwrap();
 
     // Construct a Minimq client to the broker for publishing requests.
-    let mut mqtt: minimq::Minimq<_, 256> = {
-        let stack = std_embedded_nal::STACK.clone();
-        miniconf::minimq::Minimq::new(localhost, "tester", stack).unwrap()
-    };
+    let mut mqtt: minimq::Minimq<_, 256> =
+        miniconf::minimq::Minimq::new(localhost, "tester", Stack::default()).unwrap();
 
     // Construct a settings configuration interface.
-    let mut interface: miniconf::MqttClient<Settings, _> = {
-        let stack = std_embedded_nal::STACK.clone();
-        miniconf::MqttClient::new(stack, "", "device", localhost).unwrap()
-    };
+    let mut interface: miniconf::MqttClient<Settings, _> =
+        miniconf::MqttClient::new(Stack::default(), "", "device", localhost).unwrap();
 
     // We will wait 100ms in between each state to allow the MQTT broker to catch up
     let mut state = TestState::started();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,8 +1,5 @@
 use machine::*;
-use miniconf::{
-    minimq::QoS,
-    Miniconf,
-};
+use miniconf::{minimq::QoS, Miniconf};
 use serde::Deserialize;
 use std_embedded_nal::Stack;
 


### PR DESCRIPTION
This PR cleans up Miniconf for initial release. It also does the following:
* Add support for using const-generics to implement `Miniconf` for array types
* Added an async example for running Miniconf on-host
* Revamps docs to include more helpful information