### PR TITLE
Report connection state via topic, expose automatic prefix detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde-json-core = "0.4.0"
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
 log = "0.4"
 heapless = { version = "0.7", features = ["serde"] }
-minimq = { version = "0.5", optional = true }
+minimq = { version = "^0.5.1", optional = true }
 
 [features]
 default = ["mqtt-client"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ serde-json-core = "0.4.0"
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
 log = "0.4"
 heapless = { version = "0.7", features = ["serde"] }
+minimq = { version = "0.5", optional = true }
 
-[dependencies.minimq]
+[patch.crates-io.minimq]
 git = "https://github.com/quartiq/minimq"
-branch = "master"
-optional = true
+branch = "release/0.5.0"
 
 [features]
 default = ["mqtt-client"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,12 @@ serde-json-core = "0.4.0"
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
 log = "0.4"
 heapless = { version = "0.7", features = ["serde"] }
-minimq = {version = "0.4", optional = true }
+
+[dependencies.minimq]
+git = "https://github.com/quartiq/minimq"
+branch = "feature/will-support"
+# version = "0.4"
+optional = true
 
 [features]
 default = ["mqtt-client"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ heapless = { version = "0.7", features = ["serde"] }
 
 [dependencies.minimq]
 git = "https://github.com/quartiq/minimq"
-branch = "feature/will-support"
-# version = "0.4"
+branch = "master"
 optional = true
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,6 @@ log = "0.4"
 heapless = { version = "0.7", features = ["serde"] }
 minimq = { version = "0.5", optional = true }
 
-[patch.crates-io.minimq]
-git = "https://github.com/quartiq/minimq"
-branch = "release/0.5.0"
-
 [features]
 default = ["mqtt-client"]
 mqtt-client = ["minimq"]

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -42,6 +42,7 @@ async fn mqtt_client() {
             "sample/prefix/settings/amplitude/0",
             b"32.4",
             QoS::AtMostOnce,
+            false,
             &[],
         )
         .unwrap();
@@ -52,13 +53,20 @@ async fn mqtt_client() {
             "sample/prefix/settings/inner/frame_rate",
             b"10",
             QoS::AtMostOnce,
+            false,
             &[],
         )
         .unwrap();
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     mqtt.client
-        .publish("sample/prefix/settings/exit", b"true", QoS::AtMostOnce, &[])
+        .publish(
+            "sample/prefix/settings/exit",
+            b"true",
+            QoS::AtMostOnce,
+            false,
+            &[],
+        )
         .unwrap();
 }
 

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -1,5 +1,5 @@
 use miniconf::{Miniconf, MqttClient};
-use minimq::{Minimq, QoS};
+use minimq::{Minimq, QoS, Retain};
 use std::time::Duration;
 use std_embedded_nal::Stack;
 use std_embedded_time::StandardClock;
@@ -42,7 +42,7 @@ async fn mqtt_client() {
             "sample/prefix/settings/amplitude/0",
             b"32.4",
             QoS::AtMostOnce,
-            false,
+            Retain::NotRetained,
             &[],
         )
         .unwrap();
@@ -53,7 +53,7 @@ async fn mqtt_client() {
             "sample/prefix/settings/inner/frame_rate",
             b"10",
             QoS::AtMostOnce,
-            false,
+            Retain::NotRetained,
             &[],
         )
         .unwrap();
@@ -64,7 +64,7 @@ async fn mqtt_client() {
             "sample/prefix/settings/exit",
             b"true",
             QoS::AtMostOnce,
-            false,
+            Retain::NotRetained,
             &[],
         )
         .unwrap();

--- a/py/miniconf-mqtt/miniconf/__init__.py
+++ b/py/miniconf-mqtt/miniconf/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 """ Root Miniconf module file. """
 import asyncio
+import json
 import logging
 import time
 
@@ -11,14 +12,17 @@ from gmqtt import Client as MqttClient
 from .miniconf import Miniconf
 from .version import __version__
 
-async def get_devices(broker: str,
-                      prefix_filter: str = None,
-                      discovery_timeout: float = 0.1) -> List[str]:
+async def discover(
+        broker: str,
+        prefix_filter: str,
+        discovery_timeout: float = 0.1,
+    ) -> List[str]:
     """ Get a list of available Miniconf devices.
 
     Args:
         * `broker` - The broker to search for clients on.
-        * `prefix_filter` - An MQTT-specific topic filter for device prefixes.
+        * `prefix_filter` - An MQTT-specific topic filter for device prefixes. Note that this will
+          be appended to with the default status topic name `/alive`.
         * `discovery_timeout` - The duration to search for clients in seconds.
 
     Returns:
@@ -26,26 +30,20 @@ async def get_devices(broker: str,
     """
     discovered_devices = []
 
-    suffix = '/connected'
+    suffix = '/alive'
 
     def handle_message(_client, topic, payload, _qos, _properties):
-        if not topic.endswith(suffix):
-            return
-
         logging.debug('Got message from %s: %s', topic, payload)
-        if payload == b"1":
-            discovered_devices.append(topic[:-len(suffix)])
 
+        if json.loads(payload):
+            discovered_devices.append(topic[:-len(suffix)])
 
     client = MqttClient(client_id='')
     client.on_message = handle_message
 
     await client.connect(broker)
 
-    if prefix_filter is None:
-        prefix_filter = '#'
-
-    client.subscribe(prefix_filter)
+    client.subscribe(f'{prefix_filter}/{suffix}')
 
     await asyncio.sleep(discovery_timeout)
 

--- a/py/miniconf-mqtt/miniconf/__init__.py
+++ b/py/miniconf-mqtt/miniconf/__init__.py
@@ -1,4 +1,52 @@
 #!/usr/bin/python3
 """ Root Miniconf module file. """
+import asyncio
+import logging
+import time
+
+from typing import List
+
+from gmqtt import Client as MqttClient
+
 from .miniconf import Miniconf
 from .version import __version__
+
+async def get_devices(broker: str,
+                      prefix_filter: str = None,
+                      discovery_timeout: float = 0.1) -> List[str]:
+    """ Get a list of available Miniconf devices.
+
+    Args:
+        * `broker` - The broker to search for clients on.
+        * `prefix_filter` - An MQTT-specific topic filter for device prefixes.
+        * `discovery_timeout` - The duration to search for clients in seconds.
+
+    Returns:
+        A list of discovered client prefixes that match the provided filter.
+    """
+    discovered_devices = []
+
+    suffix = '/connected'
+
+    def handle_message(_client, topic, payload, _qos, _properties):
+        if not topic.endswith(suffix):
+            return
+
+        logging.debug('Got message from %s: %s', topic, payload)
+        if payload == b"1":
+            discovered_devices.append(topic[:-len(suffix)])
+
+
+    client = MqttClient(client_id='')
+    client.on_message = handle_message
+
+    await client.connect(broker)
+
+    if prefix_filter is None:
+        prefix_filter = '#'
+
+    client.subscribe(prefix_filter)
+
+    await asyncio.sleep(discovery_timeout)
+
+    return discovered_devices

--- a/py/miniconf-mqtt/miniconf/__init__.py
+++ b/py/miniconf-mqtt/miniconf/__init__.py
@@ -43,7 +43,7 @@ async def discover(
 
     await client.connect(broker)
 
-    client.subscribe(f'{prefix_filter}/{suffix}')
+    client.subscribe(f'{prefix_filter}{suffix}')
 
     await asyncio.sleep(discovery_timeout)
 

--- a/py/miniconf-mqtt/miniconf/__main__.py
+++ b/py/miniconf-mqtt/miniconf/__main__.py
@@ -68,7 +68,7 @@ def main():
         prefix = devices[0]
 
     async def configure_settings():
-        interface = await Miniconf.create(args.prefix, args.broker)
+        interface = await Miniconf.create(prefix, args.broker)
         for setting in args.settings:
             path, value = setting.split("=", 1)
             await interface.command(path, json.loads(value), not args.no_retain)

--- a/py/miniconf-mqtt/miniconf/__main__.py
+++ b/py/miniconf-mqtt/miniconf/__main__.py
@@ -11,6 +11,7 @@ import logging
 import json
 
 from .miniconf import Miniconf
+from . import get_devices
 
 
 def main():
@@ -29,10 +30,12 @@ def main():
     parser.add_argument('--no-retain', '-n', default=False,
                         action='store_true',
                         help='Do not retain the affected settings')
-    parser.add_argument('prefix', type=str,
+    parser.add_argument('--prefix', type=str,
                         help='The MQTT topic prefix of the target')
-    parser.add_argument('settings', metavar="PATH=VALUE", nargs='+',
+    parser.add_argument('settings', metavar="PATH=VALUE", nargs='*',
                         help='JSON encoded values for settings path keys.')
+    parser.add_argument('--list', '-', action='store_true',
+                        help='Detect and list device prefixes')
 
     args = parser.parse_args()
 
@@ -41,6 +44,28 @@ def main():
         level=logging.WARN - 10*args.verbose)
 
     loop = asyncio.get_event_loop()
+
+    devices = None
+    if args.list:
+        print('Discovering devices:')
+        devices = loop.run_until_complete(get_devices(args.broker))
+        for device in devices:
+            print(device)
+
+    # If a prefix wasn't provided, try to find a device.
+    prefix = args.prefix
+    if not args.prefix:
+        if devices is None:
+            devices = loop.run_until_complete(get_devices(args.broker))
+
+        if not devices:
+            raise Exception('No Miniconf devices found. Please specify a --prefix')
+
+        assert len(devices) == 1, \
+            'Multiple miniconf devices found (%d). Please specify one with --prefix'
+
+        logging.info('Automatically using detected device prefix: %s', devices[0])
+        prefix = devices[0]
 
     async def configure_settings():
         interface = await Miniconf.create(args.prefix, args.broker)

--- a/src/mqtt_client/mqtt_client.rs
+++ b/src/mqtt_client/mqtt_client.rs
@@ -64,6 +64,12 @@ where
     ) -> Result<Self, minimq::Error<Stack::Error>> {
         let mut mqtt = minimq::Minimq::new(broker, client_id, stack, clock)?;
 
+        // Utilize a keepalive interval of 60 seconds. If this lapses, our will shall indicate our
+        // disconnected state.
+        // Note(unwrap): The client was just created, so it's valid to set a keepalive interval
+        // now, since we're not yet connected to the broker.
+        mqtt.client.set_keepalive_interval(60).unwrap();
+
         // Configure a will so that we can indicate whether or not we are connected.
         let mut connection_topic: String<75> = String::from(prefix);
         connection_topic.push_str("/alive").unwrap();

--- a/src/mqtt_client/mqtt_client.rs
+++ b/src/mqtt_client/mqtt_client.rs
@@ -24,7 +24,7 @@ use minimq::embedded_nal::{IpAddr, TcpClientStack};
 use super::messages::{MqttMessage, SettingsResponse};
 use crate::Miniconf;
 use log::info;
-use minimq::embedded_time;
+use minimq::{embedded_time, QoS, Retain};
 
 /// MQTT settings interface.
 pub struct MqttClient<Settings, Stack, Clock, const MESSAGE_SIZE: usize, const MESSAGE_COUNT: usize>
@@ -71,8 +71,8 @@ where
             .set_will(
                 &connection_topic,
                 "0".as_bytes(),
-                minimq::QoS::AtMostOnce,
-                true,
+                QoS::AtMostOnce,
+                Retain::Retained,
                 &[],
             )
             .unwrap();
@@ -116,8 +116,8 @@ where
                 .publish(
                     &connection_topic,
                     "1".as_bytes(),
-                    minimq::QoS::AtMostOnce,
-                    true,
+                    QoS::AtMostOnce,
+                    Retain::Retained,
                     &[],
                 )
                 .unwrap();
@@ -166,8 +166,8 @@ where
                     &response.message,
                     // TODO: When Minimq supports more QoS levels, this should be increased to
                     // ensure that the client has received it at least once.
-                    minimq::QoS::AtMostOnce,
-                    false,
+                    QoS::AtMostOnce,
+                    Retain::NotRetained,
                     &response.properties,
                 )
                 .ok();

--- a/src/mqtt_client/mqtt_client.rs
+++ b/src/mqtt_client/mqtt_client.rs
@@ -66,7 +66,7 @@ where
 
         // Configure a will so that we can indicate whether or not we are connected.
         let mut connection_topic: String<75> = String::from(prefix);
-        connection_topic.push_str("/connected").unwrap();
+        connection_topic.push_str("/alive").unwrap();
         mqtt.client
             .set_will(
                 &connection_topic,
@@ -110,7 +110,7 @@ where
 
             // Publish a connection status message.
             let mut connection_topic: String<75> = String::from(self.prefix.as_str());
-            connection_topic.push_str("/connected").unwrap();
+            connection_topic.push_str("/alive").unwrap();
             self.mqtt
                 .client
                 .publish(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -133,6 +133,7 @@ fn main() -> std::io::Result<()> {
                             "device/settings/data",
                             "500".as_bytes(),
                             QoS::AtMostOnce,
+                            false,
                             &[],
                         )
                         .unwrap();
@@ -150,6 +151,7 @@ fn main() -> std::io::Result<()> {
                             "device/settings/more/inner",
                             "100".as_bytes(),
                             QoS::AtMostOnce,
+                            false,
                             &[],
                         )
                         .unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,8 @@
 use machine::*;
-use miniconf::{minimq::QoS, Miniconf};
+use miniconf::{
+    minimq::{QoS, Retain},
+    Miniconf,
+};
 use serde::Deserialize;
 use std_embedded_nal::Stack;
 use std_embedded_time::StandardClock;
@@ -133,7 +136,7 @@ fn main() -> std::io::Result<()> {
                             "device/settings/data",
                             "500".as_bytes(),
                             QoS::AtMostOnce,
-                            false,
+                            Retain::NotRetained,
                             &[],
                         )
                         .unwrap();
@@ -151,7 +154,7 @@ fn main() -> std::io::Result<()> {
                             "device/settings/more/inner",
                             "100".as_bytes(),
                             QoS::AtMostOnce,
-                            false,
+                            Retain::NotRetained,
                             &[],
                         )
                         .unwrap();


### PR DESCRIPTION
This PR integrates a `prefix/connected` topic which contains the retained connected state of the client. A `Will` is set up such that this topic will be written with the value "0" when disconnected and "1" is written when the device is connected.

Additionally, the python utilities have been modified such that query of existing devices can be completed. If no `prefix` is provided, a prefix will automatically be identified using the newly exposed connection state.

TODO:
- [x] Merge and release https://github.com/quartiq/minimq/pull/66, update dependencies