### PR TITLE
Refactoring readback support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* Added key iteration
+* Added support for retrieving serialized values via keys.
+* Added APIs to the Miniconf trait for asynchronous iteration.
+
 ### Changed
+* `miniconf::update()` replaced with `Miniconf::set()`, which is part of the trait and now
+  directly available on structures.
 ### Removed
 
 ## [0.2.0] - 2021-10-28

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -22,11 +22,14 @@ impl TypeDefinition {
     /// # Note
     /// This is equivalent to adding:
     /// `where Self: DeserializeOwned` to the type definition.
-    pub fn add_deserialize_bound(&mut self) {
+    pub fn add_serde_bound(&mut self) {
         let where_clause = self.generics.make_where_clause();
         where_clause
             .predicates
             .push(parse_quote!(Self: miniconf::DeserializeOwned));
+        where_clause
+            .predicates
+            .push(parse_quote!(Self: miniconf::Serialize));
     }
 
     // Bound all generics of the type with `T: miniconf::DeserializeOwned + Miniconf`. This is necessary to
@@ -37,6 +40,7 @@ impl TypeDefinition {
                 type_param
                     .bounds
                     .push(parse_quote!(miniconf::DeserializeOwned));
+                type_param.bounds.push(parse_quote!(miniconf::Serialize));
                 type_param.bounds.push(parse_quote!(miniconf::Miniconf));
             }
         }
@@ -136,8 +140,8 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct, atomic: boo
     // If this structure must be updated atomically, it is not valid to call Miniconf recursively
     // on its members.
     if atomic {
-        // Bound the Miniconf implementation on Self implementing DeserializeOwned.
-        typedef.add_deserialize_bound();
+        // Bound the Miniconf implementation on Self implementing DeserializeOwned + Serialize.
+        typedef.add_serde_bound();
 
         let name = typedef.name;
         let (impl_generics, ty_generics, where_clause) = typedef.generics.split_for_impl();
@@ -154,18 +158,51 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct, atomic: boo
                     *self = miniconf::serde_json_core::from_slice(value)?.0;
                     Ok(())
                 }
+
+                fn string_get(&self, mut topic_parts: core::iter::Peekable<core::str::Split<char>>, value: &mut [u8]) -> Result<usize, miniconf::Error> {
+                    if topic_parts.peek().is_some() {
+                        return Err(miniconf::Error::AtomicUpdateRequired);
+                    }
+
+                    miniconf::serde_json_core::to_slice(self, value).map_err(|_| miniconf::Error::SerializationFailed)
+                }
+
+                fn recursive_iter<const TS: usize>(&self, index: &mut [usize], topic: &mut miniconf::heapless::String<TS>) -> Option<()> {
+                    if index.len() == 0 {
+                        // I don't expect this to happen...
+                        panic!("index stack too small");
+                        // return None;
+                    }
+
+                    let i = index[0];
+                    index[0] += 1;
+
+                    if i == 0 {
+                        Some(())
+                    } else {
+                        None
+                    }
+                }
             }
         };
 
         return TokenStream::from(data);
     }
 
