### PR TITLE
Adding support for deriving on generic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 * Added support for generic maximum MQTT message size
+* `derive_miniconf` added support for generic types
 
 ### Added
 

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -1,0 +1,15 @@
+use miniconf::Miniconf;
+use serde::Serialize;
+
+#[test]
+fn generic_struct() {
+    #[derive(Miniconf, Serialize, Default)]
+    struct Settings<T: Miniconf> {
+        data: T,
+    }
+
+    let mut settings = Settings::<f32>::default();
+    settings
+        .string_set("data".split('/').peekable(), b"3.0")
+        .unwrap();
+}


### PR DESCRIPTION
This PR fixes #54 by adding generic support for structures using `derive(Miniconf)`.

Previously, we were discarding generics and where-clauses when implementing `Miniconf` for the derived type. This PR updates the derive macro to carry the generic information on the type around and then propagate it back into the impl for the `Miniconf` trait.