### PR TITLE
Staging 0.5.0 miniconf release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2022-05-12
+
 ## Changed
 * **breaking** The Miniconf trait for iteration was renamed from `unchecked_iter()` and `iter()` to
   `unchecked_iter_settings()` and `iter_settings()` respectively to avoid issues with slice iteration
@@ -54,7 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Library initially released on crates.io
 
-[Unreleased]: https://github.com/quartiq/miniconf/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/quartiq/miniconf/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/quartiq/miniconf/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/quartiq/miniconf/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/quartiq/miniconf/releases/tag/v0.3.0
 [0.2.0]: https://github.com/quartiq/miniconf/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "miniconf"
 
 # Don't forget to change `derive_miniconf`'s version as well.
-version = "0.4.0"
+version = "0.5.0"
 
 authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@vertigo-designs.com"]
 edition = "2018"
@@ -13,7 +13,7 @@ keywords = ["settings", "embedded", "no_std", "configuration", "mqtt"]
 categories = ["no-std", "config", "embedded", "parsing"]
 
 [dependencies]
-derive_miniconf = { path = "derive_miniconf" , version = "0.4" }
+derive_miniconf = { path = "derive_miniconf" , version = "0.5" }
 serde-json-core = "0.4.0"
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
 log = "0.4"

--- a/derive_miniconf/Cargo.toml
+++ b/derive_miniconf/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "derive_miniconf"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@vertigo-designs.com"]
 edition = "2018"
 license = "MIT"
 description = "Derive utilities for Miniconf run-time settings configuration"
-repository = "https://github.com/quartiq/miniconf/derive_miniconf"
+repository = "https://github.com/quartiq/miniconf"
 
 keywords = ["settings", "embedded", "no_std", "configuration", "mqtt"]
 categories = ["no-std", "config", "embedded", "parsing"]


### PR DESCRIPTION
This PR fixes #86 by fixing the repo link for `derive_miniconf` and prepares for a 0.5 release.