-    let recurse_match_arms = fields.iter().map(|f| {
+    let set_recurse_match_arms = fields.iter().map(|f| {
         let match_name = &f.ident;
         quote! {
             stringify!(#match_name) => {
-                self.#match_name.string_set(topic_parts, value)?;
-                Ok(())
+                self.#match_name.string_set(topic_parts, value)
+            }
+        }
+    });
+
+    let get_recurse_match_arms = fields.iter().map(|f| {
+        let match_name = &f.ident;
+        quote! {
+            stringify!(#match_name) => {
+                self.#match_name.string_get(topic_parts, value)
             }
         }
     });
@@ -174,14 +211,30 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct, atomic: boo
         let field_name = &f.ident;
         quote! {
             #i => {
-                topic.push_str(concat!("/", stringify!(#field_name))).unwrap();
-                if let Some(()) = self.#field_name.recursive_iter(&mut index[1..], topic, value) {
+                let postfix = if topic.len() != 0 {
+                    concat!("/", stringify!(#field_name))
+                } else {
+                    stringify!(#field_name)
+                };
+
+                if topic.push_str(postfix).is_err() {
+                    return None;
+                }
+
+                if self.#field_name.recursive_iter(&mut index[1..], topic).is_some() {
                     return Some(());
                 }
-                else {
-                    index[0] += 1;
-                    index[1..].iter_mut().for_each(|x| *x = 0);
+
+                // Strip off the previously prepended index, since we completed that element and need
+                // to instead check the next one.
+                while let Some(character) = topic.pop() {
+                    if character == '/' {
+                        break;
+                    }
                 }
+
+                index[0] += 1;
+                index[1..].iter_mut().for_each(|x| *x = 0);
             }
         }
     });
@@ -197,13 +250,21 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct, atomic: boo
                 let field = topic_parts.next().ok_or(miniconf::Error::PathTooShort)?;
 
                 match field {
-                    #(#recurse_match_arms ,)*
+                    #(#set_recurse_match_arms ,)*
                     _ => Err(miniconf::Error::PathNotFound)
                 }
             }
 
-            fn recursive_iter<const TS: usize, const VS: usize>(&self, index: &mut [usize], topic: &mut heapless::String<TS>, value: &mut heapless::String<VS>) -> Option<()> {
+            fn string_get(&self, mut topic_parts: core::iter::Peekable<core::str::Split<char>>, value: &mut [u8]) -> Result<usize, miniconf::Error> {
+                let field = topic_parts.next().ok_or(miniconf::Error::PathTooShort)?;
 
+                match field {
+                    #(#get_recurse_match_arms ,)*
+                    _ => Err(miniconf::Error::PathNotFound)
+                }
+            }
+
+            fn recursive_iter<const TS: usize>(&self, index: &mut [usize], topic: &mut miniconf::heapless::String<TS>) -> Option<()> {
                 if index.len() == 0 {
                     panic!("index stack too small");
                 }
@@ -241,7 +302,7 @@ fn derive_enum(mut typedef: TypeDefinition, data: syn::DataEnum) -> TokenStream 
         }
     }
 
-    typedef.add_deserialize_bound();
+    typedef.add_serde_bound();
 
     let (impl_generics, ty_generics, where_clause) = typedef.generics.split_for_impl();
     let name = typedef.name;
@@ -259,62 +320,34 @@ fn derive_enum(mut typedef: TypeDefinition, data: syn::DataEnum) -> TokenStream 
                 *self = miniconf::serde_json_core::from_slice(value)?.0;
                 Ok(())
             }
+
+            fn string_get(&self, mut topic_parts: core::iter::Peekable<core::str::Split<char>>, value: &mut [u8]) -> Result<usize, miniconf::Error> {
+                if topic_parts.peek().is_some() {
+                    // We don't support enums that can contain other values
+                    return Err(miniconf::Error::PathTooLong)
+                }
+
+                miniconf::serde_json_core::to_slice(self, value).map_err(|_| miniconf::Error::SerializationFailed)
+            }
+
+            fn recursive_iter<const TS: usize>(&self, index: &mut [usize], topic: &mut miniconf::heapless::String<TS>) -> Option<()> {
+                if index.len() == 0 {
+                    // I don't expect this to happen...
+                    panic!("index stack too small");
+                    // return None;
+                }
+
+                let i = index[0];
+                index[0] += 1;
+
+                if i == 0 {
+                    Some(())
+                } else {
+                    None
+                }
+            }
         }
     };
 
     TokenStream::from(expanded)
 }
-
-// #[proc_macro_derive(MiniconfIter)]
-// pub fn derive_miniconf_iter(input: TokenStream) -> TokenStream {
-//     let input = parse_macro_input!(input as DeriveInput);
-
-//     let typedef = TypeDefinition::new(input.generics, input.ident);
-
-//     match input.data {
-//         syn::Data::Struct(struct_data) => derive_struct_miniconf_iter(typedef, struct_data),
-//         syn::Data::Enum(enum_data) => unimplemented!(),
-//         syn::Data::Union(_) => unimplemented!(),
-//     }
-// }
-
-// fn derive_struct_miniconf_iter(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStream {
-//     let fields = match data.fields {
-//         syn::Fields::Named(syn::FieldsNamed {ref named, .. }) => named,
-//         _ => unimplemented!("Only named fields are supported in structs."),
-//     };
-
-//     let match_arms = fields.iter().enumerate().map(|(i, f)| {
-//         let field_name = &f.ident;
-//         quote! {
-//             #i => {
-//                 topic.push_str(concat!("/", stringify!(#field_name))).unwrap();
-//                 if let Some(r) = self.#field_name.recursive_iter(&mut index[1..], topic) {
-//                     return Some(r);
-//                 }
-//                 else {
-//                     index[0] += 1;
-//                     index[1..].iter_mut().for_each(|x| *x = 0);
-//                 }
-//             }
-//         }
-//     });
-
-//     let name = typedef.name;
-
-//     let expanded = quote! {
-//         impl miniconf::MiniconfIter for #name {
-//             fn recursive_iter(&self, index: &mut [usize], topic: &mut String<128>) -> Option<String<128>> {
-//                 loop {
-//                     match index[0] {
-//                         #(#match_arms ,)*
-//                         _ => return None,
-
-//                     };
-//                 }
-//             }
-//         }
-//     };
-
-//     TokenStream::from(expanded)
-// }

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -177,7 +177,11 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct, atomic: boo
 
                 fn recurse_paths<const TS: usize>(&self, index: &mut [usize], topic: &mut miniconf::heapless::String<TS>) -> Option<()> {
                     if index.len() == 0 {
-                        return None;
+                        // Note: During expected execution paths using `into_iter()`, the size of
+                        // the index stack is checked in advance to make sure this condition
+                        // doesn't occur.  However, it's possible to happen if the user manually
+                        // calls `recurse_paths`.
+                        unreachable!("Index stack too small");
                     }
 
                     let i = index[0];
@@ -226,7 +230,11 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct, atomic: boo
                 };
 
                 if topic.push_str(postfix).is_err() {
-                    return None;
+                    // Note: During expected execution paths using `into_iter()`, the size of the
+                    // topic buffer is checked in advance to make sure this condition doesn't
+                    // occur.  However, it's possible to happen if the user manually calls
+                    // `recurse_paths`.
+                    unreachable!("Topic buffer too short");
                 }
 
                 if self.#field_name.recurse_paths(&mut index[1..], topic).is_some() {
