### PR TITLE
Fixing trait bounds on miniconf array implementations

### DIFF
--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -29,7 +29,7 @@ impl TypeDefinition {
             .push(parse_quote!(Self: miniconf::DeserializeOwned));
     }
 
-    // Bound all generics of the type with `T: miniconf::DeserializeOwned`. This is necessary to
+    // Bound all generics of the type with `T: miniconf::DeserializeOwned + Miniconf`. This is necessary to
     // make `MiniconfAtomic` and enum derives work properly.
     fn bound_generics(&mut self) {
         for generic in &mut self.generics.params {

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -1,11 +1,45 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{parse_macro_input, parse_quote, DeriveInput};
 
 /// Represents a type definition with associated generics.
 struct TypeDefinition {
     pub generics: syn::Generics,
     pub name: syn::Ident,
+}
+
+impl TypeDefinition {
+    pub fn new(generics: syn::Generics, name: syn::Ident) -> Self {
+        let mut typedef = TypeDefinition { generics, name };
+        typedef.bound_generics();
+
+        typedef
+    }
+
+    /// Bound the generated type definition to only implement when `Self: DeserializeOwned` for
+    /// cases when deserialization is required.
+    ///
+    /// # Note
+    /// This is equivalent to adding:
+    /// `where Self: DeserializeOwned` to the type definition.
+    pub fn add_deserialize_bound(&mut self) {
+        let where_clause = self.generics.make_where_clause();
+        where_clause
+            .predicates
+            .push(parse_quote!(Self: miniconf::DeserializeOwned));
+    }
+
+    // Bound all generics of the type with `T: miniconf::DeserializeOwned`. This is necessary to
+    // make `MiniconfAtomic` and enum derives work properly.
+    fn bound_generics(&mut self) {
+        for generic in &mut self.generics.params {
+            if let syn::GenericParam::Type(type_param) = generic {
+                type_param
+                    .bounds
+                    .push(parse_quote!(miniconf::DeserializeOwned));
+            }
+        }
+    }
 }
 
 /// Derive the Miniconf trait for custom types.
@@ -36,10 +70,7 @@ struct TypeDefinition {
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    let typedef = TypeDefinition {
-        generics: input.generics,
-        name: input.ident,
-    };
+    let typedef = TypeDefinition::new(input.generics, input.ident);
 
     match input.data {
         syn::Data::Struct(struct_data) => derive_struct(typedef, struct_data, false),
@@ -76,10 +107,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 pub fn derive_atomic(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    let typedef = TypeDefinition {
-        generics: input.generics,
-        name: input.ident,
-    };
+    let typedef = TypeDefinition::new(input.generics, input.ident);
 
     match input.data {
         syn::Data::Struct(struct_data) => derive_struct(typedef, struct_data, true),
@@ -98,18 +126,21 @@ pub fn derive_atomic(input: TokenStream) -> TokenStream {
 ///
 /// # Returns
 /// A token stream of the generated code.
-fn derive_struct(typedef: TypeDefinition, data: syn::DataStruct, atomic: bool) -> TokenStream {
+fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct, atomic: bool) -> TokenStream {
     let fields = match data.fields {
         syn::Fields::Named(syn::FieldsNamed { ref named, .. }) => named,
         _ => unimplemented!("Only named fields are supported in structs."),
     };
 
-    let (impl_generics, ty_generics, where_clause) = typedef.generics.split_for_impl();
-    let name = typedef.name;
-
     // If this structure must be updated atomically, it is not valid to call Miniconf recursively
     // on its members.
     if atomic {
+        // Bound the Miniconf implementation on Self implementing DeserializeOwned.
+        typedef.add_deserialize_bound();
+
+        let name = typedef.name;
+        let (impl_generics, ty_generics, where_clause) = typedef.generics.split_for_impl();
+
         let data = quote! {
             impl #impl_generics miniconf::Miniconf for #name #ty_generics #where_clause {
                 fn string_set(&mut self, mut topic_parts:
@@ -138,6 +169,9 @@ fn derive_struct(typedef: TypeDefinition, data: syn::DataStruct, atomic: bool) -
         }
     });
 
+    let (impl_generics, ty_generics, where_clause) = typedef.generics.split_for_impl();
+    let name = typedef.name;
+
     let expanded = quote! {
         impl #impl_generics miniconf::Miniconf for #name #ty_generics #where_clause {
             fn string_set(&mut self, mut topic_parts:
@@ -164,7 +198,7 @@ fn derive_struct(typedef: TypeDefinition, data: syn::DataStruct, atomic: bool) -
 ///
 /// # Returns
 /// A token stream of the generated code.
-fn derive_enum(typedef: TypeDefinition, data: syn::DataEnum) -> TokenStream {
+fn derive_enum(mut typedef: TypeDefinition, data: syn::DataEnum) -> TokenStream {
     // Only support simple enums, check each field
     for v in data.variants.iter() {
         match v.fields {
@@ -174,6 +208,8 @@ fn derive_enum(typedef: TypeDefinition, data: syn::DataEnum) -> TokenStream {
             syn::Fields::Unit => {}
         }
     }
+
+    typedef.add_deserialize_bound();
 
     let (impl_generics, ty_generics, where_clause) = typedef.generics.split_for_impl();
     let name = typedef.name;

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -37,6 +37,7 @@ impl TypeDefinition {
                 type_param
                     .bounds
                     .push(parse_quote!(miniconf::DeserializeOwned));
+                type_param.bounds.push(parse_quote!(miniconf::Miniconf));
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,10 +169,7 @@ macro_rules! impl_single {
     };
 }
 
-impl<T, const N: usize> Miniconf for [T; N]
-where
-    T: Miniconf + core::marker::Copy + DeserializeOwned,
-{
+impl<T: Miniconf, const N: usize> Miniconf for [T; N] {
     fn string_set(
         &mut self,
         mut topic_parts: core::iter::Peekable<core::str::Split<char>>,

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -33,7 +33,7 @@ fn generic_array() {
 #[test]
 fn generic_struct() {
     #[derive(Miniconf, Default)]
-    struct Settings<T: Miniconf> {
+    struct Settings<T> {
         pub inner: T,
     }
 

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -1,15 +1,51 @@
-use miniconf::Miniconf;
-use serde::Serialize;
+use miniconf::{Miniconf, MiniconfAtomic};
+use serde::Deserialize;
 
 #[test]
-fn generic_struct() {
-    #[derive(Miniconf, Serialize, Default)]
+fn generic_type() {
+    #[derive(Miniconf, Default)]
     struct Settings<T: Miniconf> {
-        data: T,
+        pub data: T,
     }
 
     let mut settings = Settings::<f32>::default();
     settings
         .string_set("data".split('/').peekable(), b"3.0")
         .unwrap();
+    assert_eq!(settings.data, 3.0);
+}
+
+#[test]
+fn generic_array() {
+    #[derive(Miniconf, Default)]
+    struct Settings<T: Miniconf> {
+        pub data: [T; 2],
+    }
+
+    let mut settings = Settings::<f32>::default();
+    settings
+        .string_set("data/0".split('/').peekable(), b"3.0")
+        .unwrap();
+
+    assert_eq!(settings.data[0], 3.0);
+}
+
+#[test]
+fn generic_struct() {
+    #[derive(Miniconf, Default)]
+    struct Settings<T: Miniconf> {
+        pub inner: T,
+    }
+
+    #[derive(MiniconfAtomic, Deserialize, Default)]
+    struct Inner {
+        pub data: f32,
+    }
+
+    let mut settings = Settings::<Inner>::default();
+    settings
+        .string_set("inner".split('/').peekable(), b"{\"data\": 3.0}")
+        .unwrap();
+
+    assert_eq!(settings.inner.data, 3.0);
 }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -49,3 +49,26 @@ fn generic_struct() {
 
     assert_eq!(settings.inner.data, 3.0);
 }
+
+#[test]
+fn generic_atomic() {
+    #[derive(Miniconf, Default)]
+    struct Settings<T> {
+        pub atomic: Inner<T>,
+    }
+
+    #[derive(Deserialize, MiniconfAtomic, Default)]
+    struct Inner<T> {
+        pub inner: [T; 5],
+    }
+
+    let mut settings = Settings::<f32>::default();
+    settings
+        .string_set(
+            "atomic".split('/').peekable(),
+            b"{\"inner\": [3.0, 0, 0, 0, 0]}",
+        )
+        .unwrap();
+
+    assert_eq!(settings.atomic.inner[0], 3.0);
+}


### PR DESCRIPTION
This PR fixes #56 by removing unnecessary trait bounds on the generic implementation for array types.

This PR also refactors the Miniconf trait implementation in the proc macro to include a where-clause for implementing `Miniconf` and `DeserializeOwned` for any generic type parameters on the struct.

For any `MiniconfAtomic` or Enum types, the additional bound of `Self: DeserializeOwned` is also added to ensure deserialization into `self` is possible.