### PR TITLE
Allowing MQTT message size to be generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Added support for generic maximum MQTT message size
 
 ### Added
 

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -61,7 +61,7 @@ async fn main() {
     // Spawn a task to send MQTT messages.
     tokio::task::spawn(async move { mqtt_client().await });
 
-    let mut client: MqttClient<Settings, Stack> = MqttClient::new(
+    let mut client: MqttClient<Settings, Stack, 256> = MqttClient::new(
         Stack::default(),
         "",
         "sample/prefix",

--- a/src/mqtt_client/mqtt_client.rs
+++ b/src/mqtt_client/mqtt_client.rs
@@ -26,19 +26,19 @@ use crate::Miniconf;
 use log::info;
 
 /// MQTT settings interface.
-pub struct MqttClient<S, N>
+pub struct MqttClient<S, N, const T: usize>
 where
     S: Miniconf + Default,
     N: TcpClientStack,
 {
     default_response_topic: String<128>,
-    mqtt: minimq::Minimq<N, 256>,
+    mqtt: minimq::Minimq<N, T>,
     settings: S,
     subscribed: bool,
     settings_prefix: String<64>,
 }
 
-impl<S, N> MqttClient<S, N>
+impl<S, N, const T: usize> MqttClient<S, N, T>
 where
     S: Miniconf + Default,
     N: TcpClientStack,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -91,7 +91,7 @@ fn main() -> std::io::Result<()> {
         miniconf::minimq::Minimq::new(localhost, "tester", Stack::default()).unwrap();
 
     // Construct a settings configuration interface.
-    let mut interface: miniconf::MqttClient<Settings, _> =
+    let mut interface: miniconf::MqttClient<Settings, _, 256> =
         miniconf::MqttClient::new(Stack::default(), "", "device", localhost).unwrap();
 
     // We will wait 100ms in between each state to allow the MQTT broker to catch up


### PR DESCRIPTION
This PR fixes #52 by allowing the MQTT client to have a configurable buffer size.