@@ -317,7 +325,10 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct, atomic: boo
 
             fn recurse_paths<const TS: usize>(&self, index: &mut [usize], topic: &mut miniconf::heapless::String<TS>) -> Option<()> {
                 if index.len() == 0 {
-                    return None;
+                    // Note: During expected execution paths using `into_iter()`, the size of the
+                    // index stack is checked in advance to make sure this condition doesn't occur.
+                    // However, it's possible to happen if the user manually calls `recurse_paths`.
+                    unreachable!("Index stack too small");
                 }
 
                 loop {
@@ -391,7 +402,10 @@ fn derive_enum(mut typedef: TypeDefinition, data: syn::DataEnum) -> TokenStream 
 
             fn recurse_paths<const TS: usize>(&self, index: &mut [usize], topic: &mut miniconf::heapless::String<TS>) -> Option<()> {
                 if index.len() == 0 {
-                    return None;
+                    // Note: During expected execution paths using `into_iter()`, the size of the
+                    // index stack is checked in advance to make sure this condition doesn't occur.
+                    // However, it's possible to happen if the user manually calls `recurse_paths`.
+                    unreachable!("Index stack too small");
                 }
 
                 let i = index[0];

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -177,9 +177,7 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct, atomic: boo
 
                 fn recurse_paths<const TS: usize>(&self, index: &mut [usize], topic: &mut miniconf::heapless::String<TS>) -> Option<()> {
                     if index.len() == 0 {
-                        // I don't expect this to happen...
-                        panic!("index stack too small");
-                        // return None;
+                        return None;
                     }
 
                     let i = index[0];
@@ -319,7 +317,7 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct, atomic: boo
 
             fn recurse_paths<const TS: usize>(&self, index: &mut [usize], topic: &mut miniconf::heapless::String<TS>) -> Option<()> {
                 if index.len() == 0 {
-                    panic!("index stack too small");
+                    return None;
                 }
 
                 loop {
@@ -393,9 +391,7 @@ fn derive_enum(mut typedef: TypeDefinition, data: syn::DataEnum) -> TokenStream 
 
             fn recurse_paths<const TS: usize>(&self, index: &mut [usize], topic: &mut miniconf::heapless::String<TS>) -> Option<()> {
                 if index.len() == 0 {
-                    // I don't expect this to happen...
-                    panic!("index stack too small");
-                    // return None;
+                    return None;
                 }
 
                 let i = index[0];

--- a/examples/readback.rs
+++ b/examples/readback.rs
@@ -30,7 +30,7 @@ fn main() {
     // type? That way we can hide what it is.
     let mut iterator_state = [0; 5];
 
-    let mut settings_iter = s.into_iter::<128>(&mut iterator_state);
+    let mut settings_iter = s.into_iter::<128>(&mut iterator_state).unwrap();
 
     // Just get one topic/value from the iterator
     if let Some(topic) = settings_iter.next() {
@@ -48,7 +48,7 @@ fn main() {
     s.data = 3;
 
     // Create a new settings iterator, print remaining values
-    for topic in s.into_iter::<128>(&mut iterator_state) {
+    for topic in s.into_iter::<128>(&mut iterator_state).unwrap() {
         let mut value = [0; 256];
         let len = s.get(&topic, &mut value).unwrap();
         println!(

--- a/examples/readback.rs
+++ b/examples/readback.rs
@@ -1,7 +1,6 @@
 // use miniconf::{Error, Miniconf};
 use miniconf::Miniconf;
 use serde::{Deserialize, Serialize};
-use serde_json_core::heapless::String;
 
 #[derive(Debug, Default, Miniconf, Serialize, Deserialize)]
 struct AdditionalSettings {
@@ -13,83 +12,6 @@ struct AdditionalSettings {
 struct Settings {
     more: AdditionalSettings,
     data: u32,
-}
-
-// This will eventually be a derived impl
-impl Settings {
-    fn miniconf_iter<'a, 'b, const TS: usize, const VS: usize>(
-        &'b self,
-        index_stack: &'a mut [usize],
-    ) -> SettingsMiniconfIter<'a, 'b, TS, VS> {
-        SettingsMiniconfIter {
-            settings: &self,
-            index: index_stack,
-        }
-    }
-}
-
-// This will eventually be derived
-// TS is the size of the topic buffer
-// VS is the size of the value buffer
-pub struct SettingsMiniconfIter<'a, 'b, const TS: usize, const VS: usize> {
-    settings: &'b Settings,
-    index: &'a mut [usize],
-}
-
-// This will eventually be derived
-impl<'a, const TS: usize, const VS: usize> Iterator for SettingsMiniconfIter<'a, '_, TS, VS> {
-    type Item = (String<TS>, String<VS>);
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut topic_buffer: String<TS> = String::new();
-        let mut value_buffer: String<VS> = String::new();
-        topic_buffer.clear();
-        value_buffer.clear();
-        if let Some(()) = self.settings.recursive_iter::<TS, VS>(
-            &mut self.index,
-            &mut topic_buffer,
-            &mut value_buffer,
-        ) {
-            Some((topic_buffer, value_buffer))
-        } else {
-            None
-        }
-    }
-}
-
-// Possible alternative to implementing Iterator?
-pub struct IterState<T: Miniconf + Serialize, const S: usize> {
-    index: [usize; S],
-    _type: core::marker::PhantomData<T>,
-}
-
-impl<'a, T: Miniconf + Serialize, const S: usize> IterState<T, S> {
-    fn new() -> IterState<T, S> {
-        IterState {
-            index: [0; S],
-            _type: core::marker::PhantomData::<T>,
-        }
-    }
-
-    fn reset(&mut self) {
-        self.index = [0; S];
-    }
-
-    fn next<const TS: usize, const VS: usize>(
-        &mut self,
-        settings: &T,
-        topic_buffer: &'a mut String<TS>,
-        value_buffer: &'a mut String<VS>,
-    ) -> Option<(&'a String<TS>, &'a String<VS>)> {
-        topic_buffer.clear();
-        value_buffer.clear();
-        if let Some(()) =
-            settings.recursive_iter::<TS, VS>(&mut self.index, topic_buffer, value_buffer)
-        {
-            Some((topic_buffer, value_buffer))
-        } else {
-            None
-        }
-    }
 }
 
 fn main() {
@@ -108,11 +30,17 @@ fn main() {
     // type? That way we can hide what it is.
     let mut iterator_state = [0; 5];
 
-    let mut settings_iter = s.miniconf_iter::<128, 10>(&mut iterator_state);
+    let mut settings_iter = s.into_iter::<128>(&mut iterator_state);
 
     // Just get one topic/value from the iterator
-    if let Some((topic, value)) = settings_iter.next() {
-        println!("{} {}", topic, value);
+    if let Some(topic) = settings_iter.next() {
+        let mut value = [0; 256];
+        let len = s.get(&topic, &mut value).unwrap();
+        println!(
+            "{:?}: {:?}",
+            topic,
+            std::str::from_utf8(&value[..len]).unwrap()
+        );
     }
 
     // Modify settings data, proving iterator is out of scope and has released
@@ -120,26 +48,13 @@ fn main() {
     s.data = 3;
 
     // Create a new settings iterator, print remaining values
-    let settings_iter = s.miniconf_iter::<128, 10>(&mut iterator_state);
-    for (topic, value) in settings_iter {
-        println!("{} {}", topic, value);
-    }
-
-    println!("\nAlternative Implementation:");
-    let mut value_buffer: String<128> = String::new();
-    let mut topic_buffer: String<128> = String::new();
-
-    let mut iter_state: IterState<Settings, 5> = IterState::new();
-
-    loop {
-        if let Some((topic, value)) = iter_state.next(&s, &mut topic_buffer, &mut value_buffer) {
-            println!("{} {}", topic, value);
-        } else {
-            // done iterating, break out
-            break;
-        }
-
-        // Proving that settings can be modified between iteration calls
-        s.data = s.data.wrapping_add(1);
+    for topic in s.into_iter::<128>(&mut iterator_state) {
+        let mut value = [0; 256];
+        let len = s.get(&topic, &mut value).unwrap();
+        println!(
+            "{:?}: {:?}",
+            topic,
+            std::str::from_utf8(&value[..len]).unwrap()
+        );
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -14,7 +14,7 @@ impl<'a, Settings: Miniconf + ?Sized, const TS: usize> Iterator for MiniconfIter
 
         if self
             .settings
-            .recursive_iter(&mut self.state, &mut topic_buffer)
+            .recurse_paths(&mut self.state, &mut topic_buffer)
             .is_some()
         {
             Some(topic_buffer)

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,25 @@
+use super::Miniconf;
+use heapless::String;
+
+pub struct MiniconfIter<'a, Settings: Miniconf + ?Sized, const TS: usize> {
+    pub(crate) settings: &'a Settings,
+    pub(crate) state: &'a mut [usize],
+}
+
+impl<'a, Settings: Miniconf + ?Sized, const TS: usize> Iterator for MiniconfIter<'a, Settings, TS> {
+    type Item = String<TS>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut topic_buffer: String<TS> = String::new();
+
+        if self
+            .settings
+            .recursive_iter(&mut self.state, &mut topic_buffer)
+            .is_some()
+        {
+            Some(topic_buffer)
+        } else {
+            None
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,9 +285,7 @@ macro_rules! impl_single {
                 _topic: &mut heapless::String<TS>,
             ) -> Option<()> {
                 if index.len() == 0 {
-                    // I don't expect this to happen...
-                    panic!("index stack too small");
-                    // return None;
+                    return None;
                 }
 
                 let i = index[0];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,7 +391,7 @@ impl<T: Miniconf, const N: usize> Miniconf for [T; N] {
                     return None;
                 }
             }
-            if write!(topic, "/{}", index[0]).is_err() {
+            if write!(topic, "{}", index[0]).is_err() {
                 return None;
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,9 @@
 //! ## Example
 //! ```
 //! use miniconf::{Miniconf, MiniconfAtomic};
-//! use serde::Deserialize;
+//! use serde::{Serialize, Deserialize};
 //!
-//! #[derive(Deserialize, MiniconfAtomic, Default)]
+//! #[derive(Deserialize, Serialize, MiniconfAtomic, Default)]
 //! struct Coefficients {
 //!     forward: f32,
 //!     backward: f32,
@@ -42,13 +42,13 @@
 //! let mut settings = Settings::default();
 //!
 //! // Update sample rate.
-//! miniconf::update(&mut settings, "sample_rate", b"350").unwrap();
+//! settings.set("sample_rate", b"350").unwrap();
 //!
 //! // Update filter coefficients.
-//! miniconf::update(&mut settings, "filter", b"{\"forward\": 35.6, \"backward\": 0.0}").unwrap();
+//! settings.set("filter", b"{\"forward\": 35.6, \"backward\": 0.0}").unwrap();
 //!
 //! // Update channel gain for channel 0.
-//! miniconf::update(&mut settings, "channel_gain/0", b"15").unwrap();
+//! settings.set("channel_gain/0", b"15").unwrap();
 //! ```
 //!
 //! ## Limitations
@@ -60,6 +60,8 @@
 #[cfg(feature = "mqtt-client")]
 mod mqtt_client;
 
+pub mod iter;
+
 #[cfg(feature = "mqtt-client")]
 pub use mqtt_client::MqttClient;
 
@@ -70,13 +72,18 @@ pub use minimq;
 pub use minimq::embedded_time;
 
 #[doc(hidden)]
-pub use serde::de::{Deserialize, DeserializeOwned};
+pub use serde::{
+    de::{Deserialize, DeserializeOwned},
+    ser::Serialize,
+};
 
 pub use serde_json_core;
 
 pub use derive_miniconf::{Miniconf, MiniconfAtomic};
 
 pub use heapless;
+
+use core::fmt::Write;
 
 /// Errors that occur during settings configuration
 #[derive(Debug, PartialEq)]
@@ -107,6 +114,11 @@ pub enum Error {
     /// Check that the serialized data is valid JSON and of the correct type.
     Deserialization(serde_json_core::de::Error),
 
+    /// The value provided could not be serialized.
+    ///
+    /// Check that the buffer had sufficient space.
+    SerializationFailed,
+
     /// When indexing into an array, the index provided was out of bounds.
     ///
     /// Check array indices to ensure that bounds for all paths are respected.
@@ -122,6 +134,7 @@ impl From<Error> for u8 {
             Error::AtomicUpdateRequired => 4,
             Error::Deserialization(_) => 5,
             Error::BadIndex => 6,
+            Error::SerializationFailed => 7,
         }
     }
 }
@@ -133,35 +146,49 @@ impl From<serde_json_core::de::Error> for Error {
 }
 
 pub trait Miniconf {
+    /// Update settings directly from a string path and data.
+    ///
+    /// # Args
+    /// * `path` - The path to update within `settings`.
+    /// * `data` - The serialized data making up the contents of the configured value.
+    ///
+    /// # Returns
+    /// The result of the configuration operation.
+    fn set(&mut self, path: &str, data: &[u8]) -> Result<(), Error> {
+        self.string_set(path.split('/').peekable(), data)
+    }
+
+    fn get(&self, path: &str, data: &mut [u8]) -> Result<usize, Error> {
+        self.string_get(path.split('/').peekable(), data)
+    }
+
+    fn into_iter<'a, const TS: usize>(
+        &'a self,
+        state: &'a mut [usize],
+    ) -> iter::MiniconfIter<'a, Self, TS> {
+        iter::MiniconfIter {
+            settings: self,
+            state,
+        }
+    }
+
     fn string_set(
         &mut self,
         topic_parts: core::iter::Peekable<core::str::Split<char>>,
         value: &[u8],
     ) -> Result<(), Error>;
 
-    fn recursive_iter<const TS: usize, const VS: usize>(
+    fn string_get(
+        &self,
+        topic_parts: core::iter::Peekable<core::str::Split<char>>,
+        value: &mut [u8],
+    ) -> Result<usize, Error>;
+
+    fn recursive_iter<const TS: usize>(
         &self,
         index: &mut [usize],
-        _topic: &mut heapless::String<TS>,
-        value: &mut heapless::String<VS>,
+        topic: &mut heapless::String<TS>,
     ) -> Option<()>;
-}
-
-/// Convenience function to update settings directly from a string path and data.
-///
-/// # Note
-/// When using prefixes on the path, it is often simpler to call
-/// `Settings::string_set(path.peekable(), data)` directly.
-///
-/// # Args
-/// * `settings` - The settings to update
-/// * `path` - The path to update within `settings`.
-/// * `data` - The serialized data making up the contents of the configured value.
-///
-/// # Returns
-/// The result of the configuration operation.
-pub fn update<T: Miniconf>(settings: &mut T, path: &str, data: &[u8]) -> Result<(), Error> {
-    settings.string_set(path.split('/').peekable(), data)
 }
 
 macro_rules! impl_single {
@@ -179,17 +206,25 @@ macro_rules! impl_single {
                 Ok(())
             }
 
+            fn string_get(
+                &self,
+                mut topic_parts: core::iter::Peekable<core::str::Split<char>>,
+                value: &mut [u8],
+            ) -> Result<usize, Error> {
+                if topic_parts.peek().is_some() {
+                    return Err(Error::PathTooLong);
+                }
+
+                serde_json_core::to_slice(self, value).map_err(|_| Error::SerializationFailed)
+            }
+
             // This implementation is the base case for primitives where it will
             // yield once for self, then return None on subsequent calls.
-            fn recursive_iter<const TS: usize, const VS: usize>(
+            fn recursive_iter<const TS: usize>(
                 &self,
                 index: &mut [usize],
                 _topic: &mut heapless::String<TS>,
-                value: &mut heapless::String<VS>,
-            ) -> Option<()>
-            where
-                Self: serde::Serialize,
-            {
+            ) -> Option<()> {
                 if index.len() == 0 {
                     // I don't expect this to happen...
                     panic!("index stack too small");
@@ -200,12 +235,10 @@ macro_rules! impl_single {
                 index[0] += 1;
                 index[1..].iter_mut().for_each(|x| *x = 0);
 
-                match i {
-                    0 => {
-                        *value = serde_json_core::to_string(&self).unwrap();
-                        Some(())
-                    }
-                    _ => None,
+                if i == 0 {
+                    Some(())
+                } else {
+                    None
                 }
             }
         }
@@ -237,13 +270,59 @@ impl<T: Miniconf, const N: usize> Miniconf for [T; N] {
         Ok(())
     }
 
-    fn recursive_iter<const TS: usize, const VS: usize>(
+    fn string_get(
         &self,
-        _index: &mut [usize],
-        _topic: &mut heapless::String<TS>,
-        _value: &mut heapless::String<VS>,
+        mut topic_parts: core::iter::Peekable<core::str::Split<char>>,
+        value: &mut [u8],
+    ) -> Result<usize, Error> {
+        let next = topic_parts.next();
+        if next.is_none() {
+            return Err(Error::PathTooShort);
+        }
+
+        // Parse what should be the index value
+        let i: usize = serde_json_core::from_str(next.unwrap())
+            .or(Err(Error::BadIndex))?
+            .0;
+
+        if i >= self.len() {
+            return Err(Error::BadIndex);
+        }
+
+        self[i].string_get(topic_parts, value)
+    }
+
+    fn recursive_iter<const TS: usize>(
+        &self,
+        index: &mut [usize],
+        topic: &mut heapless::String<TS>,
     ) -> Option<()> {
-        unimplemented!("iteration not implemented for arrays yet")
+        while index[0] < N {
+            // Add the array index to the topic name.
+            if write!(topic, "/{}", index[0]).is_err() {
+                return None;
+            }
+
+            if self[index[0]]
+                .recursive_iter(&mut index[1..], topic)
+                .is_some()
+            {
+                return Some(());
+            }
+
+            // Strip off the previously prepended index, since we completed that element and need
+            // to instead check the next one.
+            while let Some(character) = topic.pop() {
+                if character == '/' {
+                    break;
+                }
+            }
+
+            index[0] += 1;
+            index[1..].iter_mut().for_each(|x| *x = 0);
+        }
+
+        None
     }
 }
 

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -70,6 +70,11 @@ fn simple_array_indexing() {
         s.string_set(field, "7".as_bytes()).unwrap_err(),
         Error::BadIndex
     );
+
+    // Test metadata
+    let metadata = s.get_metadata();
+    assert_eq!(metadata.max_depth, 3);
+    assert_eq!(metadata.max_topic_size, "a/2".len());
 }
 
 #[test]
@@ -97,4 +102,9 @@ fn array_of_structs_indexing() {
     };
 
     assert_eq!(expected, s);
+
+    // Test metadata
+    let metadata = s.get_metadata();
+    assert_eq!(metadata.max_depth, 4);
+    assert_eq!(metadata.max_topic_size, "a/2/b".len());
 }

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -1,15 +1,15 @@
 use miniconf::Miniconf;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[test]
 fn simple_enum() {
-    #[derive(Miniconf, Debug, Deserialize, PartialEq)]
+    #[derive(Miniconf, Debug, Deserialize, Serialize, PartialEq)]
     enum Variant {
         A,
         B,
     }
 
-    #[derive(Miniconf, Debug, Deserialize)]
+    #[derive(Miniconf, Debug, Deserialize, Serialize)]
     struct S {
         v: Variant,
     }
@@ -25,7 +25,7 @@ fn simple_enum() {
 
 #[test]
 fn invalid_enum() {
-    #[derive(Miniconf, Debug, Deserialize, PartialEq)]
+    #[derive(Miniconf, Debug, Serialize, Deserialize, PartialEq)]
     enum Variant {
         A,
         B,

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -21,6 +21,11 @@ fn simple_enum() {
     s.string_set(field, "\"B\"".as_bytes()).unwrap();
 
     assert_eq!(s.v, Variant::B);
+
+    // Test metadata
+    let metadata = s.get_metadata();
+    assert_eq!(metadata.max_depth, 2);
+    assert_eq!(metadata.max_topic_size, "v".len());
 }
 
 #[test]

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -13,6 +13,11 @@ fn generic_type() {
         .string_set("data".split('/').peekable(), b"3.0")
         .unwrap();
     assert_eq!(settings.data, 3.0);
+
+    // Test metadata
+    let metadata = settings.get_metadata();
+    assert_eq!(metadata.max_depth, 2);
+    assert_eq!(metadata.max_topic_size, "data".len());
 }
 
 #[test]
@@ -28,6 +33,11 @@ fn generic_array() {
         .unwrap();
 
     assert_eq!(settings.data[0], 3.0);
+
+    // Test metadata
+    let metadata = settings.get_metadata();
+    assert_eq!(metadata.max_depth, 3);
+    assert_eq!(metadata.max_topic_size, "data/0".len());
 }
 
 #[test]
@@ -48,6 +58,11 @@ fn generic_struct() {
         .unwrap();
 
     assert_eq!(settings.inner.data, 3.0);
+
+    // Test metadata
+    let metadata = settings.get_metadata();
+    assert_eq!(metadata.max_depth, 2);
+    assert_eq!(metadata.max_topic_size, "inner".len());
 }
 
 #[test]
@@ -71,4 +86,9 @@ fn generic_atomic() {
         .unwrap();
 
     assert_eq!(settings.atomic.inner[0], 3.0);
+
+    // Test metadata
+    let metadata = settings.get_metadata();
+    assert_eq!(metadata.max_depth, 2);
+    assert_eq!(metadata.max_topic_size, "atomic".len());
 }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -1,5 +1,5 @@
 use miniconf::{Miniconf, MiniconfAtomic};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[test]
 fn generic_type() {
@@ -37,7 +37,7 @@ fn generic_struct() {
         pub inner: T,
     }
 
-    #[derive(MiniconfAtomic, Deserialize, Default)]
+    #[derive(MiniconfAtomic, Deserialize, Serialize, Default)]
     struct Inner {
         pub data: f32,
     }
@@ -57,7 +57,7 @@ fn generic_atomic() {
         pub atomic: Inner<T>,
     }
 
-    #[derive(Deserialize, MiniconfAtomic, Default)]
+    #[derive(Deserialize, Serialize, MiniconfAtomic, Default)]
     struct Inner<T> {
         pub inner: [T; 5],
     }

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,0 +1,49 @@
+use miniconf::Miniconf;
+
+#[derive(Miniconf, Default)]
+struct Inner {
+    inner: f32,
+}
+
+#[derive(Miniconf, Default)]
+struct Settings {
+    a: f32,
+    b: i32,
+    c: Inner,
+}
+
+#[test]
+fn insufficient_space() {
+    let settings = Settings::default();
+    let meta = settings.get_metadata();
+    assert_eq!(meta.max_depth, 3);
+    assert_eq!(meta.max_topic_size, "c/inner".len());
+
+    // Ensure that we can't iterate if we make a state vector that is too small.
+    let mut small_state = [0; 2];
+    assert!(settings.into_iter::<256>(&mut small_state).is_err());
+
+    // Ensure that we can't iterate if the topic buffer is too small.
+    let mut state = [0; 10];
+    assert!(settings.into_iter::<1>(&mut state).is_err());
+}
+
+#[test]
+fn test_iteration() {
+    let settings = Settings::default();
+
+    let mut iterated = std::collections::HashMap::from([
+        ("a".to_string(), false),
+        ("b".to_string(), false),
+        ("c/inner".to_string(), false),
+    ]);
+
+    let mut iter_state = [0; 32];
+    for field in settings.into_iter::<256>(&mut iter_state).unwrap() {
+        assert!(iterated.contains_key(&field.as_str().to_string()));
+        iterated.insert(field.as_str().to_string(), true);
+    }
+
+    // Ensure that all fields were iterated.
+    assert!(iterated.iter().map(|(_, value)| value).all(|&x| x));
+}

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -35,6 +35,11 @@ fn atomic_struct() {
     };
 
     assert_eq!(settings, expected);
+
+    // Check that metadata is correct.
+    let metadata = settings.get_metadata();
+    assert_eq!(metadata.max_depth, 2);
+    assert_eq!(metadata.max_topic_size, "c".len());
 }
 
 #[test]
@@ -67,4 +72,9 @@ fn recursive_struct() {
     // It is not allowed to set a non-terminal node.
     let field = "c".split('/').peekable();
     assert!(settings.string_set(field, b"{\"a\": 5}").is_err());
+
+    // Check that metadata is correct.
+    let metadata = settings.get_metadata();
+    assert_eq!(metadata.max_depth, 3);
+    assert_eq!(metadata.max_topic_size, "c/a".len());
 }

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -1,9 +1,9 @@
 use miniconf::{Miniconf, MiniconfAtomic};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[test]
 fn atomic_struct() {
-    #[derive(MiniconfAtomic, Default, PartialEq, Debug, Deserialize)]
+    #[derive(MiniconfAtomic, Default, PartialEq, Debug, Serialize, Deserialize)]
     struct Inner {
         a: u32,
         b: u32,


### PR DESCRIPTION
This PR does the following:
* Exposes a `string_get()` API
* Refactors `recursive_iter()` to just iterate across the possible topic names (keys)
* Adds in an `iter` module that contains all iteration-related code.
* Merges `develop`
* Adds a `get_metadata()` API to determine maximum necessary topic + state buffer sizes