### PR TITLE
Adding support for Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* `Option` support added to enable run-time settings tree presence.
+
 ### Changed
 * [breaking] MqttClient constructor now accepts initial settings values.
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,0 +1,129 @@
+use super::{Error, Miniconf, MiniconfMetadata};
+
+use core::fmt::Write;
+
+impl<T: Miniconf, const N: usize> Miniconf for [T; N] {
+    fn string_set(
+        &mut self,
+        mut topic_parts: core::iter::Peekable<core::str::Split<char>>,
+        value: &[u8],
+    ) -> Result<(), Error> {
+        let next = topic_parts.next();
+        if next.is_none() {
+            return Err(Error::PathTooShort);
+        }
+
+        // Parse what should be the index value
+        let i: usize = serde_json_core::from_str(next.unwrap())
+            .or(Err(Error::BadIndex))?
+            .0;
+
+        if i >= self.len() {
+            return Err(Error::BadIndex);
+        }
+
+        self[i].string_set(topic_parts, value)?;
+
+        Ok(())
+    }
+
+    fn string_get(
+        &self,
+        mut topic_parts: core::iter::Peekable<core::str::Split<char>>,
+        value: &mut [u8],
+    ) -> Result<usize, Error> {
+        let next = topic_parts.next();
+        if next.is_none() {
+            return Err(Error::PathTooShort);
+        }
+
+        // Parse what should be the index value
+        let i: usize = serde_json_core::from_str(next.unwrap())
+            .or(Err(Error::BadIndex))?
+            .0;
+
+        if i >= self.len() {
+            return Err(Error::BadIndex);
+        }
+
+        self[i].string_get(topic_parts, value)
+    }
+
+    fn get_metadata(&self) -> MiniconfMetadata {
+        // First, figure out how many digits the maximum index requires when printing.
+        let mut index = N - 1;
+        let mut num_digits = 0;
+
+        while index > 0 {
+            index /= 10;
+            num_digits += 1;
+        }
+
+        let metadata = self[0].get_metadata();
+
+        // If the sub-members have topic size, we also need to include an additional character for
+        // the path separator. This is ommitted if the sub-members have no topic (e.g. fundamental
+        // types, enums).
+        if metadata.max_topic_size > 0 {
+            MiniconfMetadata {
+                max_topic_size: metadata.max_topic_size + num_digits + 1,
+                max_depth: metadata.max_depth + 1,
+            }
+        } else {
+            MiniconfMetadata {
+                max_topic_size: num_digits,
+                max_depth: metadata.max_depth + 1,
+            }
+        }
+    }
+
+    fn recurse_paths<const TS: usize>(
+        &self,
+        index: &mut [usize],
+        topic: &mut heapless::String<TS>,
+    ) -> Option<()> {
+        let original_length = topic.len();
+
+        if index.len() == 0 {
+            // Note: During expected execution paths using `into_iter()`, the size of the
+            // index stack is checked in advance to make sure this condition doesn't occur.
+            // However, it's possible to happen if the user manually calls `recurse_paths`.
+            unreachable!("Index stack too small");
+        }
+
+        while index[0] < N {
+            // Add the array index to the topic name.
+            if topic.len() > 0 {
+                if topic.push('/').is_err() {
+                    // Note: During expected execution paths using `into_iter()`, the size of the
+                    // topic buffer is checked in advance to make sure this condition doesn't occur.
+                    // However, it's possible to happen if the user manually calls `recurse_paths`.
+                    unreachable!("Topic buffer too short");
+                }
+            }
+
+            if write!(topic, "{}", index[0]).is_err() {
+                // Note: During expected execution paths using `into_iter()`, the size of the
+                // topic buffer is checked in advance to make sure this condition doesn't occur.
+                // However, it's possible to happen if the user manually calls `recurse_paths`.
+                unreachable!("Topic buffer too short");
+            }
+
+            if self[index[0]]
+                .recurse_paths(&mut index[1..], topic)
+                .is_some()
+            {
+                return Some(());
+            }
+
+            // Strip off the previously prepended index, since we completed that element and need
+            // to instead check the next one.
+            topic.truncate(original_length);
+
+            index[0] += 1;
+            index[1..].iter_mut().for_each(|x| *x = 0);
+        }
+
+        None
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,8 @@
 #[cfg(feature = "mqtt-client")]
 mod mqtt_client;
 
-pub mod iter;
 mod array;
+pub mod iter;
 mod option;
 
 #[cfg(feature = "mqtt-client")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,8 @@
 mod mqtt_client;
 
 pub mod iter;
+mod array;
+mod option;
 
 #[cfg(feature = "mqtt-client")]
 pub use mqtt_client::MqttClient;
@@ -111,8 +113,6 @@ pub use serde_json_core;
 pub use derive_miniconf::{Miniconf, MiniconfAtomic};
 
 pub use heapless;
-
-use core::fmt::Write;
 
 /// Errors that occur during settings configuration
 #[derive(Debug, PartialEq)]
@@ -185,6 +185,7 @@ impl From<serde_json_core::de::Error> for Error {
 }
 
 /// Metadata about a settings structure.
+#[derive(Default)]
 pub struct MiniconfMetadata {
     /// The maximum length of a topic in the structure.
     pub max_topic_size: usize,
@@ -358,132 +359,6 @@ macro_rules! impl_single {
             }
         }
     };
-}
-
-impl<T: Miniconf, const N: usize> Miniconf for [T; N] {
-    fn string_set(
-        &mut self,
-        mut topic_parts: core::iter::Peekable<core::str::Split<char>>,
-        value: &[u8],
-    ) -> Result<(), Error> {
-        let next = topic_parts.next();
-        if next.is_none() {
-            return Err(Error::PathTooShort);
-        }
-
-        // Parse what should be the index value
-        let i: usize = serde_json_core::from_str(next.unwrap())
-            .or(Err(Error::BadIndex))?
-            .0;
-
-        if i >= self.len() {
-            return Err(Error::BadIndex);
-        }
-
-        self[i].string_set(topic_parts, value)?;
-
-        Ok(())
-    }
-
-    fn string_get(
-        &self,
-        mut topic_parts: core::iter::Peekable<core::str::Split<char>>,
-        value: &mut [u8],
-    ) -> Result<usize, Error> {
-        let next = topic_parts.next();
-        if next.is_none() {
-            return Err(Error::PathTooShort);
-        }
-
-        // Parse what should be the index value
-        let i: usize = serde_json_core::from_str(next.unwrap())
-            .or(Err(Error::BadIndex))?
-            .0;
-
-        if i >= self.len() {
-            return Err(Error::BadIndex);
-        }
-
-        self[i].string_get(topic_parts, value)
-    }
-
-    fn get_metadata(&self) -> MiniconfMetadata {
-        // First, figure out how many digits the maximum index requires when printing.
-        let mut index = N - 1;
-        let mut num_digits = 0;
-
-        while index > 0 {
-            index /= 10;
-            num_digits += 1;
-        }
-
-        let metadata = self[0].get_metadata();
-
-        // If the sub-members have topic size, we also need to include an additional character for
-        // the path separator. This is ommitted if the sub-members have no topic (e.g. fundamental
-        // types, enums).
-        if metadata.max_topic_size > 0 {
-            MiniconfMetadata {
-                max_topic_size: metadata.max_topic_size + num_digits + 1,
-                max_depth: metadata.max_depth + 1,
-            }
-        } else {
-            MiniconfMetadata {
-                max_topic_size: num_digits,
-                max_depth: metadata.max_depth + 1,
-            }
-        }
-    }
-
-    fn recurse_paths<const TS: usize>(
-        &self,
-        index: &mut [usize],
-        topic: &mut heapless::String<TS>,
-    ) -> Option<()> {
-        let original_length = topic.len();
-
-        if index.len() == 0 {
-            // Note: During expected execution paths using `into_iter()`, the size of the
-            // index stack is checked in advance to make sure this condition doesn't occur.
-            // However, it's possible to happen if the user manually calls `recurse_paths`.
-            unreachable!("Index stack too small");
-        }
-
-        while index[0] < N {
-            // Add the array index to the topic name.
-            if topic.len() > 0 {
-                if topic.push('/').is_err() {
-                    // Note: During expected execution paths using `into_iter()`, the size of the
-                    // topic buffer is checked in advance to make sure this condition doesn't occur.
-                    // However, it's possible to happen if the user manually calls `recurse_paths`.
-                    unreachable!("Topic buffer too short");
-                }
-            }
-
-            if write!(topic, "{}", index[0]).is_err() {
-                // Note: During expected execution paths using `into_iter()`, the size of the
-                // topic buffer is checked in advance to make sure this condition doesn't occur.
-                // However, it's possible to happen if the user manually calls `recurse_paths`.
-                unreachable!("Topic buffer too short");
-            }
-
-            if self[index[0]]
-                .recurse_paths(&mut index[1..], topic)
-                .is_some()
-            {
-                return Some(());
-            }
-
-            // Strip off the previously prepended index, since we completed that element and need
-            // to instead check the next one.
-            topic.truncate(original_length);
-
-            index[0] += 1;
-            index[1..].iter_mut().for_each(|x| *x = 0);
-        }
-
-        None
-    }
 }
 
 // Implement trait for the primitive types

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,0 +1,31 @@
+use super::{Error, Miniconf, MiniconfMetadata};
+
+impl<T: Miniconf> Miniconf for Option<T> {
+    fn string_set(
+        &mut self,
+        topic_parts: core::iter::Peekable<core::str::Split<char>>,
+        value: &[u8],
+    ) -> Result<(), Error> {
+        self.as_mut().map_or(Err(Error::PathNotFound), |inner| inner.string_set(topic_parts, value))
+    }
+
+    fn string_get(
+        &self,
+        topic_parts: core::iter::Peekable<core::str::Split<char>>,
+        value: &mut [u8],
+    ) -> Result<usize, Error> {
+        self.as_ref().map_or(Err(Error::PathNotFound), |inner| inner.string_get(topic_parts, value))
+    }
+
+    fn get_metadata(&self) -> MiniconfMetadata {
+        self.as_ref().map(|value| value.get_metadata()).unwrap_or_default()
+    }
+
+    fn recurse_paths<const TS: usize>(
+        &self,
+        index: &mut [usize],
+        topic: &mut heapless::String<TS>,
+    ) -> Option<()> {
+        self.as_ref().and_then(|value| value.recurse_paths(index, topic))
+    }
+}

