### PR TITLE
Updating MqttClient to accept initial settings values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+* [breaking] MqttClient constructor now accepts initial settings values.
+
 ### Removed
 
 ## [0.3.0] - 2021-12-13

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -81,6 +81,7 @@ async fn main() {
         "sample/prefix",
         "127.0.0.1".parse().unwrap(),
         StandardClock::default(),
+        Settings::default(),
     )
     .unwrap();
 

--- a/src/mqtt_client/mqtt_client.rs
+++ b/src/mqtt_client/mqtt_client.rs
@@ -104,7 +104,7 @@ mod sm {
 /// MQTT settings interface.
 pub struct MqttClient<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
 where
-    Settings: Miniconf + Default,
+    Settings: Miniconf,
     Stack: TcpClientStack,
     Clock: embedded_time::Clock,
 {
@@ -118,7 +118,7 @@ where
 impl<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
     MqttClient<Settings, Stack, Clock, MESSAGE_SIZE>
 where
-    Settings: Miniconf + Default,
+    Settings: Miniconf,
     Stack: TcpClientStack,
     Clock: embedded_time::Clock + Clone,
 {
@@ -130,16 +130,15 @@ where
     /// * `prefix` - The MQTT device prefix to use for this device.
     /// * `broker` - The IP address of the MQTT broker to use.
     /// * `clock` - The clock for managing the MQTT connection.
+    /// * `settings` - The initial settings values.
     pub fn new(
         stack: Stack,
         client_id: &str,
         prefix: &str,
         broker: IpAddr,
         clock: Clock,
+        settings: Settings,
     ) -> Result<Self, minimq::Error<Stack::Error>> {
-        // Check the settings topic length.
-        let settings = Settings::default();
-
         let mut mqtt = minimq::Minimq::new(broker, client_id, stack, clock.clone())?;
 
         // Note(unwrap): The client was just created, so it's valid to set a keepalive interval

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -106,6 +106,7 @@ fn main() -> std::io::Result<()> {
         "device",
         localhost,
         StandardClock::default(),
+        Settings::default(),
     )
     .unwrap();
 

--- a/tests/republish.rs
+++ b/tests/republish.rs
@@ -86,6 +86,7 @@ async fn main() {
         "republish/device",
         "127.0.0.1".parse().unwrap(),
         StandardClock::default(),
+        Settings::default(),
     )
     .unwrap();
 


### PR DESCRIPTION
This PR fixes #74 by updating the MqttClient to accept the initial settings to allow the user to provide some non-default values.