### PR TITLE
Preparing for 0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+### Changed
+### Removed
+
+## [0.3.0] - 2021-12-13
+
+### Added
 * Added key iteration
 * Added support for retrieving serialized values via keys.
 * Added APIs to the Miniconf trait for asynchronous iteration.
@@ -17,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * `miniconf::update()` replaced with `Miniconf::set()`, which is part of the trait and now
   directly available on structures.
-### Removed
+
 
 ## [0.2.0] - 2021-10-28
 
@@ -32,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Library initially released on crates.io
 
-[Unreleased]: https://github.com/quartiq/miniconf/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/quartiq/miniconf/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/quartiq/miniconf/releases/tag/v0.3.0
 [0.2.0]: https://github.com/quartiq/miniconf/releases/tag/v0.2.0
 [0.1.0]: https://github.com/quartiq/miniconf/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniconf"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@vertigo-designs.com"]
 edition = "2018"
 license = "MIT"
@@ -10,7 +10,7 @@ keywords = ["settings", "embedded", "no_std", "configuration", "mqtt"]
 categories = ["no-std", "config", "embedded", "parsing"]
 
 [dependencies]
-derive_miniconf = { path = "derive_miniconf" , version = "0.1" }
+derive_miniconf = { path = "derive_miniconf" , version = "0.3" }
 serde-json-core = "0.4.0"
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
 log = "0.4"

--- a/derive_miniconf/Cargo.toml
+++ b/derive_miniconf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_miniconf"
-version = "0.3"
+version = "0.3.0"
 authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@vertigo-designs.com"]
 edition = "2018"
 license = "MIT"

--- a/derive_miniconf/Cargo.toml
+++ b/derive_miniconf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_miniconf"
-version = "0.1.1"
+version = "0.3"
 authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@vertigo-designs.com"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
This PR prepares Miniconf for a 0.3 release.

The API has stabilized, so additional changes (like #63) can be made via patch releases.