### PR TITLE
Feature/settings validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [breaking] MqttClient constructor now accepts initial settings values.
 
 ### Removed
+* The client no longer resets the republish timeout when receiving messages.
 
 ## [0.3.0] - 2021-12-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* Added support for custom validation of settings whenever an update occurs.
+
 ### Changed
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-* Added support for custom validation of settings whenever an update occurs.
+* Added support for custom handling of settings updates.
 
 ### Changed
 ### Removed

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -100,15 +100,18 @@ async fn main() {
     .unwrap();
 
     loop {
-        client
-            .update(|settings| {
+        if client
+            .handled_update(|settings| {
                 if settings.error {
                     return Err("Intentional failure");
                 }
 
                 Ok(())
             })
-            .unwrap();
+            .unwrap()
+        {
+            println!("Settings updated: {:?}", client.settings());
+        }
 
         if client.settings().exit {
             break;

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -4,12 +4,12 @@ use std::time::Duration;
 use std_embedded_nal::Stack;
 use std_embedded_time::StandardClock;
 
-#[derive(Default, Miniconf, Debug)]
+#[derive(Clone, Default, Miniconf, Debug)]
 struct NestedSettings {
     frame_rate: u32,
 }
 
-#[derive(Default, Miniconf, Debug)]
+#[derive(Clone, Default, Miniconf, Debug)]
 struct Settings {
     inner: NestedSettings,
     amplitude: [f32; 2],

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -14,7 +14,6 @@ struct Settings {
     inner: NestedSettings,
     amplitude: [f32; 2],
     exit: bool,
-    error: bool,
 }
 
 async fn mqtt_client() {
@@ -60,28 +59,6 @@ async fn mqtt_client() {
         .unwrap();
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    assert!(mqtt
-        .client
-        .publish(
-            "sample/prefix/settings/error",
-            b"true",
-            QoS::AtMostOnce,
-            &[]
-        )
-        .is_err());
-
-    assert!(mqtt
-        .client
-        .publish(
-            "sample/prefix/settings/error",
-            b"false",
-            QoS::AtMostOnce,
-            &[]
-        )
-        .is_err());
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    tokio::time::sleep(Duration::from_millis(100)).await;
     mqtt.client
         .publish(
             "sample/prefix/settings/exit",
@@ -108,16 +85,7 @@ async fn main() {
     .unwrap();
 
     loop {
-        if client
-            .handled_update(|settings| {
-                if settings.error {
-                    return Err("Intentional failure");
-                }
-
-                Ok(())
-            })
-            .unwrap()
-        {
+        if client.update().unwrap() {
             println!("Settings updated: {:?}", client.settings());
         }
 

--- a/src/mqtt_client/messages.rs
+++ b/src/mqtt_client/messages.rs
@@ -1,4 +1,3 @@
-use core::fmt::Write;
 use heapless::{String, Vec};
 use serde::Serialize;
 
@@ -16,20 +15,24 @@ impl SettingsResponse {
             code: 0,
         }
     }
+
+    pub fn error(msg: String<64>) -> Self {
+        Self { code: 255, msg }
+    }
 }
 
-impl<T, E: core::fmt::Debug> From<Result<T, E>> for SettingsResponse {
+impl<T, E: AsRef<str>> From<Result<T, E>> for SettingsResponse {
     fn from(result: Result<T, E>) -> Self {
         match result {
             Ok(_) => SettingsResponse::ok(),
 
             Err(error) => {
                 let mut msg = String::new();
-                if write!(&mut msg, "{:?}", error).is_err() {
+                if msg.push_str(error.as_ref()).is_err() {
                     msg = String::from("Configuration Error");
                 }
 
-                Self { code: 255, msg }
+                Self::error(msg)
             }
         }
     }

--- a/src/mqtt_client/messages.rs
+++ b/src/mqtt_client/messages.rs
@@ -1,4 +1,3 @@
-use crate::Error;
 use core::fmt::Write;
 use heapless::{String, Vec};
 use serde::Serialize;
@@ -10,8 +9,8 @@ pub struct SettingsResponse {
     msg: String<64>,
 }
 
-impl From<Result<(), Error>> for SettingsResponse {
-    fn from(result: Result<(), Error>) -> Self {
+impl<E: core::fmt::Debug> From<Result<(), E>> for SettingsResponse {
+    fn from(result: Result<(), E>) -> Self {
         match result {
             Ok(_) => Self {
                 msg: String::from("OK"),
@@ -21,13 +20,10 @@ impl From<Result<(), Error>> for SettingsResponse {
             Err(error) => {
                 let mut msg = String::new();
                 if write!(&mut msg, "{:?}", error).is_err() {
-                    msg = String::from("Miniconf Error");
+                    msg = String::from("Configuration Error");
                 }
 
-                Self {
-                    code: error.into(),
-                    msg,
-                }
+                Self { code: 255, msg }
             }
         }
     }

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -1,3 +1,19 @@
 mod messages;
 mod mqtt_client;
 pub use mqtt_client::MqttClient;
+
+#[non_exhaustive]
+pub enum HandlerResult {
+    /// A settings updated was accepted.
+    UpdateAccepted,
+
+    /// The application of a setting had ramifications on other settings values. In this case, all
+    /// settings will be republished.
+    UpdateSideEffects,
+}
+
+impl From<&()> for HandlerResult {
+    fn from(_: &()) -> Self {
+        HandlerResult::UpdateAccepted
+    }
+}

--- a/src/mqtt_client/mqtt_client.rs
+++ b/src/mqtt_client/mqtt_client.rs
@@ -342,7 +342,6 @@ where
                     Ok(len) => {
                         match settings.string_set(path.split('/').peekable(), message) {
                             Ok(_) => {
-                                updated = true;
                                 let result = handler(settings);
                                 if result.is_err() {
                                     // Note(unwrap): We just serialized this value, so it should
@@ -350,7 +349,10 @@ where
                                     settings
                                         .string_set(path.split('/').peekable(), &buffer[..len])
                                         .unwrap();
+                                } else {
+                                    updated = true;
                                 }
+
                                 result.into()
                             }
                             other => other.into(),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -119,13 +119,7 @@ fn main() -> std::io::Result<()> {
         .unwrap();
 
         // Next, service the settings interface and progress the test.
-        let mut setting_update = false;
-        interface
-            .update(|_| {
-                setting_update = true;
-                Result::<(), ()>::Ok(())
-            })
-            .unwrap();
+        let setting_update = interface.update().unwrap();
         match state {
             TestState::Started(_) => {
                 if timer.is_complete() && mqtt.client.is_connected() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -119,7 +119,13 @@ fn main() -> std::io::Result<()> {
         .unwrap();
 
         // Next, service the settings interface and progress the test.
-        let setting_update = interface.update().unwrap();
+        let mut setting_update = false;
+        interface
+            .update(|_| {
+                setting_update = true;
+                Result::<(), ()>::Ok(())
+            })
+            .unwrap();
         match state {
             TestState::Started(_) => {
                 if timer.is_complete() && mqtt.client.is_connected() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,12 +10,12 @@ use std_embedded_time::StandardClock;
 #[macro_use]
 extern crate log;
 
-#[derive(Debug, Default, Miniconf, Deserialize)]
+#[derive(Clone, Debug, Default, Miniconf, Deserialize)]
 struct AdditionalSettings {
     inner: u8,
 }
 
-#[derive(Debug, Default, Miniconf, Deserialize)]
+#[derive(Clone, Debug, Default, Miniconf, Deserialize)]
 struct Settings {
     data: u32,
     more: AdditionalSettings,

--- a/tests/republish.rs
+++ b/tests/republish.rs
@@ -4,12 +4,12 @@ use miniconf::{minimq, Miniconf};
 use std_embedded_nal::Stack;
 use std_embedded_time::StandardClock;
 
-#[derive(Debug, Default, Miniconf)]
+#[derive(Clone, Debug, Default, Miniconf)]
 struct AdditionalSettings {
     inner: u8,
 }
 
-#[derive(Debug, Default, Miniconf)]
+#[derive(Clone, Debug, Default, Miniconf)]
 struct Settings {
     data: u32,
     more: AdditionalSettings,

--- a/tests/validation_failure.rs
+++ b/tests/validation_failure.rs
@@ -1,0 +1,107 @@
+use miniconf::{minimq, Miniconf};
+use serde::Deserialize;
+use std_embedded_nal::Stack;
+use std_embedded_time::StandardClock;
+
+#[derive(Debug, Default, Miniconf)]
+struct Settings {
+    error: bool,
+}
+
+#[derive(Deserialize)]
+struct Response {
+    code: u8,
+    _message: heapless::String<256>,
+}
+
+async fn client_task() {
+    // Construct a Minimq client to the broker for publishing requests.
+    let mut mqtt: minimq::Minimq<_, _, 256, 1> = miniconf::minimq::Minimq::new(
+        "127.0.0.1".parse().unwrap(),
+        "tester",
+        Stack::default(),
+        StandardClock::default(),
+    )
+    .unwrap();
+
+    // Wait for the broker connection
+    while !mqtt.client.is_connected() {
+        mqtt.poll(|_client, _topic, _message, _properties| {})
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+
+    let response_topic = "validation_failure/device/response";
+    mqtt.client.subscribe(&response_topic, &[]).unwrap();
+
+    // Wait the other device to connect.
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    // Configure the error variable to trigger an internal validation failure.
+    let properties = [minimq::Property::ResponseTopic(&response_topic)];
+
+    log::info!("Publishing error setting");
+    mqtt.client
+        .publish(
+            "validation_failure/device/settings/error",
+            b"false",
+            minimq::QoS::AtMostOnce,
+            minimq::Retain::NotRetained,
+            &properties,
+        )
+        .unwrap();
+
+    // Wait until we get a response to the request.
+    let mut continue_testing = true;
+    loop {
+        mqtt.poll(|_client, _topic, message, _properties| {
+            let data: Response = serde_json_core::from_slice(message).unwrap().0;
+            assert!(data.code != 0);
+            continue_testing = false;
+        })
+        .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        if !continue_testing {
+            break;
+        }
+    }
+}
+
+#[tokio::test]
+async fn main() {
+    env_logger::init();
+
+    // Spawn a task to send MQTT messages.
+    tokio::task::spawn(async move { client_task().await });
+
+    // Construct a settings configuration interface.
+    let mut interface: miniconf::MqttClient<Settings, _, _, 256, 1> = miniconf::MqttClient::new(
+        Stack::default(),
+        "",
+        "validation_failure/device",
+        "127.0.0.1".parse().unwrap(),
+        StandardClock::default(),
+    )
+    .unwrap();
+
+    // Update the client until the exit
+    loop {
+        if interface
+            .handled_update(|settings| {
+                log::info!("Handling setting update");
+                if settings.error {
+                    return Err(());
+                }
+
+                return Ok(());
+            })
+            .unwrap()
+        {
+            break;
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    }
+}

--- a/tests/validation_failure.rs
+++ b/tests/validation_failure.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use std_embedded_nal::Stack;
 use std_embedded_time::StandardClock;
 
-#[derive(Debug, Default, Miniconf)]
+#[derive(Clone, Debug, Default, Miniconf)]
 struct Settings {
     error: bool,
 }

--- a/tests/validation_failure.rs
+++ b/tests/validation_failure.rs
@@ -95,7 +95,7 @@ async fn main() {
                 log::info!("Handling setting update");
                 if new_settings.error {
                     should_exit = true;
-                    return Err(());
+                    return Err("Exiting now");
                 }
 
                 return Ok(());


### PR DESCRIPTION
This PR fixes #51 by adding support for a custom handler to be called whenever settings are updated.

Note: Currently, if a new setting is rejected, it still persists in the cached settings.