### PR TITLE
Feature/trait rework

### DIFF
--- a/derive_miniconf/src/attributes.rs
+++ b/derive_miniconf/src/attributes.rs
@@ -13,7 +13,7 @@ pub struct AttributeParser {
 impl AttributeParser {
     pub fn new(stream: TokenStream) -> Self {
         Self {
-            inner: stream.into_iter()
+            inner: stream.into_iter(),
         }
     }
 

--- a/derive_miniconf/src/attributes.rs
+++ b/derive_miniconf/src/attributes.rs
@@ -1,0 +1,35 @@
+use proc_macro2::token_stream::IntoIter as TokenIter;
+use proc_macro2::{TokenStream, TokenTree};
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum MiniconfAttribute {
+    Defer,
+}
+
+pub struct AttributeParser {
+    inner: TokenIter,
+}
+
+impl AttributeParser {
+    pub fn new(stream: TokenStream) -> Self {
+        Self {
+            inner: stream.into_iter()
+        }
+    }
+
+    pub fn parse(&mut self) -> MiniconfAttribute {
+        let first = self.inner.next().expect("A single keyword");
+
+        match first {
+            TokenTree::Group(group) => {
+                let ident: syn::Ident = syn::parse2(group.stream()).expect("An identifier");
+                if ident != "defer" {
+                    panic!("Unexpected miniconf attribute: {}", ident);
+                }
+
+                MiniconfAttribute::Defer
+            }
+            other => panic!("Unexpected tree: {:?}", other),
+        }
+    }
+}

--- a/derive_miniconf/src/field.rs
+++ b/derive_miniconf/src/field.rs
@@ -1,0 +1,48 @@
+
+use syn::parse_quote;
+use super::{TypeDefinition, attributes::{MiniconfAttribute, AttributeParser}};
+
+pub struct StructField {
+    pub field: syn::Field,
+    pub deferred: bool,
+}
+
+impl StructField {
+    pub fn new(field: syn::Field) -> Self {
+        let deferred = field.attrs.iter().filter(|attr| attr.path.is_ident("miniconf")).map(|attr| AttributeParser::new(attr.tokens.clone()).parse()).any(|x| x == MiniconfAttribute::Defer);
+
+        Self {
+            deferred,
+            field,
+        }
+    }
+
+    pub fn bound_generics(&self, typedef: &mut TypeDefinition) {
+        // Check our type. Path-like types may need to be bound.
+        let path = match &self.field.ty {
+            syn::Type::Path(syn::TypePath { path, ..}) => path,
+            _ => return,
+        };
+
+        // Generics will have an ident only as the type. Grab it.
+        let ident = match path.get_ident() {
+            Some(ident) => ident,
+            _ => return,
+        };
+
+        // If we got here, we may have a generic parameter. Check the ident against all of the
+        // generic params on the type.
+        for generic in &mut typedef.generics.params {
+            if let syn::GenericParam::Type(type_param) = generic {
+                if type_param.ident == *ident {
+                    if self.deferred {
+                        type_param.bounds.push(parse_quote!(miniconf::Miniconf));
+                    } else {
+                        type_param.bounds.push(parse_quote!(miniconf::Serialize));
+                        type_param.bounds.push(parse_quote!(miniconf::DeserializeOwned));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/derive_miniconf/src/field.rs
+++ b/derive_miniconf/src/field.rs
@@ -1,6 +1,8 @@
-
+use super::{
+    attributes::{AttributeParser, MiniconfAttribute},
+    TypeDefinition,
+};
 use syn::parse_quote;
-use super::{TypeDefinition, attributes::{MiniconfAttribute, AttributeParser}};
 
 pub struct StructField {
     pub field: syn::Field,
@@ -9,40 +11,83 @@ pub struct StructField {
 
 impl StructField {
     pub fn new(field: syn::Field) -> Self {
-        let deferred = field.attrs.iter().filter(|attr| attr.path.is_ident("miniconf")).map(|attr| AttributeParser::new(attr.tokens.clone()).parse()).any(|x| x == MiniconfAttribute::Defer);
+        let deferred = field
+            .attrs
+            .iter()
+            .filter(|attr| attr.path.is_ident("miniconf"))
+            .map(|attr| AttributeParser::new(attr.tokens.clone()).parse())
+            .any(|x| x == MiniconfAttribute::Defer);
 
-        Self {
-            deferred,
-            field,
-        }
+        Self { deferred, field }
     }
 
-    pub(crate) fn bound_generics(&self, typedef: &mut TypeDefinition) {
-        // Check our type. Path-like types may need to be bound.
-        let path = match &self.field.ty {
-            syn::Type::Path(syn::TypePath { path, ..}) => path,
-            _ => return,
-        };
-
-        // Generics will have an ident only as the type. Grab it.
-        let ident = match path.get_ident() {
-            Some(ident) => ident,
-            _ => return,
-        };
-
-        // If we got here, we may have a generic parameter. Check the ident against all of the
-        // generic params on the type.
+    fn bound_type(&self, ident: &syn::Ident, typedef: &mut TypeDefinition, array: bool) {
         for generic in &mut typedef.generics.params {
             if let syn::GenericParam::Type(type_param) = generic {
                 if type_param.ident == *ident {
-                    if self.deferred {
+                    // Deferred array types are a special case. These types defer directly into a
+                    // manual implementation of Miniconf that calls serde functions directly.
+                    if self.deferred && !array {
+                        // For deferred, non-array data types, we will recursively call into
+                        // Miniconf trait functions.
                         type_param.bounds.push(parse_quote!(miniconf::Miniconf));
                     } else {
+                        // For other data types, we will call into serde functions directly.
                         type_param.bounds.push(parse_quote!(miniconf::Serialize));
-                        type_param.bounds.push(parse_quote!(miniconf::DeserializeOwned));
+                        type_param
+                            .bounds
+                            .push(parse_quote!(miniconf::DeserializeOwned));
                     }
                 }
             }
         }
+    }
+
+    /// Handle an individual type encountered in the field type definition.
+    ///
+    /// # Note
+    /// This function will recursively travel through arrays.
+    ///
+    /// # Note
+    /// Only arrays and simple types are currently implemented for type bounds.
+    ///
+    /// # Args
+    /// * `typ` The Type encountered.
+    /// * `typedef` - The generic type parameters of the structure.
+    /// * `array` - Specified true if this type belongs to an upper-level array type.
+    fn handle_type(&self, typ: &syn::Type, typedef: &mut TypeDefinition, array: bool) {
+        // Check our type. Path-like types may need to be bound.
+        let path = match &typ {
+            syn::Type::Path(syn::TypePath { path, .. }) => path,
+            syn::Type::Array(syn::TypeArray { elem, .. }) => {
+                self.handle_type(elem, typedef, true);
+                return;
+            }
+            other => panic!("Unsupported type: {:?}", other),
+        };
+
+        // Generics will have an ident only as the type. Grab it.
+        if let Some(ident) = path.get_ident() {
+            self.bound_type(ident, typedef, array);
+        }
+
+        // Search for generics in the type signature.
+        for segment in path.segments.iter() {
+            if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                for arg in args.args.iter() {
+                    if let syn::GenericArgument::Type(typ) = arg {
+                        self.handle_type(typ, typedef, array);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Bound the generic parameters of the field.
+    ///
+    /// # Args
+    /// * `typedef` The typedefinitions for the structure.
+    pub(crate) fn bound_generics(&self, typedef: &mut TypeDefinition) {
+        self.handle_type(&self.field.ty, typedef, false)
     }
 }

--- a/derive_miniconf/src/field.rs
+++ b/derive_miniconf/src/field.rs
@@ -17,7 +17,7 @@ impl StructField {
         }
     }
 
-    pub fn bound_generics(&self, typedef: &mut TypeDefinition) {
+    pub(crate) fn bound_generics(&self, typedef: &mut TypeDefinition) {
         // Check our type. Path-like types may need to be bound.
         let path = match &self.field.ty {
             syn::Type::Path(syn::TypePath { path, ..}) => path,

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -1,6 +1,11 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, parse_quote, DeriveInput};
+use syn::{parse_macro_input, DeriveInput};
+
+mod attributes;
+mod field;
+
+use field::StructField;
 
 /// Represents a type definition with associated generics.
 struct TypeDefinition {
@@ -10,40 +15,7 @@ struct TypeDefinition {
 
 impl TypeDefinition {
     pub fn new(generics: syn::Generics, name: syn::Ident) -> Self {
-        let mut typedef = TypeDefinition { generics, name };
-        typedef.bound_generics();
-
-        typedef
-    }
-
-    /// Bound the generated type definition to only implement when `Self: DeserializeOwned` for
-    /// cases when deserialization is required.
-    ///
-    /// # Note
-    /// This is equivalent to adding:
-    /// `where Self: DeserializeOwned` to the type definition.
-    pub fn add_serde_bound(&mut self) {
-        let where_clause = self.generics.make_where_clause();
-        where_clause
-            .predicates
-            .push(parse_quote!(Self: miniconf::DeserializeOwned));
-        where_clause
-            .predicates
-            .push(parse_quote!(Self: miniconf::Serialize));
-    }
-
-    // Bound all generics of the type with `T: miniconf::DeserializeOwned + Miniconf`. This is necessary to
-    // make `MiniconfAtomic` and enum derives work properly.
-    fn bound_generics(&mut self) {
-        for generic in &mut self.generics.params {
-            if let syn::GenericParam::Type(type_param) = generic {
-                type_param
-                    .bounds
-                    .push(parse_quote!(miniconf::DeserializeOwned));
-                type_param.bounds.push(parse_quote!(miniconf::Serialize));
-                type_param.bounds.push(parse_quote!(miniconf::Miniconf));
-            }
-        }
+        Self { generics, name }
     }
 }
 
@@ -61,63 +33,27 @@ impl TypeDefinition {
 /// ```rust
 /// #[derive(Miniconf)]
 /// struct Nested {
+///     #[miniconf(defer)]
 ///     data: [u32; 2],
 /// }
 /// #[derive(Miniconf)]
 /// struct Settings {
 ///     // Accessed with path `nested/data/0` or `nested/data/1`
+///     #[miniconf(defer)]
 ///     nested: Nested,
 ///
 ///     // Accessed with path `external`
 ///     external: bool,
 /// }
-#[proc_macro_derive(Miniconf)]
+#[proc_macro_derive(Miniconf, attributes(miniconf))]
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     let typedef = TypeDefinition::new(input.generics, input.ident);
 
     match input.data {
-        syn::Data::Struct(struct_data) => derive_struct(typedef, struct_data, false),
-        syn::Data::Enum(enum_data) => derive_enum(typedef, enum_data),
-        syn::Data::Union(_) => unimplemented!(),
-    }
-}
-
-/// Derive the Miniconf trait for a custom type that must be updated atomically.
-///
-/// This derive function should be used if the setting must be updated entirely at once (e.g.
-/// individual portions of the struct may not be updated independently).
-///
-/// See [Miniconf](derive.Miniconf.html) for more information.
-///
-/// # Example
-/// ```rust
-/// #[derive(MiniconfAtomic)]
-/// struct FilterParameters {
-///     coefficient: f32,
-///     length: usize,
-/// }
-///
-/// #[derive(Miniconf)]
-/// struct Settings {
-///     // Accessed with path `filter`, but `filter/length` and `filter/coefficients` are
-///     inaccessible.
-///     filter: FilterParameters,
-///
-///     // Accessed with path `external`
-///     external: bool,
-/// }
-#[proc_macro_derive(MiniconfAtomic)]
-pub fn derive_atomic(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-
-    let typedef = TypeDefinition::new(input.generics, input.ident);
-
-    match input.data {
-        syn::Data::Struct(struct_data) => derive_struct(typedef, struct_data, true),
-        syn::Data::Enum(enum_data) => derive_enum(typedef, enum_data),
-        syn::Data::Union(_) => unimplemented!(),
+        syn::Data::Struct(struct_data) => derive_struct(typedef, struct_data),
+        _ => unimplemented!(),
     }
 }
 
@@ -131,140 +67,133 @@ pub fn derive_atomic(input: TokenStream) -> TokenStream {
 ///
 /// # Returns
 /// A token stream of the generated code.
-fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct, atomic: bool) -> TokenStream {
-    let fields = match data.fields {
+fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStream {
+    let raw_fields = match data.fields {
         syn::Fields::Named(syn::FieldsNamed { ref named, .. }) => named,
         _ => unimplemented!("Only named fields are supported in structs."),
     };
 
-    // If this structure must be updated atomically, it is not valid to call Miniconf recursively
-    // on its members.
-    if atomic {
-        // Bound the Miniconf implementation on Self implementing DeserializeOwned + Serialize.
-        typedef.add_serde_bound();
+    let fields: Vec<StructField> = raw_fields.iter().map(|x| StructField::new(x.clone())).collect();
 
-        let name = typedef.name;
-        let (impl_generics, ty_generics, where_clause) = typedef.generics.split_for_impl();
-
-        let data = quote! {
-            impl #impl_generics miniconf::Miniconf for #name #ty_generics #where_clause {
-                fn string_set(&mut self, mut topic_parts:
-                core::iter::Peekable<core::str::Split<char>>, value: &[u8]) ->
-                Result<(), miniconf::Error> {
-                    if topic_parts.peek().is_some() {
-                        return Err(miniconf::Error::AtomicUpdateRequired);
-                    }
-
-                    *self = miniconf::serde_json_core::from_slice(value)?.0;
-                    Ok(())
-                }
-
-                fn string_get(&self, mut topic_parts: core::iter::Peekable<core::str::Split<char>>, value: &mut [u8]) -> Result<usize, miniconf::Error> {
-                    if topic_parts.peek().is_some() {
-                        return Err(miniconf::Error::AtomicUpdateRequired);
-                    }
-
-                    miniconf::serde_json_core::to_slice(self, value).map_err(|_| miniconf::Error::SerializationFailed)
-                }
-
-                fn get_metadata(&self) -> miniconf::MiniconfMetadata {
-                    // Atomic structs have no children and a single index.
-                    miniconf::MiniconfMetadata {
-                        max_topic_size: 0,
-                        max_depth: 1,
-                    }
-                }
-
-                fn recurse_paths<const TS: usize>(&self, index: &mut [usize], topic: &mut miniconf::heapless::String<TS>) -> Option<()> {
-                    if index.len() == 0 {
-                        // Note: During expected execution paths using `into_iter()`, the size of
-                        // the index stack is checked in advance to make sure this condition
-                        // doesn't occur.  However, it's possible to happen if the user manually
-                        // calls `recurse_paths`.
-                        unreachable!("Index stack too small");
-                    }
-
-                    let i = index[0];
-                    index[0] += 1;
-
-                    if i == 0 {
-                        Some(())
-                    } else {
-                        None
-                    }
-                }
-            }
-        };
-
-        return TokenStream::from(data);
+    for field in fields.iter() {
+        field.bound_generics(&mut typedef);
     }
 
     let set_recurse_match_arms = fields.iter().map(|f| {
-        let match_name = &f.ident;
-        quote! {
-            stringify!(#match_name) => {
-                self.#match_name.string_set(topic_parts, value)
+        let match_name = &f.field.ident;
+        if f.deferred {
+            quote! {
+                stringify!(#match_name) => {
+                    self.#match_name.string_set(topic_parts, value)
+                }
+            }
+        } else {
+            quote! {
+                stringify!(#match_name) => {
+                    if topic_parts.peek().is_some() {
+                        return Err(miniconf::Error::PathTooLong)
+                    }
+
+                    self.#match_name = miniconf::serde_json_core::from_slice(value)?.0;
+                    Ok(())
+                }
             }
         }
     });
 
     let get_recurse_match_arms = fields.iter().map(|f| {
-        let match_name = &f.ident;
-        quote! {
-            stringify!(#match_name) => {
-                self.#match_name.string_get(topic_parts, value)
+        let match_name = &f.field.ident;
+        if f.deferred {
+            quote! {
+                stringify!(#match_name) => {
+                    self.#match_name.string_get(topic_parts, value)
+                }
+            }
+        } else {
+            quote! {
+                stringify!(#match_name) => {
+                    if topic_parts.peek().is_some() {
+                        return Err(miniconf::Error::PathTooLong);
+                    }
+
+                    miniconf::serde_json_core::to_slice(&self.#match_name, value).map_err(|_| miniconf::Error::SerializationFailed)
+                }
             }
         }
     });
 
     let iter_match_arms = fields.iter().enumerate().map(|(i, f)| {
-        let field_name = &f.ident;
-        quote! {
-            #i => {
-                let original_length = topic.len();
+        let field_name = &f.field.ident;
+        if f.deferred {
+            quote! {
+                #i => {
+                    let original_length = topic.len();
 
-                let postfix = if topic.len() != 0 {
-                    concat!("/", stringify!(#field_name))
-                } else {
-                    stringify!(#field_name)
-                };
+                    let postfix = if topic.len() != 0 {
+                        concat!("/", stringify!(#field_name))
+                    } else {
+                        stringify!(#field_name)
+                    };
 
-                if topic.push_str(postfix).is_err() {
-                    // Note: During expected execution paths using `into_iter()`, the size of the
-                    // topic buffer is checked in advance to make sure this condition doesn't
-                    // occur.  However, it's possible to happen if the user manually calls
-                    // `recurse_paths`.
-                    unreachable!("Topic buffer too short");
+                    if topic.push_str(postfix).is_err() {
+                        // Note: During expected execution paths using `into_iter()`, the size of the
+                        // topic buffer is checked in advance to make sure this condition doesn't
+                        // occur.  However, it's possible to happen if the user manually calls
+                        // `recurse_paths`.
+                        unreachable!("Topic buffer too short");
+                    }
+
+                    if self.#field_name.recurse_paths(&mut index[1..], topic).is_some() {
+                        return Some(());
+                    }
+
+                    // Strip off the previously prepended index, since we completed that element and need
+                    // to instead check the next one.
+                    topic.truncate(original_length);
+
+                    index[0] += 1;
+                    index[1..].iter_mut().for_each(|x| *x = 0);
                 }
+            }
+        } else {
+            quote! {
+                #i => {
+                    let i = index[0];
+                    index[0] += 1;
 
-                if self.#field_name.recurse_paths(&mut index[1..], topic).is_some() {
-                    return Some(());
+                    if i == 0 {
+                        return Some(())
+                    }
                 }
-
-                // Strip off the previously prepended index, since we completed that element and need
-                // to instead check the next one.
-                topic.truncate(original_length);
-
-                index[0] += 1;
-                index[1..].iter_mut().for_each(|x| *x = 0);
             }
         }
     });
 
     let iter_metadata_arms = fields.iter().enumerate().map(|(i, f)| {
-        let field_name = &f.ident;
-        quote! {
-            #i => {
-                let mut meta = self.#field_name.get_metadata();
+        let field_name = &f.field.ident;
+        if f.deferred {
+            quote! {
+                #i => {
+                    let mut meta = self.#field_name.get_metadata();
 
-                // If the subfield has additional paths, we need to add space for a separator.
-                if meta.max_topic_size > 0 {
-                    meta.max_topic_size += 1;
+                    // If the subfield has additional paths, we need to add space for a separator.
+                    if meta.max_topic_size > 0 {
+                        meta.max_topic_size += 1;
+                    }
+
+                    meta.max_topic_size += stringify!(#field_name).len();
+
+                    meta
                 }
-
-                meta.max_topic_size += stringify!(#field_name).len();
-
-                meta
+            }
+        } else {
+            quote! {
+                #i => {
+                    miniconf::MiniconfMetadata {
+                        max_topic_size: stringify!(#field_name).len(),
+                        max_depth: 1,
+                    }
+                }
             }
         }
     });
@@ -337,84 +266,6 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct, atomic: boo
                         _ => return None,
 
                     };
-                }
-            }
-        }
-    };
-
-    TokenStream::from(expanded)
-}
-
-/// Derive the Miniconf trait for simple enums.
-///
-/// # Args
-/// * `typedef` - The type definition.
-/// * `data` - The data associated with the enum definition.
-///
-/// # Returns
-/// A token stream of the generated code.
-fn derive_enum(mut typedef: TypeDefinition, data: syn::DataEnum) -> TokenStream {
-    // Only support simple enums, check each field
-    for v in data.variants.iter() {
-        match v.fields {
-            syn::Fields::Named(_) | syn::Fields::Unnamed(_) => {
-                unimplemented!("Only simple, C-like enums are supported.")
-            }
-            syn::Fields::Unit => {}
-        }
-    }
-
-    typedef.add_serde_bound();
-
-    let (impl_generics, ty_generics, where_clause) = typedef.generics.split_for_impl();
-    let name = typedef.name;
-
-    let expanded = quote! {
-        impl #impl_generics miniconf::Miniconf for #name #ty_generics #where_clause {
-            fn string_set(&mut self, mut topic_parts:
-            core::iter::Peekable<core::str::Split<char>>, value: &[u8]) ->
-            Result<(), miniconf::Error> {
-                if topic_parts.peek().is_some() {
-                    // We don't support enums that can contain other values
-                    return Err(miniconf::Error::PathTooLong)
-                }
-
-                *self = miniconf::serde_json_core::from_slice(value)?.0;
-                Ok(())
-            }
-
-            fn string_get(&self, mut topic_parts: core::iter::Peekable<core::str::Split<char>>, value: &mut [u8]) -> Result<usize, miniconf::Error> {
-                if topic_parts.peek().is_some() {
-                    // We don't support enums that can contain other values
-                    return Err(miniconf::Error::PathTooLong)
-                }
-
-                miniconf::serde_json_core::to_slice(self, value).map_err(|_| miniconf::Error::SerializationFailed)
-            }
-
-            fn get_metadata(&self) -> miniconf::MiniconfMetadata {
-                // Atomic structs have no children and a single index.
-                miniconf::MiniconfMetadata {
-                    max_topic_size: 0,
-                    max_depth: 1,
-                }
-            }
-
-            fn recurse_paths<const TS: usize>(&self, index: &mut [usize], topic: &mut miniconf::heapless::String<TS>) -> Option<()> {
-                if index.len() == 0 {
-                    // Note: During expected execution paths using `into_iter()`, the size of the
-                    // index stack is checked in advance to make sure this condition doesn't occur.
-                    // However, it's possible to happen if the user manually calls `recurse_paths`.
-                    unreachable!("Index stack too small");
-                }
-
-                let i = index[0];
-                index[0] += 1;
-
-                if i == 0 {
-                    Some(())
-                } else {
-                    None
                 }
             }
         }

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -8,7 +8,7 @@ mod field;
 use field::StructField;
 
 /// Represents a type definition with associated generics.
-struct TypeDefinition {
+pub(crate) struct TypeDefinition {
     pub generics: syn::Generics,
     pub name: syn::Ident,
 }

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -73,7 +73,10 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
         _ => unimplemented!("Only named fields are supported in structs."),
     };
 
-    let fields: Vec<StructField> = raw_fields.iter().map(|x| StructField::new(x.clone())).collect();
+    let fields: Vec<StructField> = raw_fields
+        .iter()
+        .map(|x| StructField::new(x.clone()))
+        .collect();
 
     for field in fields.iter() {
         field.bound_generics(&mut typedef);

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -11,7 +11,9 @@ struct NestedSettings {
 
 #[derive(Clone, Default, Miniconf, Debug)]
 struct Settings {
+    #[miniconf(defer)]
     inner: NestedSettings,
+    #[miniconf(defer)]
     amplitude: [f32; 2],
     exit: bool,
 }

--- a/examples/readback.rs
+++ b/examples/readback.rs
@@ -1,14 +1,14 @@
 use miniconf::Miniconf;
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Miniconf, Serialize, Deserialize)]
+#[derive(Debug, Default, Miniconf)]
 struct AdditionalSettings {
     inner: u8,
     inner2: u32,
 }
 
-#[derive(Debug, Default, Miniconf, Serialize, Deserialize)]
+#[derive(Debug, Default, Miniconf)]
 struct Settings {
+    #[miniconf(defer)]
     more: AdditionalSettings,
     data: u32,
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -2,7 +2,54 @@ use super::{Error, Miniconf, MiniconfMetadata};
 
 use core::fmt::Write;
 
-impl<T: Miniconf, const N: usize> Miniconf for [T; N] {
+pub struct MiniconfArray<T: Miniconf, const N: usize>(pub [T; N]);
+
+impl<T: Miniconf, const N: usize> core::ops::Deref for MiniconfArray<T, N> {
+    type Target = [T; N];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl<T: Miniconf, const N: usize> core::ops::DerefMut for MiniconfArray<T, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: Default + Miniconf + Copy, const N: usize> Default for MiniconfArray<T, N> {
+    fn default() -> Self {
+        Self([T::default(); N])
+    }
+}
+
+impl<T: core::fmt::Debug + Miniconf, const N: usize> core::fmt::Debug for MiniconfArray<T, N> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T: PartialEq + Miniconf, const N: usize> PartialEq<[T; N]> for MiniconfArray<T, N> {
+    fn eq(&self, other: &[T; N]) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl<T: PartialEq + Miniconf, const N: usize> PartialEq for MiniconfArray<T, N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl <T: Clone + Miniconf, const N: usize> Clone for MiniconfArray<T, N> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl <T: Copy + Miniconf, const N: usize> Copy for MiniconfArray<T, N> { }
+
+impl<T: Miniconf, const N: usize> Miniconf for MiniconfArray<T, N> {
     fn string_set(
         &mut self,
         mut topic_parts: core::iter::Peekable<core::str::Split<char>>,
@@ -18,11 +65,11 @@ impl<T: Miniconf, const N: usize> Miniconf for [T; N] {
             .or(Err(Error::BadIndex))?
             .0;
 
-        if i >= self.len() {
+        if i >= self.0.len() {
             return Err(Error::BadIndex);
         }
 
-        self[i].string_set(topic_parts, value)?;
+        self.0[i].string_set(topic_parts, value)?;
 
         Ok(())
     }
@@ -42,11 +89,11 @@ impl<T: Miniconf, const N: usize> Miniconf for [T; N] {
             .or(Err(Error::BadIndex))?
             .0;
 
-        if i >= self.len() {
+        if i >= self.0.len() {
             return Err(Error::BadIndex);
         }
 
-        self[i].string_get(topic_parts, value)
+        self.0[i].string_get(topic_parts, value)
     }
 
     fn get_metadata(&self) -> MiniconfMetadata {
@@ -59,7 +106,7 @@ impl<T: Miniconf, const N: usize> Miniconf for [T; N] {
             num_digits += 1;
         }
 
-        let metadata = self[0].get_metadata();
+        let metadata = self.0[0].get_metadata();
 
         // If the sub-members have topic size, we also need to include an additional character for
         // the path separator. This is ommitted if the sub-members have no topic (e.g. fundamental
@@ -107,7 +154,7 @@ impl<T: Miniconf, const N: usize> Miniconf for [T; N] {
                 unreachable!("Topic buffer too short");
             }
 
-            if self[index[0]]
+            if self.0[index[0]]
                 .recurse_paths(&mut index[1..], topic)
                 .is_some()
             {
@@ -120,6 +167,112 @@ impl<T: Miniconf, const N: usize> Miniconf for [T; N] {
 
             index[0] += 1;
             index[1..].iter_mut().for_each(|x| *x = 0);
+        }
+
+        None
+    }
+}
+
+impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for [T; N] {
+    fn string_set(
+        &mut self,
+        mut topic_parts: core::iter::Peekable<core::str::Split<char>>,
+        value: &[u8],
+    ) -> Result<(), Error> {
+        let next = topic_parts.next();
+        if next.is_none() {
+            return Err(Error::PathTooShort);
+        }
+
+        // Parse what should be the index value
+        let i: usize = serde_json_core::from_str(next.unwrap())
+            .or(Err(Error::BadIndex))?
+            .0;
+
+        if i >= self.len() {
+            return Err(Error::BadIndex);
+        }
+
+        if topic_parts.peek().is_some() {
+            return Err(Error::PathTooLong);
+        }
+
+        self[i] = serde_json_core::from_slice(value)?.0;
+        Ok(())
+    }
+
+    fn string_get(
+        &self,
+        mut topic_parts: core::iter::Peekable<core::str::Split<char>>,
+        value: &mut [u8],
+    ) -> Result<usize, Error> {
+        let next = topic_parts.next();
+        if next.is_none() {
+            return Err(Error::PathTooShort);
+        }
+
+        // Parse what should be the index value
+        let i: usize = serde_json_core::from_str(next.unwrap())
+            .or(Err(Error::BadIndex))?
+            .0;
+
+        if i >= self.len() {
+            return Err(Error::BadIndex);
+        }
+
+        if topic_parts.peek().is_some() {
+            return Err(Error::PathTooLong);
+        }
+
+        serde_json_core::to_slice(&self[i], value).map_err(|_| Error::SerializationFailed)
+    }
+
+    fn get_metadata(&self) -> MiniconfMetadata {
+        // First, figure out how many digits the maximum index requires when printing.
+        let mut index = N - 1;
+        let mut num_digits = 0;
+
+        while index > 0 {
+            index /= 10;
+            num_digits += 1;
+        }
+
+        MiniconfMetadata {
+            max_topic_size: num_digits,
+            max_depth: 1,
+        }
+    }
+
+    fn recurse_paths<const TS: usize>(
+        &self,
+        index: &mut [usize],
+        topic: &mut heapless::String<TS>,
+    ) -> Option<()> {
+        if index.is_empty() {
+            // Note: During expected execution paths using `into_iter()`, the size of the
+            // index stack is checked in advance to make sure this condition doesn't occur.
+            // However, it's possible to happen if the user manually calls `recurse_paths`.
+            unreachable!("Index stack too small");
+        }
+
+        if index[0] < N {
+            // Add the array index to the topic name.
+            if topic.len() > 0 && topic.push('/').is_err() {
+                // Note: During expected execution paths using `into_iter()`, the size of the
+                // topic buffer is checked in advance to make sure this condition doesn't occur.
+                // However, it's possible to happen if the user manually calls `recurse_paths`.
+                unreachable!("Topic buffer too short");
+            }
+
+            if write!(topic, "{}", index[0]).is_err() {
+                // Note: During expected execution paths using `into_iter()`, the size of the
+                // topic buffer is checked in advance to make sure this condition doesn't occur.
+                // However, it's possible to happen if the user manually calls `recurse_paths`.
+                unreachable!("Topic buffer too short");
+            }
+
+            index[0] += 1;
+            return Some(());
         }
 
         None

--- a/src/array.rs
+++ b/src/array.rs
@@ -41,13 +41,13 @@ impl<T: PartialEq + Miniconf, const N: usize> PartialEq for MiniconfArray<T, N> 
     }
 }
 
-impl <T: Clone + Miniconf, const N: usize> Clone for MiniconfArray<T, N> {
+impl<T: Clone + Miniconf, const N: usize> Clone for MiniconfArray<T, N> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
 }
 
-impl <T: Copy + Miniconf, const N: usize> Copy for MiniconfArray<T, N> { }
+impl<T: Copy + Miniconf, const N: usize> Copy for MiniconfArray<T, N> {}
 
 impl<T: Miniconf, const N: usize> Miniconf for MiniconfArray<T, N> {
     fn string_set(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,6 @@ pub use serde::{
 };
 
 pub use array::MiniconfArray;
-pub use option::MiniconfOption;
 
 pub use serde_json_core;
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -24,7 +24,8 @@ impl<T: Miniconf> Miniconf for MiniconfOption<T> {
     }
 
     fn get_metadata(&self) -> MiniconfMetadata {
-        self.0.as_ref()
+        self.0
+            .as_ref()
             .map(|value| value.get_metadata())
             .unwrap_or_default()
     }
@@ -34,7 +35,8 @@ impl<T: Miniconf> Miniconf for MiniconfOption<T> {
         index: &mut [usize],
         topic: &mut heapless::String<TS>,
     ) -> Option<()> {
-        self.0.as_ref()
+        self.0
+            .as_ref()
             .and_then(|value| value.recurse_paths(index, topic))
     }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,12 +1,14 @@
 use super::{Error, Miniconf, MiniconfMetadata};
 
-impl<T: Miniconf> Miniconf for Option<T> {
+pub struct MiniconfOption<T: Miniconf>(pub Option<T>);
+
+impl<T: Miniconf> Miniconf for MiniconfOption<T> {
     fn string_set(
         &mut self,
         topic_parts: core::iter::Peekable<core::str::Split<char>>,
         value: &[u8],
     ) -> Result<(), Error> {
-        self.as_mut().map_or(Err(Error::PathNotFound), |inner| {
+        self.0.as_mut().map_or(Err(Error::PathNotFound), |inner| {
             inner.string_set(topic_parts, value)
         })
     }
@@ -16,13 +18,13 @@ impl<T: Miniconf> Miniconf for Option<T> {
         topic_parts: core::iter::Peekable<core::str::Split<char>>,
         value: &mut [u8],
     ) -> Result<usize, Error> {
-        self.as_ref().map_or(Err(Error::PathNotFound), |inner| {
+        self.0.as_ref().map_or(Err(Error::PathNotFound), |inner| {
             inner.string_get(topic_parts, value)
         })
     }
 
     fn get_metadata(&self) -> MiniconfMetadata {
-        self.as_ref()
+        self.0.as_ref()
             .map(|value| value.get_metadata())
             .unwrap_or_default()
     }
@@ -32,7 +34,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
         index: &mut [usize],
         topic: &mut heapless::String<TS>,
     ) -> Option<()> {
-        self.as_ref()
+        self.0.as_ref()
             .and_then(|value| value.recurse_paths(index, topic))
     }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,14 +1,12 @@
 use super::{Error, Miniconf, MiniconfMetadata};
 
-pub struct MiniconfOption<T: Miniconf>(pub Option<T>);
-
-impl<T: Miniconf> Miniconf for MiniconfOption<T> {
+impl<T: Miniconf> Miniconf for Option<T> {
     fn string_set(
         &mut self,
         topic_parts: core::iter::Peekable<core::str::Split<char>>,
         value: &[u8],
     ) -> Result<(), Error> {
-        self.0.as_mut().map_or(Err(Error::PathNotFound), |inner| {
+        self.as_mut().map_or(Err(Error::PathNotFound), |inner| {
             inner.string_set(topic_parts, value)
         })
     }
@@ -18,14 +16,13 @@ impl<T: Miniconf> Miniconf for MiniconfOption<T> {
         topic_parts: core::iter::Peekable<core::str::Split<char>>,
         value: &mut [u8],
     ) -> Result<usize, Error> {
-        self.0.as_ref().map_or(Err(Error::PathNotFound), |inner| {
+        self.as_ref().map_or(Err(Error::PathNotFound), |inner| {
             inner.string_get(topic_parts, value)
         })
     }
 
     fn get_metadata(&self) -> MiniconfMetadata {
-        self.0
-            .as_ref()
+        self.as_ref()
             .map(|value| value.get_metadata())
             .unwrap_or_default()
     }
@@ -35,8 +32,7 @@ impl<T: Miniconf> Miniconf for MiniconfOption<T> {
         index: &mut [usize],
         topic: &mut heapless::String<TS>,
     ) -> Option<()> {
-        self.0
-            .as_ref()
+        self.as_ref()
             .and_then(|value| value.recurse_paths(index, topic))
     }
 }

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,4 +1,4 @@
-use miniconf::{Error, MiniconfArray, Miniconf};
+use miniconf::{Error, Miniconf, MiniconfArray};
 use serde::Deserialize;
 
 #[derive(Debug, Default, Miniconf, Deserialize)]

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,4 +1,4 @@
-use miniconf::{Error, Miniconf};
+use miniconf::{Error, MiniconfArray, Miniconf};
 use serde::Deserialize;
 
 #[derive(Debug, Default, Miniconf, Deserialize)]
@@ -9,6 +9,7 @@ struct AdditionalSettings {
 #[derive(Debug, Default, Miniconf, Deserialize)]
 struct Settings {
     data: u32,
+    #[miniconf(defer)]
     more: AdditionalSettings,
 }
 
@@ -16,6 +17,7 @@ struct Settings {
 fn simple_array() {
     #[derive(Miniconf, Default)]
     struct S {
+        #[miniconf(defer)]
         a: [u8; 3],
     }
 
@@ -53,6 +55,7 @@ fn nonexistent_field() {
 fn simple_array_indexing() {
     #[derive(Miniconf, Default)]
     struct S {
+        #[miniconf(defer)]
         a: [u8; 3],
     }
 
@@ -73,20 +76,21 @@ fn simple_array_indexing() {
 
     // Test metadata
     let metadata = s.get_metadata();
-    assert_eq!(metadata.max_depth, 3);
+    assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_topic_size, "a/2".len());
 }
 
 #[test]
 fn array_of_structs_indexing() {
-    #[derive(Miniconf, Default, Clone, Copy, Deserialize, Debug, PartialEq)]
+    #[derive(Miniconf, Default, Clone, Copy, Debug, PartialEq)]
     struct Inner {
         b: u8,
     }
 
     #[derive(Miniconf, Default, PartialEq, Debug)]
     struct S {
-        a: [Inner; 3],
+        #[miniconf(defer)]
+        a: MiniconfArray<Inner, 3>,
     }
 
     let mut s = S::default();

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -3,13 +3,13 @@ use serde::{Deserialize, Serialize};
 
 #[test]
 fn simple_enum() {
-    #[derive(Miniconf, Debug, Deserialize, Serialize, PartialEq)]
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
     enum Variant {
         A,
         B,
     }
 
-    #[derive(Miniconf, Debug, Deserialize, Serialize)]
+    #[derive(Miniconf, Debug)]
     struct S {
         v: Variant,
     }
@@ -30,13 +30,13 @@ fn simple_enum() {
 
 #[test]
 fn invalid_enum() {
-    #[derive(Miniconf, Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
     enum Variant {
         A,
         B,
     }
 
-    #[derive(Miniconf, Debug, Deserialize)]
+    #[derive(Miniconf, Debug)]
     struct S {
         v: Variant,
     }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -1,10 +1,10 @@
-use miniconf::{Miniconf, MiniconfAtomic};
+use miniconf::{Miniconf, DeserializeOwned};
 use serde::{Deserialize, Serialize};
 
 #[test]
 fn generic_type() {
     #[derive(Miniconf, Default)]
-    struct Settings<T: Miniconf> {
+    struct Settings<T: Serialize + DeserializeOwned> {
         pub data: T,
     }
 
@@ -23,7 +23,8 @@ fn generic_type() {
 #[test]
 fn generic_array() {
     #[derive(Miniconf, Default)]
-    struct Settings<T: Miniconf> {
+    struct Settings<T: Serialize + DeserializeOwned> {
+        #[miniconf(defer)]
         pub data: [T; 2],
     }
 
@@ -36,18 +37,18 @@ fn generic_array() {
 
     // Test metadata
     let metadata = settings.get_metadata();
-    assert_eq!(metadata.max_depth, 3);
+    assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_topic_size, "data/0".len());
 }
 
 #[test]
 fn generic_struct() {
     #[derive(Miniconf, Default)]
-    struct Settings<T> {
+    struct Settings<T: Serialize + DeserializeOwned> {
         pub inner: T,
     }
 
-    #[derive(MiniconfAtomic, Deserialize, Serialize, Default)]
+    #[derive(Serialize, Deserialize, Default)]
     struct Inner {
         pub data: f32,
     }
@@ -68,11 +69,11 @@ fn generic_struct() {
 #[test]
 fn generic_atomic() {
     #[derive(Miniconf, Default)]
-    struct Settings<T> {
+    struct Settings<T: Serialize + DeserializeOwned> {
         pub atomic: Inner<T>,
     }
 
-    #[derive(Deserialize, Serialize, MiniconfAtomic, Default)]
+    #[derive(Deserialize, Serialize, Default)]
     struct Inner<T> {
         pub inner: [T; 5],
     }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -1,4 +1,4 @@
-use miniconf::{Miniconf, DeserializeOwned};
+use miniconf::{DeserializeOwned, Miniconf};
 use serde::{Deserialize, Serialize};
 
 #[test]
@@ -23,7 +23,7 @@ fn generic_type() {
 #[test]
 fn generic_array() {
     #[derive(Miniconf, Default)]
-    struct Settings<T: Serialize + DeserializeOwned> {
+    struct Settings<T> {
         #[miniconf(defer)]
         pub data: [T; 2],
     }
@@ -44,7 +44,7 @@ fn generic_array() {
 #[test]
 fn generic_struct() {
     #[derive(Miniconf, Default)]
-    struct Settings<T: Serialize + DeserializeOwned> {
+    struct Settings<T> {
         pub inner: T,
     }
 
@@ -69,7 +69,7 @@ fn generic_struct() {
 #[test]
 fn generic_atomic() {
     #[derive(Miniconf, Default)]
-    struct Settings<T: Serialize + DeserializeOwned> {
+    struct Settings<T> {
         pub atomic: Inner<T>,
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18,6 +18,7 @@ struct AdditionalSettings {
 #[derive(Clone, Debug, Default, Miniconf, Deserialize)]
 struct Settings {
     data: u32,
+    #[miniconf(defer)]
     more: AdditionalSettings,
 }
 

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -9,6 +9,7 @@ struct Inner {
 struct Settings {
     a: f32,
     b: i32,
+    #[miniconf(defer)]
     c: Inner,
 }
 
@@ -50,14 +51,19 @@ fn test_iteration() {
 
 #[test]
 fn test_array_iteration() {
-    // TODO: Replace this with mutable iteration when implemented.
-    let settings = [false; 5];
-    let mut settings_copy = [false; 5];
+    #[derive(Miniconf, Default)]
+    struct Settings {
+        #[miniconf(defer)]
+        data: [bool; 5],
+    }
+
+    let settings = Settings::default();
+    let mut settings_copy = Settings::default();
 
     let mut iter_state = [0; 32];
     for field in settings.iter_settings::<256>(&mut iter_state).unwrap() {
         settings_copy.set(&field, b"true").unwrap();
     }
 
-    assert!(settings_copy.iter().all(|x| *x));
+    assert!(settings_copy.data.iter().all(|x| *x));
 }

--- a/tests/republish.rs
+++ b/tests/republish.rs
@@ -1,5 +1,3 @@
-use tokio;
-
 use miniconf::{minimq, Miniconf};
 use std_embedded_nal::Stack;
 use std_embedded_time::StandardClock;
@@ -12,6 +10,7 @@ struct AdditionalSettings {
 #[derive(Clone, Debug, Default, Miniconf)]
 struct Settings {
     data: u32,
+    #[miniconf(defer)]
     more: AdditionalSettings,
 }
 

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -1,9 +1,8 @@
-use miniconf::{Miniconf, MiniconfAtomic};
-use serde::{Deserialize, Serialize};
+use miniconf::Miniconf;
 
 #[test]
 fn atomic_struct() {
-    #[derive(MiniconfAtomic, Default, PartialEq, Debug, Serialize, Deserialize)]
+    #[derive(Miniconf, Default, PartialEq, Debug)]
     struct Inner {
         a: u32,
         b: u32,
@@ -13,6 +12,7 @@ fn atomic_struct() {
     struct Settings {
         a: f32,
         b: bool,
+        #[miniconf(defer)]
         c: Inner,
     }
 
@@ -53,6 +53,7 @@ fn recursive_struct() {
     struct Settings {
         a: f32,
         b: bool,
+        #[miniconf(defer)]
         c: Inner,
     }
 


### PR DESCRIPTION
This PR fixes #99 

Notable changes:
* A new `#[miniconf(defer)]` tag has replaced `#[derive(MiniconfAtomic)]`. This tells miniconf to recurse through the object for settings. Any item not explicitly marked as `defer` will be trated as an atomic element.
* New `MiniconfArray` type has been added
   * The `MiniconfArray` is used in leiu of a `[T; N]` to defer down to miniconf traits when using deference.
      * A default implementation is provided for `[T; N]` that defers down to serde primitives instead of Miniconf traits.

* Default Miniconf implementations have been removed for basic types. Instead, Miniconf relies on `Serialize + DeserializeOwned` on these types, which allows integrating foreign types into `Miniconf` structures without having to implement `Miniconf` on them
* Trait bounding for generics has been simplified to relax the requirements of Serde traits to only those that directly are called.