--- a/src/option.rs
+++ b/src/option.rs
@@ -6,7 +6,9 @@ impl<T: Miniconf> Miniconf for Option<T> {
         topic_parts: core::iter::Peekable<core::str::Split<char>>,
         value: &[u8],
     ) -> Result<(), Error> {
-        self.as_mut().map_or(Err(Error::PathNotFound), |inner| inner.string_set(topic_parts, value))
+        self.as_mut().map_or(Err(Error::PathNotFound), |inner| {
+            inner.string_set(topic_parts, value)
+        })
     }
 
     fn string_get(
@@ -14,11 +16,15 @@ impl<T: Miniconf> Miniconf for Option<T> {
         topic_parts: core::iter::Peekable<core::str::Split<char>>,
         value: &mut [u8],
     ) -> Result<usize, Error> {
-        self.as_ref().map_or(Err(Error::PathNotFound), |inner| inner.string_get(topic_parts, value))
+        self.as_ref().map_or(Err(Error::PathNotFound), |inner| {
+            inner.string_get(topic_parts, value)
+        })
     }
 
     fn get_metadata(&self) -> MiniconfMetadata {
-        self.as_ref().map(|value| value.get_metadata()).unwrap_or_default()
+        self.as_ref()
+            .map(|value| value.get_metadata())
+            .unwrap_or_default()
     }
 
     fn recurse_paths<const TS: usize>(
@@ -26,6 +32,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
         index: &mut [usize],
         topic: &mut heapless::String<TS>,
     ) -> Option<()> {
-        self.as_ref().and_then(|value| value.recurse_paths(index, topic))
+        self.as_ref()
+            .and_then(|value| value.recurse_paths(index, topic))
     }
 }

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -1,0 +1,49 @@
+use miniconf::Miniconf;
+
+#[derive(Copy, Clone, Default, Miniconf)]
+struct Settings {
+    value: Option<u32>,
+}
+
+#[test]
+fn get_set_none() {
+    let mut settings = Settings::default();
+    let mut data = [0; 100];
+
+    // Check that if the option is None, the value cannot be get or set.
+    settings.value.take();
+    assert!(settings.get("value", &mut data).is_err());
+    assert!(settings.set("value", b"5").is_err());
+}
+
+#[test]
+fn get_set_some() {
+    let mut settings = Settings::default();
+    let mut data = [0; 10];
+
+    // Check that if the option is Some, the value can be get or set.
+    settings.value.replace(5);
+
+    let len = settings.get("value", &mut data).unwrap();
+    assert_eq!(&data[..len], b"5");
+
+    settings.set("value", b"7").unwrap();
+    assert_eq!(settings.value.unwrap(), 7);
+}
+
+#[test]
+fn iterate_some_none() {
+    let mut settings = Settings::default();
+
+    // When the value is None, it should not be iterated over as a topic.
+    let mut state = [0; 10];
+    settings.value.take();
+    let mut iterator = settings.into_iter::<128>(&mut state).unwrap();
+    assert!(iterator.next().is_none());
+
+    // When the value is Some, it should be iterated over.
+    let mut state = [0; 10];
+    settings.value.replace(5);
+    let mut iterator = settings.into_iter::<128>(&mut state).unwrap();
+    assert_eq!(iterator.next().uwnrap(), "value");
+}

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -45,5 +45,5 @@ fn iterate_some_none() {
     let mut state = [0; 10];
     settings.value.replace(5);
     let mut iterator = settings.into_iter::<128>(&mut state).unwrap();
-    assert_eq!(iterator.next().uwnrap(), "value");
+    assert_eq!(iterator.next().unwrap(), "value");
 }


### PR DESCRIPTION
This PR adds support for using `Option` with Miniconf. An `Option` is used to indicate a the presence of a setting at run-time. If a portion of the settings tree is set to None, it cannot be configured and will not be iterated over as a path string.

If the setting is Some, the option is transparent to Miniconf and struct will act as if the Option does not exist at all.

I've also moved the `array` implementation to a separate file to clean things up a bit.

This PR fixes #76 

TODO:
- [x] Test with a hardware implementation