### PR TITLE
Cleaning up python client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   respectively to conform with standard conventions.
 * Python client API is no longer retain by default. CLI is unchanged
 * Python requests API updated to use a static response topic
+* Python requests now have a timeout
 
 ### Removed
 * The client no longer resets the republish timeout when receiving messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#71](https://github.com/quartiq/miniconf/issues/71)
 * [breaking] `into_iter()` and `unchecked_into_iter()` renamed to `iter()` and `unchecked_iter()`
   respectively to conform with standard conventions.
+* Python client API is no longer retain by default. CLI is unchanged
+* Python requests API updated to use a static response topic
 
 ### Removed
 * The client no longer resets the republish timeout when receiving messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * python module: don't emite whitespace in JSON to match serde-json-core (#92)
 * `heapless::String` now implements `Miniconf` directly.
+* Python client API is no longer retain by default. CLI is unchanged
 
 ### Fixed
 * Python device discovery now only discovers unique device identifiers. See [#97](https://github.com/quartiq/miniconf/issues/97)
+* Python requests API updated to use a static response topic
+* Python requests now have a timeout
 
 
 ## [0.5.0] - 2022-05-12
@@ -33,9 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#71](https://github.com/quartiq/miniconf/issues/71)
 * [breaking] `into_iter()` and `unchecked_into_iter()` renamed to `iter()` and `unchecked_iter()`
   respectively to conform with standard conventions.
-* Python client API is no longer retain by default. CLI is unchanged
-* Python requests API updated to use a static response topic
-* Python requests now have a timeout
 
 ### Removed
 * The client no longer resets the republish timeout when receiving messages.

--- a/py/miniconf-mqtt/miniconf/__main__.py
+++ b/py/miniconf-mqtt/miniconf/__main__.py
@@ -58,8 +58,8 @@ def main():
         assert len(devices) == 1, \
             f'Multiple miniconf devices found ({devices}). Please specify a more specific --prefix'
 
-        logging.info('Automatically using detected device prefix: %s', list(devices)[0])
         prefix = list(devices)[0]
+        logging.info('Automatically using detected device prefix: %s', prefix)
 
     async def configure_settings():
         interface = await Miniconf.create(prefix, args.broker)

--- a/py/miniconf-mqtt/miniconf/__main__.py
+++ b/py/miniconf-mqtt/miniconf/__main__.py
@@ -58,8 +58,8 @@ def main():
         assert len(devices) == 1, \
             f'Multiple miniconf devices found ({devices}). Please specify a more specific --prefix'
 
-        logging.info('Automatically using detected device prefix: %s', devices[0])
-        prefix = devices[0]
+        logging.info('Automatically using detected device prefix: %s', list(devices)[0])
+        prefix = list(devices)[0]
 
     async def configure_settings():
         interface = await Miniconf.create(prefix, args.broker)

--- a/py/miniconf-mqtt/miniconf/__main__.py
+++ b/py/miniconf-mqtt/miniconf/__main__.py
@@ -58,7 +58,7 @@ def main():
         assert len(devices) == 1, \
             f'Multiple miniconf devices found ({devices}). Please specify a more specific --prefix'
 
-        prefix = list(devices)[0]
+        prefix = devices.pop()
         logging.info('Automatically using detected device prefix: %s', prefix)
 
     async def configure_settings():

--- a/py/miniconf-mqtt/miniconf/miniconf.py
+++ b/py/miniconf-mqtt/miniconf/miniconf.py
@@ -35,7 +35,6 @@ class Miniconf:
             client: A connected MQTT5 client.
             prefix: The MQTT toptic prefix of the device to control.
         """
-        self.request_id = 0
         self.client = client
         self.prefix = prefix
         self.inflight = {}
@@ -82,7 +81,6 @@ class Miniconf:
         request_id = uuid.uuid1().hex.encode()
         assert request_id not in self.inflight
         self.inflight[request_id] = fut
-        self.request_id += 1
 
         payload = json.dumps(value, separators=(",", ":"))
         LOGGER.info('Sending "%s" to "%s"', value, topic)

--- a/py/miniconf-mqtt/miniconf/miniconf.py
+++ b/py/miniconf-mqtt/miniconf/miniconf.py
@@ -56,6 +56,10 @@ class Miniconf:
             # Extract request_id corrleation data from the properties
             request_id = properties['correlation_data'][0]
 
+            if request_id not in self.inflight:
+                LOGGER.info("Discarding message with CD: %s", request_id)
+                return
+
             self.inflight[request_id].set_result(json.loads(payload))
             del self.inflight[request_id]
         else:
@@ -83,7 +87,7 @@ class Miniconf:
         self.inflight[request_id] = fut
 
         payload = json.dumps(value, separators=(",", ":"))
-        LOGGER.info('Sending "%s" to "%s"', value, topic)
+        LOGGER.info('Sending "%s" to "%s" with CD: %s', value, topic, request_id)
 
         self.client.publish(
             topic, payload=payload, qos=0, retain=retain,

--- a/py/miniconf-mqtt/miniconf/miniconf.py
+++ b/py/miniconf-mqtt/miniconf/miniconf.py
@@ -65,7 +65,7 @@ class Miniconf:
         else:
             LOGGER.warning('Unexpected message on "%s"', topic)
 
-    async def command(self, path, value, retain=False):
+    async def command(self, path, value, retain=False, timeout=5):
         """Write the provided data to the specified path.
 
         Args:
@@ -73,6 +73,7 @@ class Miniconf:
             value: The value to write to the path.
             retain: Retain the MQTT message changing the setting
                 by the broker.
+            timeout: The maximum time to wait for the response in seconds.
 
         Returns:
             The response to the command as a dictionary.
@@ -94,6 +95,6 @@ class Miniconf:
             response_topic=self.response_topic,
             correlation_data=request_id)
 
-        result = await fut
+        result = await asyncio.wait_for(fut, timeout)
         if result['code'] != 0:
             raise MiniconfException(result['msg'])


### PR DESCRIPTION
This PR fixes #94 by updating the python client to store UUID as the correlation data and use a static response topic.

This PR fixes #84 by updating the python API to be no-retain by default.

This PR fixes #57 by adding a timeout to the Python API.