### PR TITLE
Feature/minimq update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* Updated minimq dependency to support ping TCP reconnection support
+
 ### Removed
 
 ## [0.1.0] - 2021-08-11

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,10 @@ log = "0.4"
 heapless = { version = "0.7", features = ["serde"] }
 minimq = { version = "0.3", optional = true }
 
+# TODO: Remove patch
 [patch.crates-io.minimq]
 git = "https://github.com/quartiq/minimq"
-rev = "c2b0c41"
+branch = "rs/issue-53/receive-timeout-pings"
 
 [features]
 default = ["mqtt-client"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ machine = "0.3"
 env_logger = "0.9"
 std-embedded-nal = "0.1"
 tokio = { version = "1.9", features = ["rt-multi-thread", "time", "macros"] }
+std-embedded-time = "0.1"
 
 [[example]]
 name = "mqtt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ log = "0.4"
 heapless = { version = "0.7", features = ["serde"] }
 minimq = { version = "0.3", optional = true }
 
+[patch.crates-io.minimq]
+git = "https://github.com/quartiq/minimq"
+rev = "c2b0c41"
+
 [features]
 default = ["mqtt-client"]
 mqtt-client = ["minimq"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,7 @@ serde-json-core = "0.4.0"
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
 log = "0.4"
 heapless = { version = "0.7", features = ["serde"] }
-
-# TODO: Remove patch
-[dependencies.minimq]
-optional = true
-git = "https://github.com/quartiq/minimq"
-branch = "release/0.4"
+minimq = "0.4"
 
 [features]
 default = ["mqtt-client"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde-json-core = "0.4.0"
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
 log = "0.4"
 heapless = { version = "0.7", features = ["serde"] }
-minimq = "0.4"
+minimq = {version = "0.4", optional = true }
 
 [features]
 default = ["mqtt-client"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ serde-json-core = "0.4.0"
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
 log = "0.4"
 heapless = { version = "0.7", features = ["serde"] }
-minimq = { version = "0.3", optional = true }
 
 # TODO: Remove patch
-[patch.crates-io.minimq]
+[dependencies.minimq]
+optional = true
 git = "https://github.com/quartiq/minimq"
-branch = "rs/issue-53/receive-timeout-pings"
+branch = "release/0.4"
 
 [features]
 default = ["mqtt-client"]

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -18,7 +18,7 @@ struct Settings {
 
 async fn mqtt_client() {
     // Construct a Minimq client to the broker for publishing requests.
-    let mut mqtt: Minimq<_, _, 256, 3> = Minimq::new(
+    let mut mqtt: Minimq<_, _, 256, 1> = Minimq::new(
         "127.0.0.1".parse().unwrap(),
         "tester",
         Stack::default(),
@@ -67,7 +67,7 @@ async fn main() {
     // Spawn a task to send MQTT messages.
     tokio::task::spawn(async move { mqtt_client().await });
 
-    let mut client: MqttClient<Settings, Stack, StandardClock, 256, 3> = MqttClient::new(
+    let mut client: MqttClient<Settings, Stack, StandardClock, 256, 1> = MqttClient::new(
         Stack::default(),
         "",
         "sample/prefix",

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -18,7 +18,7 @@ struct Settings {
 
 async fn mqtt_client() {
     // Construct a Minimq client to the broker for publishing requests.
-    let mut mqtt: Minimq<_, _, 256> = Minimq::new(
+    let mut mqtt: Minimq<_, _, 256, 3> = Minimq::new(
         "127.0.0.1".parse().unwrap(),
         "tester",
         Stack::default(),
@@ -67,7 +67,7 @@ async fn main() {
     // Spawn a task to send MQTT messages.
     tokio::task::spawn(async move { mqtt_client().await });
 
-    let mut client: MqttClient<Settings, Stack, StandardClock, 256> = MqttClient::new(
+    let mut client: MqttClient<Settings, Stack, StandardClock, 256, 3> = MqttClient::new(
         Stack::default(),
         "",
         "sample/prefix",

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -2,36 +2,7 @@ use miniconf::{Miniconf, MqttClient};
 use minimq::{Minimq, QoS};
 use std::time::Duration;
 use std_embedded_nal::Stack;
-
-use embedded_time::{fraction::Fraction, Clock};
-use std::time::Instant;
-
-#[derive(Default)]
-struct StdClock {
-    start: core::cell::UnsafeCell<Option<Instant>>,
-}
-
-impl Clock for StdClock {
-    type T = u32;
-
-    const SCALING_FACTOR: Fraction = Fraction::new(1, 1_000);
-
-    fn try_now(&self) -> Result<embedded_time::Instant<Self>, embedded_time::clock::Error> {
-        let std_now = Instant::now();
-        let start = unsafe {
-            if (*self.start.get()).is_none() {
-                (*self.start.get()).replace(std_now);
-                std_now
-            } else {
-                (*self.start.get()).unwrap()
-            }
-        };
-
-        let elapsed = std_now - start;
-
-        Ok(embedded_time::Instant::new(elapsed.as_millis() as u32))
-    }
-}
+use std_embedded_time::StandardClock;
 
 #[derive(Default, Miniconf, Debug)]
 struct NestedSettings {
@@ -47,8 +18,13 @@ struct Settings {
 
 async fn mqtt_client() {
     // Construct a Minimq client to the broker for publishing requests.
-    let mut mqtt: Minimq<_, 256> =
-        Minimq::new("127.0.0.1".parse().unwrap(), "tester", Stack::default()).unwrap();
+    let mut mqtt: Minimq<_, _, 256> = Minimq::new(
+        "127.0.0.1".parse().unwrap(),
+        "tester",
+        Stack::default(),
+        StandardClock::default(),
+    )
+    .unwrap();
 
     // Wait for the broker connection
     while !mqtt.client.is_connected().unwrap() {
@@ -91,11 +67,12 @@ async fn main() {
     // Spawn a task to send MQTT messages.
     tokio::task::spawn(async move { mqtt_client().await });
 
-    let mut client: MqttClient<Settings, Stack> = MqttClient::new(
+    let mut client: MqttClient<Settings, Stack, StandardClock> = MqttClient::new(
         Stack::default(),
         "",
         "sample/prefix",
         "127.0.0.1".parse().unwrap(),
+        StandardClock::default(),
     )
     .unwrap();
 

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -3,6 +3,36 @@ use minimq::{Minimq, QoS};
 use std::time::Duration;
 use std_embedded_nal::Stack;
 
+use embedded_time::{fraction::Fraction, Clock};
+use std::time::Instant;
+
+#[derive(Default)]
+struct StdClock {
+    start: core::cell::UnsafeCell<Option<Instant>>,
+}
+
+impl Clock for StdClock {
+    type T = u32;
+
+    const SCALING_FACTOR: Fraction = Fraction::new(1, 1_000);
+
+    fn try_now(&self) -> Result<embedded_time::Instant<Self>, embedded_time::clock::Error> {
+        let std_now = Instant::now();
+        let start = unsafe {
+            if (*self.start.get()).is_none() {
+                (*self.start.get()).replace(std_now);
+                std_now
+            } else {
+                (*self.start.get()).unwrap()
+            }
+        };
+
+        let elapsed = std_now - start;
+
+        Ok(embedded_time::Instant::new(elapsed.as_millis() as u32))
+    }
+}
+
 #[derive(Default, Miniconf, Debug)]
 struct NestedSettings {
     frame_rate: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,9 @@ pub use mqtt_client::MqttClient;
 #[cfg(feature = "mqtt-client")]
 pub use minimq;
 
+#[cfg(feature = "mqtt-client")]
+pub use minimq::embedded_time;
+
 pub use serde::de::{Deserialize, DeserializeOwned};
 pub use serde_json_core;
 

--- a/src/mqtt_client/mqtt_client.rs
+++ b/src/mqtt_client/mqtt_client.rs
@@ -27,21 +27,21 @@ use log::info;
 use minimq::embedded_time;
 
 /// MQTT settings interface.
-pub struct MqttClient<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
+pub struct MqttClient<Settings, Stack, Clock, const MESSAGE_SIZE: usize, const MESSAGE_COUNT: usize>
 where
     Settings: Miniconf + Default,
     Stack: TcpClientStack,
     Clock: embedded_time::Clock,
 {
     default_response_topic: String<128>,
-    mqtt: minimq::Minimq<Stack, Clock, MESSAGE_SIZE>,
+    mqtt: minimq::Minimq<Stack, Clock, MESSAGE_SIZE, MESSAGE_COUNT>,
     settings: Settings,
     subscribed: bool,
     settings_prefix: String<64>,
 }
 
-impl<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
-    MqttClient<Settings, Stack, Clock, MESSAGE_SIZE>
+impl<Settings, Stack, Clock, const MESSAGE_SIZE: usize, const MESSAGE_COUNT: usize>
+    MqttClient<Settings, Stack, Clock, MESSAGE_SIZE, MESSAGE_COUNT>
 where
     Settings: Miniconf + Default,
     Stack: TcpClientStack,

--- a/src/mqtt_client/mqtt_client.rs
+++ b/src/mqtt_client/mqtt_client.rs
@@ -85,7 +85,7 @@ where
     pub fn update(&mut self) -> Result<bool, minimq::Error<N::Error>> {
         // If we're no longer subscribed to the settings topic, but we are connected to the broker,
         // resubscribe.
-        if !self.subscribed && self.mqtt.client.is_connected()? {
+        if !self.subscribed && self.mqtt.client.is_connected() {
             log::info!("MQTT connected, subscribing to settings");
             // Note(unwrap): We construct a string with two more characters than the prefix
             // strucutre, so we are guaranteed to have space for storage.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,6 +3,36 @@ use miniconf::{minimq::QoS, Miniconf};
 use serde::Deserialize;
 use std_embedded_nal::Stack;
 
+use embedded_time::{fraction::Fraction, Clock};
+use std::time::Instant;
+
+#[derive(Default)]
+struct StdClock {
+    start: core::cell::UnsafeCell<Option<Instant>>,
+}
+
+impl Clock for StdClock {
+    type T = u32;
+
+    const SCALING_FACTOR: Fraction = Fraction::new(1, 1_000);
+
+    fn try_now(&self) -> Result<embedded_time::Instant<Self>, embedded_time::clock::Error> {
+        let std_now = Instant::now();
+        let start = unsafe {
+            if (*self.start.get()).is_none() {
+                (*self.start.get()).replace(std_now);
+                std_now
+            } else {
+                (*self.start.get()).unwrap()
+            }
+        };
+
+        let elapsed = std_now - start;
+
+        Ok(embedded_time::Instant::new(elapsed.as_millis() as u32))
+    }
+}
+
 #[macro_use]
 extern crate log;
 
@@ -88,11 +118,11 @@ fn main() -> std::io::Result<()> {
 
     // Construct a Minimq client to the broker for publishing requests.
     let mut mqtt: minimq::Minimq<_, 256> =
-        miniconf::minimq::Minimq::new(localhost, "tester", Stack::default()).unwrap();
+        miniconf::minimq::Minimq::new(localhost, "tester", Stack::default(), StdClock::default()).unwrap();
 
     // Construct a settings configuration interface.
     let mut interface: miniconf::MqttClient<Settings, _> =
-        miniconf::MqttClient::new(Stack::default(), "", "device", localhost).unwrap();
+        miniconf::MqttClient::new(Stack::default(), "", "device", localhost, StdClock::default()).unwrap();
 
     // We will wait 100ms in between each state to allow the MQTT broker to catch up
     let mut state = TestState::started();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -88,7 +88,7 @@ fn main() -> std::io::Result<()> {
     let localhost = "127.0.0.1".parse().unwrap();
 
     // Construct a Minimq client to the broker for publishing requests.
-    let mut mqtt: minimq::Minimq<_, _, 256> = miniconf::minimq::Minimq::new(
+    let mut mqtt: minimq::Minimq<_, _, 256, 1> = miniconf::minimq::Minimq::new(
         localhost,
         "tester",
         Stack::default(),
@@ -97,7 +97,7 @@ fn main() -> std::io::Result<()> {
     .unwrap();
 
     // Construct a settings configuration interface.
-    let mut interface: miniconf::MqttClient<Settings, _, _, 256> = miniconf::MqttClient::new(
+    let mut interface: miniconf::MqttClient<Settings, _, _, 256, 1> = miniconf::MqttClient::new(
         Stack::default(),
         "",
         "device",


### PR DESCRIPTION
This PR updates `miniconf` to utilize an updated version of minimq that uses ping timeouts.

TODO:
- [x] Release patch to minimq with bumped version