### PR TITLE
rework (make get/set_path generic Peekable, associated fns for metadata and next_path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [breaking] The API has changed to be agnostic to usage (e.g. now referring to namespace paths and values
   instead of topics and settings). Functions in the `Miniconf` trait have been renamed.
 * [breaking] Errors and the Metadata struct have beem marked `#[non_exhaustive]`
+* [breaking] `metadata()`, `unchecked_iter_paths()`, `iter_paths()`, `next_path()` are
+  all associated functions now.
+* [breaking] Path iteration has been changed to move ownership of the iteration state into the iterator.
+  And the path depth is now a const generic.
+* [breaking] Path iteration will always return all paths regardless of potential runtime `miniconf::Option`
+  or deferred `Option` being `None`.
 
 ### Fixed
 * Python device discovery now only discovers unique device identifiers. See [#97](https://github.com/quartiq/miniconf/issues/97)

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -222,7 +222,7 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
         impl #impl_generics miniconf::Miniconf for #name #ty_generics #where_clause {
             fn set_path<'a, P: miniconf::Peekable<Item = &'a str>>(
                 &mut self,
-                mut path_parts: P,
+                path_parts: &'a mut P,
                 value: &[u8]
             ) -> Result<(), miniconf::Error> {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
@@ -235,7 +235,7 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
 
             fn get_path<'a, P: miniconf::Peekable<Item = &'a str>>(
                 &self,
-                mut path_parts: P,
+                path_parts: &'a mut P,
                 value: &mut [u8]
             ) -> Result<usize, miniconf::Error> {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -27,7 +27,7 @@ impl TypeDefinition {
 /// slashes.
 ///
 /// For arrays, the array index is treated as a unique identifier. That is, to access the first
-/// element of array `test`, the path would be `test/0`.
+/// element of array `data`, the path would be `data/0`.
 ///
 /// # Example
 /// ```rust
@@ -171,11 +171,12 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
     });
 
     let metadata_arms = fields.iter().enumerate().map(|(i, f)| {
+        let field_type = &f.field.ty;
         let field_name = &f.field.ident;
         if f.deferred {
             quote! {
                 #i => {
-                    let mut meta = self.#field_name.metadata();
+                    let mut meta = <#field_type>::metadata();
 
                     // Unconditionally account for separator since we add it
                     // even if elements that are deferred to (`Options`)
@@ -231,7 +232,7 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
                 }
             }
 
-            fn metadata(&self) -> miniconf::Metadata {
+            fn metadata() -> miniconf::Metadata {
                 // Loop through all child elements, collecting the maximum length + depth of any
                 // member.
                 let mut meta = miniconf::Metadata::default();

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -233,7 +233,11 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
                 }
             }
 
-            fn get_path(&self, mut path_parts: core::iter::Peekable<core::str::Split<char>>, value: &mut [u8]) -> Result<usize, miniconf::Error> {
+            fn get_path<'a, P: miniconf::Peekable<Item = &'a str>>(
+                &self,
+                mut path_parts: P,
+                value: &mut [u8]
+            ) -> Result<usize, miniconf::Error> {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
 
                 match field {

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -177,12 +177,11 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
                 #i => {
                     let mut meta = self.#field_name.metadata();
 
-                    // If the subfield has additional paths, we need to add space for a separator.
-                    if meta.max_length > 0 {
-                        meta.max_length += 1;
-                    }
-
-                    meta.max_length += stringify!(#field_name).len();
+                    // Unconditionally account for separator since we add it
+                    // even if elements that are deferred to (`Options`)
+                    // may have no further hierarchy to add and remove the separator again.
+                    meta.max_length += concat!(stringify!(#field_name), "/").len();
+                    meta.max_depth += 1;
 
                     meta
                 }
@@ -246,9 +245,6 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
                     meta.max_length = meta.max_length.max(item_meta.max_length);
                     meta.max_depth = meta.max_depth.max(item_meta.max_depth);
                 }
-
-                // We need an additional state depth for this node.
-                meta.max_depth += 1;
 
                 meta
             }

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -132,13 +132,7 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
                 #i => {
                     let original_length = path.len();
 
-                    let postfix = if path.len() != 0 {
-                        concat!("/", stringify!(#field_name))
-                    } else {
-                        stringify!(#field_name)
-                    };
-
-                    if path.push_str(postfix).is_err() {
+                    if path.push_str(concat!(stringify!(#field_name), "/")).is_err() {
                         // Note: During expected execution paths using `into_iter()`, the size of the
                         // topic buffer is checked in advance to make sure this condition doesn't
                         // occur.  However, it's possible to happen if the user manually calls
@@ -161,22 +155,14 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
         } else {
             quote! {
                 #i => {
-                    let i = state[0];
-                    state[0] += 1;
-
-                    let postfix = if path.len() != 0 {
-                        concat!("/", stringify!(#field_name))
-                    } else {
-                        stringify!(#field_name)
-                    };
-
-                    if path.push_str(postfix).is_err() {
+                    if path.push_str(stringify!(#field_name)).is_err() {
                         // Note: During expected execution paths using `into_iter()`, the size of the
                         // topic buffer is checked in advance to make sure this condition doesn't
                         // occur.  However, it's possible to happen if the user manually calls
                         // `next_path`.
                         unreachable!("Topic buffer too short");
                     }
+                    state[0] += 1;
 
                     return true;
                 }

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -127,6 +127,7 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
     });
 
     let next_path_arms = fields.iter().enumerate().map(|(i, f)| {
+        let field_type = &f.field.ty;
         let field_name = &f.field.ident;
         if f.deferred {
             quote! {
@@ -141,7 +142,7 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
                         unreachable!("Topic buffer too short");
                     }
 
-                    if self.#field_name.next_path(&mut state[1..], path) {
+                    if <#field_type>::next_path(&mut state[1..], path) {
                         return true;
                     }
 
@@ -251,7 +252,7 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
                 meta
             }
 
-            fn next_path<const TS: usize>(&self, state: &mut [usize], path: &mut miniconf::heapless::String<TS>) -> bool {
+            fn next_path<const TS: usize>(state: &mut [usize], path: &mut miniconf::heapless::String<TS>) -> bool {
                 if state.len() == 0 {
                     // Note: During expected execution paths using `into_iter()`, the size of the
                     // state stack is checked in advance to make sure this condition doesn't occur.

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -220,9 +220,11 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
 
     let expanded = quote! {
         impl #impl_generics miniconf::Miniconf for #name #ty_generics #where_clause {
-            fn set_path(&mut self, mut path_parts:
-            core::iter::Peekable<core::str::Split<char>>, value: &[u8]) ->
-            Result<(), miniconf::Error> {
+            fn set_path<'a, P: miniconf::Peekable<Item = &'a str>>(
+                &mut self,
+                mut path_parts: P,
+                value: &[u8]
+            ) -> Result<(), miniconf::Error> {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
 
                 match field {

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -97,8 +97,9 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
                         return Err(miniconf::Error::PathTooLong)
                     }
 
-                    self.#match_name = miniconf::serde_json_core::from_slice(value)?.0;
-                    Ok(())
+                    let (value, len) = miniconf::serde_json_core::from_slice(value)?;
+                    self.#match_name = value;
+                    Ok(len)
                 }
             }
         }
@@ -210,7 +211,7 @@ fn derive_struct(mut typedef: TypeDefinition, data: syn::DataStruct) -> TokenStr
                 &mut self,
                 path_parts: &'a mut P,
                 value: &[u8]
-            ) -> Result<(), miniconf::Error> {
+            ) -> Result<usize, miniconf::Error> {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
 
                 match field {

--- a/examples/readback.rs
+++ b/examples/readback.rs
@@ -22,14 +22,8 @@ fn main() {
         },
     };
 
-    // Maintains our state of iteration. This is created external from the
-    // iterator struct so that we can destroy the iterator struct, create a new
-    // one, and resume from where we left off.
-    // Perhaps we can wrap this up as some sort of templated `MiniconfIterState`
-    // type? That way we can hide what it is.
-    let mut iterator_state = [0; 5];
-
-    let mut settings_iter = s.iter_paths::<128>(&mut iterator_state).unwrap();
+    // Maintains our state of iteration.
+    let mut settings_iter = Settings::iter_paths::<5, 128>().unwrap();
 
     // Just get one topic/value from the iterator
     if let Some(topic) = settings_iter.next() {
@@ -46,8 +40,7 @@ fn main() {
     // the settings
     s.data = 3;
 
-    // Create a new settings iterator, print remaining values
-    for topic in s.iter_paths::<128>(&mut iterator_state).unwrap() {
+    for topic in settings_iter {
         let mut value = [0; 256];
         let len = s.get(&topic, &mut value).unwrap();
         println!(

--- a/src/array.rs
+++ b/src/array.rs
@@ -124,14 +124,14 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
         state: &mut [usize],
         topic: &mut heapless::String<TS>,
     ) -> bool {
-        let original_length = topic.len();
-
         // Note(unreachable): During expected execution paths using `into_iter()`, the size of the
         // index stack is checked in advance to make sure this condition doesn't occur.
         // However, it's possible to happen if the user manually calls `next_path`.
         if state.is_empty() {
             unreachable!("Index stack too small");
         }
+
+        let original_length = topic.len();
 
         while state[0] < N {
             // Add the array index to the topic name.

--- a/src/array.rs
+++ b/src/array.rs
@@ -113,11 +113,7 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
         meta
     }
 
-    fn next_path<const TS: usize>(
-        &self,
-        state: &mut [usize],
-        topic: &mut heapless::String<TS>,
-    ) -> bool {
+    fn next_path<const TS: usize>(state: &mut [usize], topic: &mut heapless::String<TS>) -> bool {
         // Note(unreachable): During expected execution paths using `into_iter()`, the size of the
         // index stack is checked in advance to make sure this condition doesn't occur.
         // However, it's possible to happen if the user manually calls `next_path`.
@@ -133,7 +129,7 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
                 unreachable!("Topic buffer too short");
             }
 
-            if self.0[state[0]].next_path(&mut state[1..], topic) {
+            if T::next_path(&mut state[1..], topic) {
                 return true;
             }
 
@@ -202,11 +198,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         }
     }
 
-    fn next_path<const TS: usize>(
-        &self,
-        state: &mut [usize],
-        path: &mut heapless::String<TS>,
-    ) -> bool {
+    fn next_path<const TS: usize>(state: &mut [usize], path: &mut heapless::String<TS>) -> bool {
         // Note(unreachable): During expected execution paths using `into_iter()`, the size of the
         // index stack is checked in advance to make sure this condition doesn't occur.
         // However, it's possible to happen if the user manually calls `next_path`.

--- a/src/array.rs
+++ b/src/array.rs
@@ -90,9 +90,9 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
         Ok(())
     }
 
-    fn get_path(
+    fn get_path<'a, P: Peekable<Item = &'a str>>(
         &self,
-        mut path_parts: core::iter::Peekable<core::str::Split<char>>,
+        mut path_parts: P,
         value: &mut [u8],
     ) -> Result<usize, Error> {
         let i = self.0.index(path_parts.next())?;
@@ -189,9 +189,9 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         Ok(())
     }
 
-    fn get_path(
+    fn get_path<'a, P: Peekable<Item = &'a str>>(
         &self,
-        mut path_parts: core::iter::Peekable<core::str::Split<char>>,
+        mut path_parts: P,
         value: &mut [u8],
     ) -> Result<usize, Error> {
         let i = self.index(path_parts.next())?;

--- a/src/array.rs
+++ b/src/array.rs
@@ -101,8 +101,8 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
             .get_path(path_parts, value)
     }
 
-    fn metadata(&self) -> Metadata {
-        let mut meta = self.0[0].metadata();
+    fn metadata() -> Metadata {
+        let mut meta = T::metadata();
 
         // Unconditionally account for separator since we add it
         // even if elements that are deferred to (`Options`)
@@ -194,7 +194,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         serde_json_core::to_slice(item, value).map_err(|_| Error::SerializationFailed)
     }
 
-    fn metadata(&self) -> Metadata {
+    fn metadata() -> Metadata {
         Metadata {
             max_length: digits(N - 1),
             max_depth: 1,

--- a/src/array.rs
+++ b/src/array.rs
@@ -135,11 +135,7 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
 
         while state[0] < N {
             // Add the array index to the topic name.
-            if topic.len() > 0 && topic.push('/').is_err() {
-                unreachable!("Topic buffer too short");
-            }
-
-            if write!(topic, "{}", state[0]).is_err() {
+            if write!(topic, "{}/", state[0]).is_err() {
                 unreachable!("Topic buffer too short");
             }
 
@@ -225,18 +221,14 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
 
         if state[0] < N {
             // Add the array index to the topic name.
-            if path.len() > 0 && path.push('/').is_err() {
-                unreachable!("Topic buffer too short");
-            }
-
             if write!(path, "{}", state[0]).is_err() {
                 unreachable!("Topic buffer too short");
             }
 
             state[0] += 1;
-            return true;
+            true
+        } else {
+            false
         }
-
-        false
     }
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -79,7 +79,7 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
         &mut self,
         path_parts: &'a mut P,
         value: &[u8],
-    ) -> Result<(), Error> {
+    ) -> Result<usize, Error> {
         let i = self.0.index(path_parts.next())?;
 
         self.0
@@ -167,7 +167,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         &mut self,
         path_parts: &mut P,
         value: &[u8],
-    ) -> Result<(), Error> {
+    ) -> Result<usize, Error> {
         let i = self.index(path_parts.next())?;
 
         if path_parts.peek().is_some() {
@@ -175,8 +175,9 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         }
 
         let item = <[T]>::get_mut(self, i).ok_or(Error::BadIndex)?;
-        *item = serde_json_core::from_slice(value)?.0;
-        Ok(())
+        let (value, len) = serde_json_core::from_slice(value)?;
+        *item = value;
+        Ok(len)
     }
 
     fn get_path<'a, P: Peekable<Item = &'a str>>(

--- a/src/array.rs
+++ b/src/array.rs
@@ -11,7 +11,7 @@
 //! `Miniconf` items, you can (and often want to) use [`Array`]. However, if each element in your list is
 //! individually configurable as a single value (e.g. a list of u32), then you must use a
 //! standard [T; N] array.
-use super::{Error, Metadata, Miniconf};
+use super::{Error, Metadata, Miniconf, Peekable};
 
 use core::fmt::Write;
 
@@ -75,9 +75,9 @@ const fn digits(x: usize) -> usize {
 }
 
 impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
-    fn set_path(
+    fn set_path<'a, P: Peekable<Item = &'a str>>(
         &mut self,
-        mut path_parts: core::iter::Peekable<core::str::Split<char>>,
+        mut path_parts: P,
         value: &[u8],
     ) -> Result<(), Error> {
         let i = self.0.index(path_parts.next())?;
@@ -173,9 +173,9 @@ impl<T, const N: usize> IndexLookup for [T; N] {
 }
 
 impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for [T; N] {
-    fn set_path(
+    fn set_path<'a, P: Peekable<Item = &'a str>>(
         &mut self,
-        mut path_parts: core::iter::Peekable<core::str::Split<char>>,
+        mut path_parts: P,
         value: &[u8],
     ) -> Result<(), Error> {
         let i = self.index(path_parts.next())?;

--- a/src/array.rs
+++ b/src/array.rs
@@ -77,7 +77,7 @@ const fn digits(x: usize) -> usize {
 impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
     fn set_path<'a, P: Peekable<Item = &'a str>>(
         &mut self,
-        mut path_parts: P,
+        path_parts: &'a mut P,
         value: &[u8],
     ) -> Result<(), Error> {
         let i = self.0.index(path_parts.next())?;
@@ -92,7 +92,7 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
 
     fn get_path<'a, P: Peekable<Item = &'a str>>(
         &self,
-        mut path_parts: P,
+        path_parts: &'a mut P,
         value: &mut [u8],
     ) -> Result<usize, Error> {
         let i = self.0.index(path_parts.next())?;
@@ -175,7 +175,7 @@ impl<T, const N: usize> IndexLookup for [T; N] {
 impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for [T; N] {
     fn set_path<'a, P: Peekable<Item = &'a str>>(
         &mut self,
-        mut path_parts: P,
+        path_parts: &mut P,
         value: &[u8],
     ) -> Result<(), Error> {
         let i = self.index(path_parts.next())?;
@@ -191,7 +191,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
 
     fn get_path<'a, P: Peekable<Item = &'a str>>(
         &self,
-        mut path_parts: P,
+        path_parts: &mut P,
         value: &mut [u8],
     ) -> Result<usize, Error> {
         let i = self.index(path_parts.next())?;

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -5,8 +5,8 @@ use heapless::String;
 /// An iterator over the paths in a Miniconf namespace.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MiniconfIter<M: ?Sized, const L: usize, const TS: usize> {
-    pub(crate) marker: PhantomData<M>,
-    pub(crate) state: [usize; L],
+    marker: PhantomData<M>,
+    state: [usize; L],
 }
 
 impl<M: ?Sized, const L: usize, const TS: usize> Default for MiniconfIter<M, L, TS> {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,19 +1,30 @@
 use super::Miniconf;
+use core::marker::PhantomData;
 use heapless::String;
 
 /// An iterator over the paths in a Miniconf namespace.
-pub struct MiniconfIter<'a, M: ?Sized, const TS: usize> {
-    pub(crate) marker: core::marker::PhantomData<M>,
-    pub(crate) state: &'a mut [usize],
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MiniconfIter<M: ?Sized, const L: usize, const TS: usize> {
+    pub(crate) marker: PhantomData<M>,
+    pub(crate) state: [usize; L],
 }
 
-impl<'a, M: Miniconf + ?Sized, const TS: usize> Iterator for MiniconfIter<'a, M, TS> {
+impl<M: ?Sized, const L: usize, const TS: usize> Default for MiniconfIter<M, L, TS> {
+    fn default() -> Self {
+        MiniconfIter {
+            marker: PhantomData,
+            state: [0; L],
+        }
+    }
+}
+
+impl<M: Miniconf + ?Sized, const L: usize, const TS: usize> Iterator for MiniconfIter<M, L, TS> {
     type Item = String<TS>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut path = Self::Item::new();
 
-        if M::next_path(self.state, &mut path) {
+        if M::next_path(&mut self.state, &mut path) {
             Some(path)
         } else {
             None

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -3,7 +3,7 @@ use heapless::String;
 
 /// An iterator over the paths in a Miniconf namespace.
 pub struct MiniconfIter<'a, M: ?Sized, const TS: usize> {
-    pub(crate) namespace: &'a M,
+    pub(crate) marker: core::marker::PhantomData<M>,
     pub(crate) state: &'a mut [usize],
 }
 
@@ -13,7 +13,7 @@ impl<'a, M: Miniconf + ?Sized, const TS: usize> Iterator for MiniconfIter<'a, M,
     fn next(&mut self) -> Option<Self::Item> {
         let mut path = Self::Item::new();
 
-        if self.namespace.next_path(self.state, &mut path) {
+        if M::next_path(self.state, &mut path) {
             Some(path)
         } else {
             None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,7 +332,7 @@ pub trait Miniconf {
         &'a self,
         state: &'a mut [usize],
     ) -> Result<iter::MiniconfIter<'a, Self, TS>, IterError> {
-        let meta = self.metadata();
+        let meta = Self::metadata();
 
         if TS < meta.max_length {
             return Err(IterError::InsufficientTopicLength);
@@ -391,5 +391,5 @@ pub trait Miniconf {
     ) -> bool;
 
     /// Get metadata about the structure.
-    fn metadata(&self) -> Metadata;
+    fn metadata() -> Metadata;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,6 +277,7 @@ pub struct Metadata {
     pub max_depth: usize,
 }
 
+/// Helper trait for `core::iter::Peekable`.
 pub trait Peekable: core::iter::Iterator {
     fn peek(&mut self) -> core::option::Option<&Self::Item>;
 }
@@ -292,7 +293,7 @@ pub trait Miniconf {
     /// Update an element by path.
     ///
     /// # Args
-    /// * `path` - The path to the element.
+    /// * `path` - The path to the element. With '/' as separator.
     /// * `data` - The serialized data making up the content.
     ///
     /// # Returns
@@ -304,7 +305,7 @@ pub trait Miniconf {
     /// Retrieve a serialized value by path.
     ///
     /// # Args
-    /// * `path` - The path to the element.
+    /// * `path` - The path to the element. With '/' as separator.
     /// * `data` - The buffer to serialize the data into.
     ///
     /// # Returns

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@
 //! settings.set("filter/backward", b"0.15").unwrap();
 //!
 //! // Update the gains simultaneously
-//! settings.set("gain", b"[1.0, 2.0]").unwrap()
+//! settings.set("gain", b"[1.0, 2.0]").unwrap();
 //! ```
 //!
 //! ## Limitations
@@ -298,7 +298,7 @@ pub trait Miniconf {
     ///
     /// # Returns
     /// The result of the configuration operation.
-    fn set(&mut self, path: &str, data: &[u8]) -> Result<(), Error> {
+    fn set(&mut self, path: &str, data: &[u8]) -> Result<usize, Error> {
         self.set_path(&mut path.split('/').peekable(), data)
     }
 
@@ -376,7 +376,7 @@ pub trait Miniconf {
         &mut self,
         path_parts: &'a mut P,
         value: &[u8],
-    ) -> Result<(), Error>;
+    ) -> Result<usize, Error>;
 
     fn get_path<'a, P: Peekable<Item = &'a str>>(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,7 +296,7 @@ pub trait Miniconf {
     /// * `data` - The serialized data making up the content.
     ///
     /// # Returns
-    /// The result of the configuration operation.
+    /// The number of bytes consumed from `data` or an `Error`.
     fn set(&mut self, path: &str, data: &[u8]) -> Result<usize, Error> {
         self.set_path(&mut path.split('/').peekable(), data)
     }
@@ -308,7 +308,7 @@ pub trait Miniconf {
     /// * `data` - The buffer to serialize the data into.
     ///
     /// # Returns
-    /// The number of bytes used in the `data` buffer for serialization.
+    /// The number of bytes used in the `data` buffer or an `Error`.
     fn get(&self, path: &str, data: &mut [u8]) -> Result<usize, Error> {
         self.get_path(&mut path.split('/').peekable(), data)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,9 +377,9 @@ pub trait Miniconf {
         value: &[u8],
     ) -> Result<(), Error>;
 
-    fn get_path(
+    fn get_path<'a, P: Peekable<Item = &'a str>>(
         &self,
-        path_parts: core::iter::Peekable<core::str::Split<char>>,
+        path_parts: P,
         value: &mut [u8],
     ) -> Result<usize, Error>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ pub trait Miniconf {
     /// # Returns
     /// The result of the configuration operation.
     fn set(&mut self, path: &str, data: &[u8]) -> Result<(), Error> {
-        self.set_path(path.split('/').peekable(), data)
+        self.set_path(&mut path.split('/').peekable(), data)
     }
 
     /// Retrieve a serialized value by path.
@@ -310,7 +310,7 @@ pub trait Miniconf {
     /// # Returns
     /// The number of bytes used in the `data` buffer for serialization.
     fn get(&self, path: &str, data: &mut [u8]) -> Result<usize, Error> {
-        self.get_path(path.split('/').peekable(), data)
+        self.get_path(&mut path.split('/').peekable(), data)
     }
 
     /// Create an iterator of all possible paths.
@@ -373,13 +373,13 @@ pub trait Miniconf {
 
     fn set_path<'a, P: Peekable<Item = &'a str>>(
         &mut self,
-        path_parts: P,
+        path_parts: &'a mut P,
         value: &[u8],
     ) -> Result<(), Error>;
 
     fn get_path<'a, P: Peekable<Item = &'a str>>(
         &self,
-        path_parts: P,
+        path_parts: &'a mut P,
         value: &mut [u8],
     ) -> Result<usize, Error>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,12 @@ pub enum Error {
     ///
     /// Check array indices to ensure that bounds for all paths are respected.
     BadIndex,
+
+    /// The path does not exist at runtime.
+    ///
+    /// This is the case if a deferred `core::option::Option` or `miniconf::Option`
+    /// is `None` at runtime.
+    PathAbsent,
 }
 
 /// Errors that occur during iteration over topic paths.
@@ -255,6 +261,7 @@ impl From<Error> for u8 {
             Error::Deserialization(_) => 5,
             Error::BadIndex => 6,
             Error::SerializationFailed => 7,
+            Error::PathAbsent => 8,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ pub trait Miniconf {
     /// Update an element by path.
     ///
     /// # Args
-    /// * `path` - The path to the element. With '/' as separator.
+    /// * `path` - The path to the element with '/' as the separator.
     /// * `data` - The serialized data making up the content.
     ///
     /// # Returns
@@ -304,7 +304,7 @@ pub trait Miniconf {
     /// Retrieve a serialized value by path.
     ///
     /// # Args
-    /// * `path` - The path to the element. With '/' as separator.
+    /// * `path` - The path to the element with '/' as the separator.
     /// * `data` - The buffer to serialize the data into.
     ///
     /// # Returns

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,7 @@ pub trait Miniconf {
         state: &'a mut [usize],
     ) -> iter::MiniconfIter<'a, Self, TS> {
         iter::MiniconfIter {
-            namespace: self,
+            marker: core::marker::PhantomData,
             state,
         }
     }
@@ -384,11 +384,7 @@ pub trait Miniconf {
         value: &mut [u8],
     ) -> Result<usize, Error>;
 
-    fn next_path<const TS: usize>(
-        &self,
-        state: &mut [usize],
-        path: &mut heapless::String<TS>,
-    ) -> bool;
+    fn next_path<const TS: usize>(state: &mut [usize], path: &mut heapless::String<TS>) -> bool;
 
     /// Get metadata about the structure.
     fn metadata() -> Metadata;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,6 +277,16 @@ pub struct Metadata {
     pub max_depth: usize,
 }
 
+pub trait Peekable: core::iter::Iterator {
+    fn peek(&mut self) -> core::option::Option<&Self::Item>;
+}
+
+impl<I: core::iter::Iterator> Peekable for core::iter::Peekable<I> {
+    fn peek(&mut self) -> core::option::Option<&Self::Item> {
+        core::iter::Peekable::peek(self)
+    }
+}
+
 /// Derive-able trait for structures that can be mutated using serialized paths and values.
 pub trait Miniconf {
     /// Update an element by path.
@@ -361,9 +371,9 @@ pub trait Miniconf {
         }
     }
 
-    fn set_path(
+    fn set_path<'a, P: Peekable<Item = &'a str>>(
         &mut self,
-        path_parts: core::iter::Peekable<core::str::Split<char>>,
+        path_parts: P,
         value: &[u8],
     ) -> Result<(), Error>;
 

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -177,7 +177,7 @@ where
         let mut settings_prefix: String<MAX_TOPIC_LENGTH> = String::from(prefix);
         settings_prefix.push_str("/settings").unwrap();
 
-        assert!(settings_prefix.len() + 1 + settings.metadata().max_length <= MAX_TOPIC_LENGTH);
+        assert!(settings_prefix.len() + 1 + Settings::metadata().max_length <= MAX_TOPIC_LENGTH);
 
         Ok(Self {
             mqtt,

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -384,21 +384,20 @@ where
             };
 
             let mut new_settings = settings.clone();
-            let message: SettingsResponse =
-                match new_settings.set_path(&mut path.split('/').peekable(), message) {
-                    Ok(_) => {
-                        updated = true;
-                        handler(path, settings, &new_settings).into()
+            let message: SettingsResponse = match new_settings.set(path, message) {
+                Ok(_) => {
+                    updated = true;
+                    handler(path, settings, &new_settings).into()
+                }
+                err => {
+                    let mut msg = String::new();
+                    if write!(&mut msg, "{:?}", err).is_err() {
+                        msg = String::from("Configuration Error");
                     }
-                    err => {
-                        let mut msg = String::new();
-                        if write!(&mut msg, "{:?}", err).is_err() {
-                            msg = String::from("Configuration Error");
-                        }
 
-                        SettingsResponse::error(msg)
-                    }
-                };
+                    SettingsResponse::error(msg)
+                }
+            };
 
             let response = MqttMessage::new(properties, default_response_topic, &message);
 

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -198,9 +198,9 @@ where
         for topic in &mut self.state.context_mut().republish_state {
             let mut data = [0; MESSAGE_SIZE];
 
-            // Note: The topic may not exist at runtime (`miniconf::Option` or deferred `Option`).
+            // Note: The topic may be absent at runtime (`miniconf::Option` or deferred `Option`).
             let len = match self.settings.get(&topic, &mut data) {
-                Err(crate::Error::PathNotFound) => continue,
+                Err(crate::Error::PathAbsent) => continue,
                 Ok(len) => len,
                 e => e.unwrap(),
             };

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -385,7 +385,7 @@ where
 
             let mut new_settings = settings.clone();
             let message: SettingsResponse =
-                match new_settings.set_path(path.split('/').peekable(), message) {
+                match new_settings.set_path(&mut path.split('/').peekable(), message) {
                     Ok(_) => {
                         updated = true;
                         handler(path, settings, &new_settings).into()

--- a/src/option.rs
+++ b/src/option.rs
@@ -70,9 +70,9 @@ impl<T: Miniconf> Miniconf for Option<T> {
         })
     }
 
-    fn get_path(
+    fn get_path<'a, P: Peekable<Item = &'a str>>(
         &self,
-        path_parts: core::iter::Peekable<core::str::Split<char>>,
+        path_parts: P,
         value: &mut [u8],
     ) -> Result<usize, Error> {
         self.0.as_ref().map_or(Err(Error::PathNotFound), |inner| {
@@ -113,9 +113,9 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
         Ok(())
     }
 
-    fn get_path(
+    fn get_path<'a, P: Peekable<Item = &'a str>>(
         &self,
-        mut path_parts: core::iter::Peekable<core::str::Split<char>>,
+        mut path_parts: P,
         value: &mut [u8],
     ) -> Result<usize, Error> {
         if path_parts.peek().is_some() {

--- a/src/option.rs
+++ b/src/option.rs
@@ -99,7 +99,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
         self.0
             .as_ref()
             .map(|value| value.next_path(state, path))
-            .unwrap_or(false)
+            .unwrap_or_default()
     }
 }
 
@@ -146,10 +146,15 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
     fn next_path<const TS: usize>(
         &self,
         state: &mut [usize],
-        _path: &mut heapless::String<TS>,
+        path: &mut heapless::String<TS>,
     ) -> bool {
         if self.is_some() && state[0] == 0 {
             state[0] += 1;
+
+            // Remove trailing slash added by a deferring container (array or struct).
+            if path.ends_with('/') {
+                path.pop();
+            }
             true
         } else {
             false

--- a/src/option.rs
+++ b/src/option.rs
@@ -64,7 +64,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
         &mut self,
         path_parts: &'a mut P,
         value: &[u8],
-    ) -> Result<(), Error> {
+    ) -> Result<usize, Error> {
         if let Some(inner) = self.0.as_mut() {
             inner.set_path(path_parts, value)
         } else {
@@ -105,7 +105,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
         &mut self,
         path_parts: &mut P,
         value: &[u8],
-    ) -> Result<(), Error> {
+    ) -> Result<usize, Error> {
         if self.is_none() {
             return Err(Error::PathNotFound);
         }
@@ -114,8 +114,9 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
             return Err(Error::PathTooLong);
         }
 
-        *self = Some(serde_json_core::from_slice(value)?.0);
-        Ok(())
+        let (value, len) = serde_json_core::from_slice(value)?;
+        *self = Some(value);
+        Ok(len)
     }
 
     fn get_path<'a, P: Peekable<Item = &'a str>>(

--- a/src/option.rs
+++ b/src/option.rs
@@ -84,11 +84,8 @@ impl<T: Miniconf> Miniconf for Option<T> {
         }
     }
 
-    fn metadata(&self) -> Metadata {
-        self.0
-            .as_ref()
-            .map(|value| value.metadata())
-            .unwrap_or_default()
+    fn metadata() -> Metadata {
+        T::metadata()
     }
 
     fn next_path<const TS: usize>(
@@ -139,7 +136,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
             .map_err(|_| Error::SerializationFailed)
     }
 
-    fn metadata(&self) -> Metadata {
+    fn metadata() -> Metadata {
         Metadata::default()
     }
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -106,7 +106,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
 impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::Option<T> {
     fn set_path<'a, P: Peekable<Item = &'a str>>(
         &mut self,
-        path_parts: &'a mut P,
+        path_parts: &mut P,
         value: &[u8],
     ) -> Result<(), Error> {
         if path_parts.peek().is_some() {
@@ -119,7 +119,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
 
     fn get_path<'a, P: Peekable<Item = &'a str>>(
         &self,
-        path_parts: &'a mut P,
+        path_parts: &mut P,
         value: &mut [u8],
     ) -> Result<usize, Error> {
         if path_parts.peek().is_some() {

--- a/src/option.rs
+++ b/src/option.rs
@@ -62,22 +62,26 @@ impl<T: Copy> Copy for Option<T> {}
 impl<T: Miniconf> Miniconf for Option<T> {
     fn set_path<'a, P: Peekable<Item = &'a str>>(
         &mut self,
-        path_parts: P,
+        path_parts: &'a mut P,
         value: &[u8],
     ) -> Result<(), Error> {
-        self.0.as_mut().map_or(Err(Error::PathNotFound), |inner| {
+        if let Some(inner) = self.0.as_mut() {
             inner.set_path(path_parts, value)
-        })
+        } else {
+            Err(Error::PathNotFound)
+        }
     }
 
     fn get_path<'a, P: Peekable<Item = &'a str>>(
         &self,
-        path_parts: P,
+        path_parts: &'a mut P,
         value: &mut [u8],
     ) -> Result<usize, Error> {
-        self.0.as_ref().map_or(Err(Error::PathNotFound), |inner| {
+        if let Some(inner) = self.0.as_ref() {
             inner.get_path(path_parts, value)
-        })
+        } else {
+            Err(Error::PathNotFound)
+        }
     }
 
     fn metadata(&self) -> Metadata {
@@ -102,7 +106,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
 impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::Option<T> {
     fn set_path<'a, P: Peekable<Item = &'a str>>(
         &mut self,
-        mut path_parts: P,
+        path_parts: &'a mut P,
         value: &[u8],
     ) -> Result<(), Error> {
         if path_parts.peek().is_some() {
@@ -115,7 +119,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
 
     fn get_path<'a, P: Peekable<Item = &'a str>>(
         &self,
-        mut path_parts: P,
+        path_parts: &'a mut P,
         value: &mut [u8],
     ) -> Result<usize, Error> {
         if path_parts.peek().is_some() {

--- a/src/option.rs
+++ b/src/option.rs
@@ -88,15 +88,8 @@ impl<T: Miniconf> Miniconf for Option<T> {
         T::metadata()
     }
 
-    fn next_path<const TS: usize>(
-        &self,
-        state: &mut [usize],
-        path: &mut heapless::String<TS>,
-    ) -> bool {
-        self.0
-            .as_ref()
-            .map(|value| value.next_path(state, path))
-            .unwrap_or_default()
+    fn next_path<const TS: usize>(state: &mut [usize], path: &mut heapless::String<TS>) -> bool {
+        T::next_path(state, path)
     }
 }
 
@@ -141,12 +134,8 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
         Metadata::default()
     }
 
-    fn next_path<const TS: usize>(
-        &self,
-        state: &mut [usize],
-        path: &mut heapless::String<TS>,
-    ) -> bool {
-        if self.is_some() && state[0] == 0 {
+    fn next_path<const TS: usize>(state: &mut [usize], path: &mut heapless::String<TS>) -> bool {
+        if state[0] == 0 {
             state[0] += 1;
 
             // Remove trailing slash added by a deferring container (array or struct).

--- a/src/option.rs
+++ b/src/option.rs
@@ -121,7 +121,6 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
             return Err(Error::PathTooLong);
         }
 
-        // Note(unwrap): checked above
         let data = self.as_ref().ok_or(Error::PathAbsent)?;
         serde_json_core::to_slice(data, value).map_err(|_| Error::SerializationFailed)
     }

--- a/src/option.rs
+++ b/src/option.rs
@@ -15,7 +15,7 @@
 //!
 //! Miniconf also allows for the normal usage of Rust `Option` types. In this case, the `Option`
 //! can be used to atomically access the nullable content within.
-use super::{Error, Metadata, Miniconf};
+use super::{Error, Metadata, Miniconf, Peekable};
 
 /// An `Option` that exposes its value through their [`Miniconf`](trait.Miniconf.html) implementation.
 pub struct Option<T>(pub core::option::Option<T>);
@@ -60,9 +60,9 @@ impl<T: Clone> Clone for Option<T> {
 impl<T: Copy> Copy for Option<T> {}
 
 impl<T: Miniconf> Miniconf for Option<T> {
-    fn set_path(
+    fn set_path<'a, P: Peekable<Item = &'a str>>(
         &mut self,
-        path_parts: core::iter::Peekable<core::str::Split<char>>,
+        path_parts: P,
         value: &[u8],
     ) -> Result<(), Error> {
         self.0.as_mut().map_or(Err(Error::PathNotFound), |inner| {
@@ -100,9 +100,9 @@ impl<T: Miniconf> Miniconf for Option<T> {
 }
 
 impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::Option<T> {
-    fn set_path(
+    fn set_path<'a, P: Peekable<Item = &'a str>>(
         &mut self,
-        mut path_parts: core::iter::Peekable<core::str::Split<char>>,
+        mut path_parts: P,
         value: &[u8],
     ) -> Result<(), Error> {
         if path_parts.peek().is_some() {

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -97,7 +97,7 @@ fn array_of_structs_indexing() {
 
     // Test metadata
     let metadata = s.metadata();
-    assert_eq!(metadata.max_depth, 4);
+    assert_eq!(metadata.max_depth, 3);
     assert_eq!(metadata.max_length, "a/2/b".len());
 }
 

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -24,17 +24,14 @@ fn simple_array() {
     let mut s = S::default();
 
     // Updating a single field should succeed.
-    let field = "a/0".split('/').peekable();
-    s.set_path(field, "99".as_bytes()).unwrap();
+    s.set("a/0", "99".as_bytes()).unwrap();
     assert_eq!(99, s.a[0]);
 
     // Updating entire array atomically is not supported.
-    let field = "a".split('/').peekable();
-    assert!(s.set_path(field, "[1,2,3]".as_bytes()).is_err());
+    assert!(s.set("a", "[1,2,3]".as_bytes()).is_err());
 
     // Invalid index should generate an error.
-    let field = "a/100".split('/').peekable();
-    assert!(s.set_path(field, "99".as_bytes()).is_err());
+    assert!(s.set("a/100", "99".as_bytes()).is_err());
 }
 
 #[test]
@@ -47,9 +44,7 @@ fn nonexistent_field() {
 
     let mut s = S::default();
 
-    let field = "a/b/1".split('/').peekable();
-
-    assert!(s.set_path(field, "7".as_bytes()).is_err());
+    assert!(s.set("a/1/b", "7".as_bytes()).is_err());
 }
 
 #[test]
@@ -62,18 +57,12 @@ fn simple_array_indexing() {
 
     let mut s = S::default();
 
-    let field = "a/1".split('/').peekable();
-
-    s.set_path(field, "7".as_bytes()).unwrap();
+    s.set("a/1", "7".as_bytes()).unwrap();
 
     assert_eq!([0, 7, 0], s.a);
 
     // Ensure that setting an out-of-bounds index generates an error.
-    let field = "a/3".split('/').peekable();
-    assert_eq!(
-        s.set_path(field, "7".as_bytes()).unwrap_err(),
-        Error::BadIndex
-    );
+    assert_eq!(s.set("a/3", "7".as_bytes()).unwrap_err(), Error::BadIndex);
 
     // Test metadata
     let metadata = s.metadata();
@@ -96,9 +85,7 @@ fn array_of_structs_indexing() {
 
     let mut s = S::default();
 
-    let field = "a/1/b".split('/').peekable();
-
-    s.set_path(field, "7".as_bytes()).unwrap();
+    s.set("a/1/b", "7".as_bytes()).unwrap();
 
     let expected = {
         let mut e = S::default();
@@ -124,8 +111,7 @@ fn array_of_arrays() {
 
     let mut s = S::default();
 
-    let field = "data/0/0".split('/').peekable();
-    s.set_path(field, "7".as_bytes()).unwrap();
+    s.set("data/0/0", "7".as_bytes()).unwrap();
 
     let expected = {
         let mut e = S::default();
@@ -145,8 +131,7 @@ fn atomic_array() {
 
     let mut s = S::default();
 
-    let field = "data".split('/').peekable();
-    s.set_path(field, "[1, 2]".as_bytes()).unwrap();
+    s.set("data", "[1, 2]".as_bytes()).unwrap();
 
     let expected = {
         let mut e = S::default();

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -65,7 +65,7 @@ fn simple_array_indexing() {
     assert_eq!(s.set("a/3", "7".as_bytes()).unwrap_err(), Error::BadIndex);
 
     // Test metadata
-    let metadata = s.metadata();
+    let metadata = S::metadata();
     assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_length, "a/2".len());
 }
@@ -96,7 +96,7 @@ fn array_of_structs_indexing() {
     assert_eq!(expected, s);
 
     // Test metadata
-    let metadata = s.metadata();
+    let metadata = S::metadata();
     assert_eq!(metadata.max_depth, 3);
     assert_eq!(metadata.max_length, "a/2/b".len());
 }
@@ -152,7 +152,7 @@ fn short_array() {
     }
 
     // Test metadata
-    let meta = S::default().metadata();
+    let meta = S::metadata();
     assert_eq!(meta.max_depth, 2);
     assert_eq!(meta.max_length, "data/0".len());
 }
@@ -166,5 +166,5 @@ fn null_array() {
         #[miniconf(defer)]
         data: [u32; 0],
     }
-    let _meta = S::default().metadata();
+    let _meta = S::metadata();
 }

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -16,9 +16,7 @@ fn simple_enum() {
 
     let mut s = S { v: Variant::A };
 
-    let field = "v".split('/').peekable();
-
-    s.set_path(field, "\"B\"".as_bytes()).unwrap();
+    s.set("v", "\"B\"".as_bytes()).unwrap();
 
     assert_eq!(s.v, Variant::B);
 
@@ -43,7 +41,5 @@ fn invalid_enum() {
 
     let mut s = S { v: Variant::A };
 
-    let field = "v".split('/').peekable();
-
-    assert!(s.set_path(field, "\"C\"".as_bytes()).is_err());
+    assert!(s.set("v", "\"C\"".as_bytes()).is_err());
 }

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -22,7 +22,7 @@ fn simple_enum() {
 
     // Test metadata
     let metadata = s.metadata();
-    assert_eq!(metadata.max_depth, 2);
+    assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "v".len());
 }
 

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -21,7 +21,7 @@ fn simple_enum() {
     assert_eq!(s.v, Variant::B);
 
     // Test metadata
-    let metadata = s.metadata();
+    let metadata = S::metadata();
     assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "v".len());
 }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -9,9 +9,7 @@ fn generic_type() {
     }
 
     let mut settings = Settings::<f32>::default();
-    settings
-        .set_path("data".split('/').peekable(), b"3.0")
-        .unwrap();
+    settings.set("data", b"3.0").unwrap();
     assert_eq!(settings.data, 3.0);
 
     // Test metadata
@@ -29,9 +27,7 @@ fn generic_array() {
     }
 
     let mut settings = Settings::<f32>::default();
-    settings
-        .set_path("data/0".split('/').peekable(), b"3.0")
-        .unwrap();
+    settings.set("data/0", b"3.0").unwrap();
 
     assert_eq!(settings.data[0], 3.0);
 
@@ -54,9 +50,7 @@ fn generic_struct() {
     }
 
     let mut settings = Settings::<Inner>::default();
-    settings
-        .set_path("inner".split('/').peekable(), b"{\"data\": 3.0}")
-        .unwrap();
+    settings.set("inner", b"{\"data\": 3.0}").unwrap();
 
     assert_eq!(settings.inner.data, 3.0);
 
@@ -80,10 +74,7 @@ fn generic_atomic() {
 
     let mut settings = Settings::<f32>::default();
     settings
-        .set_path(
-            "atomic".split('/').peekable(),
-            b"{\"inner\": [3.0, 0, 0, 0, 0]}",
-        )
+        .set("atomic", b"{\"inner\": [3.0, 0, 0, 0, 0]}")
         .unwrap();
 
     assert_eq!(settings.atomic.inner[0], 3.0);

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -13,7 +13,7 @@ fn generic_type() {
     assert_eq!(settings.data, 3.0);
 
     // Test metadata
-    let metadata = settings.metadata();
+    let metadata = Settings::<f32>::metadata();
     assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "data".len());
 }
@@ -32,7 +32,7 @@ fn generic_array() {
     assert_eq!(settings.data[0], 3.0);
 
     // Test metadata
-    let metadata = settings.metadata();
+    let metadata = Settings::<f32>::metadata();
     assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_length, "data/0".len());
 }
@@ -55,7 +55,7 @@ fn generic_struct() {
     assert_eq!(settings.inner.data, 3.0);
 
     // Test metadata
-    let metadata = settings.metadata();
+    let metadata = Settings::<Inner>::metadata();
     assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "inner".len());
 }
@@ -80,7 +80,7 @@ fn generic_atomic() {
     assert_eq!(settings.atomic.inner[0], 3.0);
 
     // Test metadata
-    let metadata = settings.metadata();
+    let metadata = Settings::<f32>::metadata();
     assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "atomic".len());
 }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -14,7 +14,7 @@ fn generic_type() {
 
     // Test metadata
     let metadata = settings.metadata();
-    assert_eq!(metadata.max_depth, 2);
+    assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "data".len());
 }
 
@@ -56,7 +56,7 @@ fn generic_struct() {
 
     // Test metadata
     let metadata = settings.metadata();
-    assert_eq!(metadata.max_depth, 2);
+    assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "inner".len());
 }
 
@@ -81,6 +81,6 @@ fn generic_atomic() {
 
     // Test metadata
     let metadata = settings.metadata();
-    assert_eq!(metadata.max_depth, 2);
+    assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "atomic".len());
 }

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -15,32 +15,26 @@ struct Settings {
 
 #[test]
 fn insufficient_space() {
-    let settings = Settings::default();
     let meta = Settings::metadata();
     assert_eq!(meta.max_depth, 2);
     assert_eq!(meta.max_length, "c/inner".len());
 
     // Ensure that we can't iterate if we make a state vector that is too small.
-    let mut small_state = [0; 1];
-    assert!(settings.iter_paths::<256>(&mut small_state).is_err());
+    assert!(Settings::iter_paths::<1, 256>().is_err());
 
     // Ensure that we can't iterate if the topic buffer is too small.
-    let mut state = [0; 10];
-    assert!(settings.iter_paths::<1>(&mut state).is_err());
+    assert!(Settings::iter_paths::<10, 1>().is_err());
 }
 
 #[test]
 fn test_iteration() {
-    let settings = Settings::default();
-
     let mut iterated = std::collections::HashMap::from([
         ("a".to_string(), false),
         ("b".to_string(), false),
         ("c/inner".to_string(), false),
     ]);
 
-    let mut iter_state = [0; 32];
-    for field in settings.iter_paths::<256>(&mut iter_state).unwrap() {
+    for field in Settings::iter_paths::<32, 256>().unwrap() {
         assert!(iterated.contains_key(&field.as_str().to_string()));
         iterated.insert(field.as_str().to_string(), true);
     }
@@ -57,13 +51,11 @@ fn test_array_iteration() {
         data: [bool; 5],
     }
 
-    let settings = Settings::default();
-    let mut settings_copy = Settings::default();
+    let mut settings = Settings::default();
 
-    let mut iter_state = [0; 32];
-    for field in settings.iter_paths::<256>(&mut iter_state).unwrap() {
-        settings_copy.set(&field, b"true").unwrap();
+    for field in Settings::iter_paths::<32, 256>().unwrap() {
+        settings.set(&field, b"true").unwrap();
     }
 
-    assert!(settings_copy.data.iter().all(|x| *x));
+    assert!(settings.data.iter().all(|x| *x));
 }

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -17,11 +17,11 @@ struct Settings {
 fn insufficient_space() {
     let settings = Settings::default();
     let meta = settings.metadata();
-    assert_eq!(meta.max_depth, 3);
+    assert_eq!(meta.max_depth, 2);
     assert_eq!(meta.max_length, "c/inner".len());
 
     // Ensure that we can't iterate if we make a state vector that is too small.
-    let mut small_state = [0; 2];
+    let mut small_state = [0; 1];
     assert!(settings.iter_paths::<256>(&mut small_state).is_err());
 
     // Ensure that we can't iterate if the topic buffer is too small.

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -16,7 +16,7 @@ struct Settings {
 #[test]
 fn insufficient_space() {
     let settings = Settings::default();
-    let meta = settings.metadata();
+    let meta = Settings::metadata();
     assert_eq!(meta.max_depth, 2);
     assert_eq!(meta.max_length, "c/inner".len());
 

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -41,10 +41,11 @@ fn option_get_set_some() {
 fn option_iterate_some_none() {
     let mut settings = Settings::default();
 
-    // When the value is None, it should not be iterated over as a topic.
+    // When the value is None, it will still be iterated over as a topic but may not exist at runtime.
     let mut state = [0; 10];
     settings.value.take();
     let mut iterator = settings.iter_paths::<128>(&mut state).unwrap();
+    assert_eq!(iterator.next().unwrap(), "value/data");
     assert!(iterator.next().is_none());
 
     // When the value is Some, it should be iterated over.
@@ -52,6 +53,7 @@ fn option_iterate_some_none() {
     settings.value.replace(Inner { data: 5 });
     let mut iterator = settings.iter_paths::<128>(&mut state).unwrap();
     assert_eq!(iterator.next().unwrap(), "value/data");
+    assert!(iterator.next().is_none());
 }
 
 #[test]
@@ -94,6 +96,7 @@ fn option_test_defer_option() {
 
     let mut state = [0; 10];
     let mut iterator = s.iter_paths::<128>(&mut state).unwrap();
+    assert_eq!(iterator.next(), Some("data".into()));
     assert!(iterator.next().is_none());
 
     assert!(s.set("data", b"7").is_err());

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -42,16 +42,14 @@ fn option_iterate_some_none() {
     let mut settings = Settings::default();
 
     // When the value is None, it will still be iterated over as a topic but may not exist at runtime.
-    let mut state = [0; 10];
     settings.value.take();
-    let mut iterator = settings.iter_paths::<128>(&mut state).unwrap();
+    let mut iterator = Settings::iter_paths::<10, 128>().unwrap();
     assert_eq!(iterator.next().unwrap(), "value/data");
     assert!(iterator.next().is_none());
 
     // When the value is Some, it should be iterated over.
-    let mut state = [0; 10];
     settings.value.replace(Inner { data: 5 });
-    let mut iterator = settings.iter_paths::<128>(&mut state).unwrap();
+    let mut iterator = Settings::iter_paths::<10, 128>().unwrap();
     assert_eq!(iterator.next().unwrap(), "value/data");
     assert!(iterator.next().is_none());
 }
@@ -66,16 +64,14 @@ fn option_test_normal_option() {
     let mut s = S::default();
     assert!(s.data.is_none());
 
-    let mut state = [0; 10];
-    let mut iterator = s.iter_paths::<128>(&mut state).unwrap();
+    let mut iterator = S::iter_paths::<10, 128>().unwrap();
     assert_eq!(iterator.next(), Some("data".into()));
     assert!(iterator.next().is_none());
 
     s.set("data", b"7").unwrap();
     assert_eq!(s.data, Some(7));
 
-    let mut state = [0; 10];
-    let mut iterator = s.iter_paths::<128>(&mut state).unwrap();
+    let mut iterator = S::iter_paths::<10, 128>().unwrap();
     assert_eq!(iterator.next(), Some("data".into()));
     assert!(iterator.next().is_none());
 
@@ -94,8 +90,7 @@ fn option_test_defer_option() {
     let mut s = S::default();
     assert!(s.data.is_none());
 
-    let mut state = [0; 10];
-    let mut iterator = s.iter_paths::<128>(&mut state).unwrap();
+    let mut iterator = S::iter_paths::<10, 128>().unwrap();
     assert_eq!(iterator.next(), Some("data".into()));
     assert!(iterator.next().is_none());
 
@@ -104,8 +99,7 @@ fn option_test_defer_option() {
     s.set("data", b"7").unwrap();
     assert_eq!(s.data, Some(7));
 
-    let mut state = [0; 10];
-    let mut iterator = s.iter_paths::<128>(&mut state).unwrap();
+    let mut iterator = S::iter_paths::<10, 128>().unwrap();
     assert_eq!(iterator.next(), Some("data".into()));
     assert!(iterator.next().is_none());
 

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -62,19 +62,49 @@ fn option_test_normal_option() {
     }
 
     let mut s = S::default();
-    s.data.take();
+    assert!(s.data.is_none());
 
     let mut state = [0; 10];
     let mut iterator = s.iter_paths::<128>(&mut state).unwrap();
-    assert!(iterator.next().is_some());
+    assert_eq!(iterator.next(), Some("data".into()));
+    assert!(iterator.next().is_none());
 
     s.set("data", b"7").unwrap();
-    assert_eq!(s.data.unwrap(), 7);
+    assert_eq!(s.data, Some(7));
 
     let mut state = [0; 10];
     let mut iterator = s.iter_paths::<128>(&mut state).unwrap();
-    assert!(iterator.next().is_some());
+    assert_eq!(iterator.next(), Some("data".into()));
+    assert!(iterator.next().is_none());
 
     s.set("data", b"null").unwrap();
     assert!(s.data.is_none());
+}
+
+#[test]
+fn option_test_defer_option() {
+    #[derive(Copy, Clone, Default, Miniconf)]
+    struct S {
+        #[miniconf(defer)]
+        data: Option<u32>,
+    }
+
+    let mut s = S::default();
+    assert!(s.data.is_none());
+
+    let mut state = [0; 10];
+    let mut iterator = s.iter_paths::<128>(&mut state).unwrap();
+    assert!(iterator.next().is_none());
+
+    assert!(s.set("data", b"7").is_err());
+    s.data = Some(0);
+    s.set("data", b"7").unwrap();
+    assert_eq!(s.data, Some(7));
+
+    let mut state = [0; 10];
+    let mut iterator = s.iter_paths::<128>(&mut state).unwrap();
+    assert_eq!(iterator.next(), Some("data".into()));
+    assert!(iterator.next().is_none());
+
+    assert!(s.set("data", b"null").is_err());
 }

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -34,7 +34,7 @@ fn atomic_struct() {
     assert_eq!(settings, expected);
 
     // Check that metadata is correct.
-    let metadata = settings.metadata();
+    let metadata = Settings::metadata();
     assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "c".len());
 }
@@ -69,7 +69,7 @@ fn recursive_struct() {
     assert!(settings.set("c", b"{\"a\": 5}").is_err());
 
     // Check that metadata is correct.
-    let metadata = settings.metadata();
+    let metadata = Settings::metadata();
     assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_length, "c/a".len());
 }

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -35,7 +35,7 @@ fn atomic_struct() {
 
     // Check that metadata is correct.
     let metadata = settings.metadata();
-    assert_eq!(metadata.max_depth, 2);
+    assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "c".len());
 }
 
@@ -70,7 +70,7 @@ fn recursive_struct() {
 
     // Check that metadata is correct.
     let metadata = settings.metadata();
-    assert_eq!(metadata.max_depth, 3);
+    assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_length, "c/a".len());
 }
 

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -18,14 +18,11 @@ fn atomic_struct() {
 
     let mut settings = Settings::default();
 
-    let field = "c/a".split('/').peekable();
-
     // Inner settings structure is atomic, so cannot be set.
-    assert!(settings.set_path(field, b"4").is_err());
+    assert!(settings.set("c/a", b"4").is_err());
 
     // Inner settings can be updated atomically.
-    let field = "c".split('/').peekable();
-    settings.set_path(field, b"{\"a\": 5, \"b\": 3}").unwrap();
+    settings.set("c", b"{\"a\": 5, \"b\": 3}").unwrap();
 
     let expected = {
         let mut expected = Settings::default();
@@ -59,9 +56,7 @@ fn recursive_struct() {
 
     let mut settings = Settings::default();
 
-    let field = "c/a".split('/').peekable();
-
-    settings.set_path(field, b"3").unwrap();
+    settings.set("c/a", b"3").unwrap();
     let expected = {
         let mut expected = Settings::default();
         expected.c.a = 3;
@@ -71,8 +66,7 @@ fn recursive_struct() {
     assert_eq!(settings, expected);
 
     // It is not allowed to set a non-terminal node.
-    let field = "c".split('/').peekable();
-    assert!(settings.set_path(field, b"{\"a\": 5}").is_err());
+    assert!(settings.set("c", b"{\"a\": 5}").is_err());
 
     // Check that metadata is correct.
     let metadata = settings.metadata();
@@ -89,12 +83,10 @@ fn struct_with_string() {
 
     let mut s = Settings::default();
 
-    let field = "string".split('/').peekable();
     let mut buf = [0u8; 256];
-    let len = s.get_path(field, &mut buf).unwrap();
+    let len = s.get("string", &mut buf).unwrap();
     assert_eq!(&buf[..len], b"\"\"");
 
-    let field = "string".split('/').peekable();
-    s.set_path(field, br#""test""#).unwrap();
+    s.set("string", br#""test""#).unwrap();
     assert_eq!(s.string, "test");
 }


### PR DESCRIPTION
* a small step towards #104
* Changes the path assembly logic to postfix the separator. This is a bit easier in the logic.
* makes `metadata()` an associated fn
* homogenizes the API and e.g. makes the mqtt client and the unittests use `set()` where appropriate
* also makes the metadata semantically correct (depth N if there are N elements in the path)
* make `next_path` and related API associated fns
* Move the iterator state into the iterator
* fixes #88 by iterating all paths regardless of `Option` nulls.
* adds `Error::PathAbsent` to mark runtime absence in the case of `Option::None`.