### PR TITLE
Renaming iterator functions to prevent name conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+* **breaking** The Miniconf trait for iteration was renamed from `unchecked_iter()` and `iter()` to
+  `unchecked_iter_settings()` and `iter_settings()` respectively to avoid issues with slice iteration
+  name conflicts. See [#87](https://github.com/quartiq/miniconf/issues/87)
+
 ## [0.4.0] - 2022-05-11
 
 ### Added

--- a/examples/readback.rs
+++ b/examples/readback.rs
@@ -29,7 +29,7 @@ fn main() {
     // type? That way we can hide what it is.
     let mut iterator_state = [0; 5];
 
-    let mut settings_iter = s.iter::<128>(&mut iterator_state).unwrap();
+    let mut settings_iter = s.iter_settings::<128>(&mut iterator_state).unwrap();
 
     // Just get one topic/value from the iterator
     if let Some(topic) = settings_iter.next() {
@@ -47,7 +47,7 @@ fn main() {
     s.data = 3;
 
     // Create a new settings iterator, print remaining values
-    for topic in s.iter::<128>(&mut iterator_state).unwrap() {
+    for topic in s.iter_settings::<128>(&mut iterator_state).unwrap() {
         let mut value = [0; 256];
         let len = s.get(&topic, &mut value).unwrap();
         println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@
 //! let settings = Settings::default();
 //!
 //!let mut state = [0; 8];
-//! for topic in settings.iter::<128>(&mut state).unwrap() {
+//! for topic in settings.iter_settings::<128>(&mut state).unwrap() {
 //!     println!("Discovered topic: `{:?}`", topic);
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@ pub trait Miniconf {
     ///
     /// # Args
     /// * `state` - A state vector to record iteration state in.
-    fn iter<'a, const TS: usize>(
+    fn iter_settings<'a, const TS: usize>(
         &'a self,
         state: &'a mut [usize],
     ) -> Result<iter::MiniconfIter<'a, Self, TS>, IterError> {
@@ -295,7 +295,7 @@ pub trait Miniconf {
     ///
     /// # Args
     /// * `state` - A state vector to record iteration state in.
-    fn unchecked_iter<'a, const TS: usize>(
+    fn unchecked_iter_settings<'a, const TS: usize>(
         &'a self,
         state: &'a mut [usize],
     ) -> iter::MiniconfIter<'a, Self, TS> {

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -195,7 +195,7 @@ where
 
         for topic in self
             .settings
-            .iter::<MAX_TOPIC_LENGTH>(&mut self.state.context_mut().republish_state)
+            .iter_settings::<MAX_TOPIC_LENGTH>(&mut self.state.context_mut().republish_state)
             .unwrap()
         {
             let mut data = [0; MESSAGE_SIZE];

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -50,6 +50,7 @@ fn test_iteration() {
 
 #[test]
 fn test_array_iteration() {
+    // TODO: Replace this with mutable iteration when implemented.
     let settings = [false; 5];
     let mut settings_copy = [false; 5];
 
@@ -59,4 +60,5 @@ fn test_array_iteration() {
     }
 
     assert!(settings_copy.iter().all(|x| *x));
+
 }

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -60,5 +60,4 @@ fn test_array_iteration() {
     }
 
     assert!(settings_copy.iter().all(|x| *x));
-
 }

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -21,11 +21,11 @@ fn insufficient_space() {
 
     // Ensure that we can't iterate if we make a state vector that is too small.
     let mut small_state = [0; 2];
-    assert!(settings.iter::<256>(&mut small_state).is_err());
+    assert!(settings.iter_settings::<256>(&mut small_state).is_err());
 
     // Ensure that we can't iterate if the topic buffer is too small.
     let mut state = [0; 10];
-    assert!(settings.iter::<1>(&mut state).is_err());
+    assert!(settings.iter_settings::<1>(&mut state).is_err());
 }
 
 #[test]
@@ -39,11 +39,24 @@ fn test_iteration() {
     ]);
 
     let mut iter_state = [0; 32];
-    for field in settings.iter::<256>(&mut iter_state).unwrap() {
+    for field in settings.iter_settings::<256>(&mut iter_state).unwrap() {
         assert!(iterated.contains_key(&field.as_str().to_string()));
         iterated.insert(field.as_str().to_string(), true);
     }
 
     // Ensure that all fields were iterated.
     assert!(iterated.iter().map(|(_, value)| value).all(|&x| x));
+}
+
+#[test]
+fn test_array_iteration() {
+    let settings = [false; 5];
+    let mut settings_copy = [false; 5];
+
+    let mut iter_state = [0; 32];
+    for field in settings.iter_settings::<256>(&mut iter_state).unwrap() {
+        settings_copy.set(&field, b"true").unwrap();
+    }
+
+    assert!(settings_copy.iter().all(|x| *x));
 }

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -38,12 +38,12 @@ fn iterate_some_none() {
     // When the value is None, it should not be iterated over as a topic.
     let mut state = [0; 10];
     settings.value.take();
-    let mut iterator = settings.iter::<128>(&mut state).unwrap();
+    let mut iterator = settings.iter_settings::<128>(&mut state).unwrap();
     assert!(iterator.next().is_none());
 
     // When the value is Some, it should be iterated over.
     let mut state = [0; 10];
     settings.value.replace(5);
-    let mut iterator = settings.iter::<128>(&mut state).unwrap();
+    let mut iterator = settings.iter_settings::<128>(&mut state).unwrap();
     assert_eq!(iterator.next().unwrap(), "value");
 }


### PR DESCRIPTION
This PR fixes #87 by renaming the `iter()` methods to `iter_settings()` to avoid conflicting with the resolution lookup ordering of `core::slice::iter()`