### PR TITLE
Reverting python API, adding CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* Added publication of connectivity (alive) state to `<prefix>/alive` using MQTT will messages.
+* Added automatic discovery of prefixes to CLI.
+
 ### Changed
 ### Removed
 

--- a/py/miniconf-mqtt/miniconf/__main__.py
+++ b/py/miniconf-mqtt/miniconf/__main__.py
@@ -30,10 +30,10 @@ def main():
     parser.add_argument('--no-retain', '-n', default=False,
                         action='store_true',
                         help='Do not retain the affected settings')
-    parser.add_argument('--prefix', required=True, type=str,
+    parser.add_argument('prefix', type=str,
                         help='The MQTT topic prefix of the target (or a prefix filter in the case '
                              'of discovery)')
-    parser.add_argument('settings', metavar="PATH=VALUE", nargs='*',
+    parser.add_argument('settings', metavar="PATH=VALUE", nargs='+',
                         help='JSON encoded values for settings path keys.')
     parser.add_argument('--discover', '-d', action='store_true',
                         help='Detect and list device prefixes')

--- a/py/miniconf-mqtt/miniconf/__main__.py
+++ b/py/miniconf-mqtt/miniconf/__main__.py
@@ -33,7 +33,7 @@ def main():
     parser.add_argument('prefix', type=str,
                         help='The MQTT topic prefix of the target (or a prefix filter in the case '
                              'of discovery)')
-    parser.add_argument('settings', metavar="PATH=VALUE", nargs='+',
+    parser.add_argument('settings', metavar="PATH=VALUE", nargs='*',
                         help='JSON encoded values for settings path keys.')
     parser.add_argument('--discover', '-d', action='store_true',
                         help='Detect and list device prefixes')


### PR DESCRIPTION
This PR fixes some unintended CLI changes introduced in #61.

This PR also updates the CHANGELOG to mention the new `alive` topic.