### PR TITLE
reorganize derive macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ client](MqttClient) and a Python reference implementation to ineract with it.
 
 ## Example
 ```rust
-use miniconf::{Miniconf, IterError, Error};
+use miniconf::Miniconf;
 use serde::{Serialize, Deserialize};
 
 #[derive(Deserialize, Serialize, Copy, Clone, Default)]

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -153,10 +153,9 @@ fn metadata_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::TokenS
 /// Derive the Miniconf trait for structs.
 ///
 /// # Args
-/// * `input` - The derive input token stream.
 /// * `data` - The data associated with the struct definition.
-/// * `atomic` - specified true if the data must be updated atomically. If false, data must be
-///   set at a terminal node.
+/// * `generics` - The generics of the definition. Sufficient bounds will be added here.
+/// * `ident` - The identifier to derive the impl for.
 ///
 /// # Returns
 /// A token stream of the generated code.

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -187,6 +187,7 @@ fn derive_struct(mut input: DeriveInput) -> TokenStream {
                 value: &[u8]
             ) -> Result<usize, miniconf::Error> {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
+                #[allow(unreachable_code)]
                 let peek = path_parts.peek().is_some();
 
                 match field {
@@ -201,6 +202,7 @@ fn derive_struct(mut input: DeriveInput) -> TokenStream {
                 value: &mut [u8]
             ) -> Result<usize, miniconf::Error> {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
+                #[allow(unreachable_code)]
                 let peek = path_parts.peek().is_some();
 
                 match field {
@@ -213,9 +215,9 @@ fn derive_struct(mut input: DeriveInput) -> TokenStream {
                 state: &mut [usize],
                 path: &mut miniconf::heapless::String<TS>
             ) -> Result<bool, miniconf::IterError> {
+                #[allow(unreachable_code)]
+                let original_length = path.len();
                 loop {
-                    let original_length = path.len();
-
                     match *state.first().ok_or(miniconf::IterError::PathDepth)? {
                         #(#next_path_arms ,)*
                         _ => return Ok(false),
@@ -240,14 +242,17 @@ fn derive_struct(mut input: DeriveInput) -> TokenStream {
                 let mut meta = miniconf::Metadata::default();
 
                 for index in 0.. {
-                    let item_meta = match index {
+                    let item_meta: miniconf::Metadata = match index {
                         #(#metadata_arms ,)*
                         _ => break,
                     };
 
-                    meta.max_length = meta.max_length.max(item_meta.max_length);
-                    meta.max_depth = meta.max_depth.max(item_meta.max_depth);
-                    meta.count += item_meta.count;
+                    #[allow(unreachable_code)]
+                    {
+                        meta.max_length = meta.max_length.max(item_meta.max_length);
+                        meta.max_depth = meta.max_depth.max(item_meta.max_depth);
+                        meta.count += item_meta.count;
+                    }
                 }
 
                 meta

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -55,7 +55,7 @@ fn get_path_arm(f: &StructField) -> proc_macro2::TokenStream {
         quote! {
             stringify!(#match_name) => {
                 if peek {
-                    return Err(miniconf::Error::PathTooLong);
+                    Err(miniconf::Error::PathTooLong)
                 } else {
                     Ok(miniconf::serde_json_core::to_slice(&self.#match_name, value)?)
                 }

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -134,11 +134,13 @@ fn metadata_arm((i, f): (usize, &StructField)) -> proc_macro2::TokenStream {
     } else {
         quote! {
             #i => {
-                miniconf::Metadata {
-                    max_length: stringify!(#field_name).len(),
-                    max_depth: 1,
-                    count: 1,
-                }
+                let mut meta = miniconf::Metadata::default();
+
+                meta.max_length = stringify!(#field_name).len();
+                meta.max_depth = 1;
+                meta.count = 1;
+
+                meta
             }
         }
     }

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -134,13 +134,11 @@ fn metadata_arm((i, f): (usize, &StructField)) -> proc_macro2::TokenStream {
     } else {
         quote! {
             #i => {
-                let mut meta = miniconf::Metadata::default();
-
-                meta.max_length = stringify!(#field_name).len();
-                meta.max_depth = 1;
-                meta.count = 1;
-
-                meta
+                miniconf::Metadata {
+                    max_length: stringify!(#field_name).len(),
+                    max_depth: 1,
+                    count: 1,
+                }
             }
         }
     }

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -187,7 +187,6 @@ fn derive_struct(mut input: DeriveInput) -> TokenStream {
                 value: &[u8]
             ) -> Result<usize, miniconf::Error> {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
-                #[allow(unreachable_code)]
                 let peek = path_parts.peek().is_some();
 
                 match field {
@@ -202,7 +201,6 @@ fn derive_struct(mut input: DeriveInput) -> TokenStream {
                 value: &mut [u8]
             ) -> Result<usize, miniconf::Error> {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
-                #[allow(unreachable_code)]
                 let peek = path_parts.peek().is_some();
 
                 match field {
@@ -215,7 +213,6 @@ fn derive_struct(mut input: DeriveInput) -> TokenStream {
                 state: &mut [usize],
                 path: &mut miniconf::heapless::String<TS>
             ) -> Result<bool, miniconf::IterError> {
-                #[allow(unreachable_code)]
                 let original_length = path.len();
                 loop {
                     match *state.first().ok_or(miniconf::IterError::PathDepth)? {

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -43,9 +43,9 @@ pub fn derive(input: TokenStream) -> TokenStream {
     }
 }
 
-fn get_path_arm(f: &StructField) -> proc_macro2::TokenStream {
-    let match_name = &f.field.ident;
-    if f.deferred {
+fn get_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
+    let match_name = &struct_field.field.ident;
+    if struct_field.deferred {
         quote! {
             stringify!(#match_name) => {
                 self.#match_name.get_path(path_parts, value)
@@ -64,9 +64,9 @@ fn get_path_arm(f: &StructField) -> proc_macro2::TokenStream {
     }
 }
 
-fn set_path_arm(f: &StructField) -> proc_macro2::TokenStream {
-    let match_name = &f.field.ident;
-    if f.deferred {
+fn set_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
+    let match_name = &struct_field.field.ident;
+    if struct_field.deferred {
         quote! {
             stringify!(#match_name) => {
                 self.#match_name.set_path(path_parts, value)
@@ -87,10 +87,10 @@ fn set_path_arm(f: &StructField) -> proc_macro2::TokenStream {
     }
 }
 
-fn next_path_arm((i, f): (usize, &StructField)) -> proc_macro2::TokenStream {
-    let field_type = &f.field.ty;
-    let field_name = &f.field.ident;
-    if f.deferred {
+fn next_path_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::TokenStream {
+    let field_type = &struct_field.field.ty;
+    let field_name = &struct_field.field.ident;
+    if struct_field.deferred {
         quote! {
             #i => {
                 path.push_str(concat!(stringify!(#field_name), "/"))
@@ -114,10 +114,10 @@ fn next_path_arm((i, f): (usize, &StructField)) -> proc_macro2::TokenStream {
     }
 }
 
-fn metadata_arm((i, f): (usize, &StructField)) -> proc_macro2::TokenStream {
-    let field_type = &f.field.ty;
-    let field_name = &f.field.ident;
-    if f.deferred {
+fn metadata_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::TokenStream {
+    let field_type = &struct_field.field.ty;
+    let field_name = &struct_field.field.ident;
+    if struct_field.deferred {
         quote! {
             #i => {
                 let mut meta = <#field_type>::metadata();

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -44,6 +44,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 }
 
 fn get_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
+    // Quote context is a match of the field name with `self`, `path_parts`, `peek`, and `value` available.
     let match_name = &struct_field.field.ident;
     if struct_field.deferred {
         quote! {
@@ -65,6 +66,7 @@ fn get_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
 }
 
 fn set_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
+    // Quote context is a match of the field name with `self`, `path_parts`, `peek`, and `value` available.
     let match_name = &struct_field.field.ident;
     if struct_field.deferred {
         quote! {
@@ -88,6 +90,7 @@ fn set_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
 }
 
 fn next_path_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::TokenStream {
+    // Quote context is a match of the field index with `self`, `state`, and `path` available.
     let field_type = &struct_field.field.ty;
     let field_name = &struct_field.field.ident;
     if struct_field.deferred {
@@ -115,6 +118,7 @@ fn next_path_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::Token
 }
 
 fn metadata_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::TokenStream {
+    // Quote context is a match of the field index.
     let field_type = &struct_field.field.ty;
     let field_name = &struct_field.field.ident;
     if struct_field.deferred {

--- a/derive_miniconf/src/lib.rs
+++ b/derive_miniconf/src/lib.rs
@@ -125,7 +125,7 @@ fn metadata_arm((i, f): (usize, &StructField)) -> proc_macro2::TokenStream {
                 // Unconditionally account for separator since we add it
                 // even if elements that are deferred to (`Options`)
                 // may have no further hierarchy to add and remove the separator again.
-                meta.max_length += concat!(stringify!(#field_name), "/").len();
+                meta.max_length += stringify!(#field_name).len() + 1;
                 meta.max_depth += 1;
 
                 meta
@@ -244,6 +244,7 @@ fn derive_struct(mut input: DeriveInput) -> TokenStream {
                         _ => break,
                     };
 
+                    // Note(unreachable) Empty structs break immediatly
                     #[allow(unreachable_code)]
                     {
                         meta.max_length = meta.max_length.max(item_meta.max_length);

--- a/src/array.rs
+++ b/src/array.rs
@@ -16,7 +16,8 @@ use super::{Error, IterError, Metadata, Miniconf, Peekable};
 use core::fmt::Write;
 
 /// An array that exposes each element through their [`Miniconf`](trait.Miniconf.html) implementation.
-pub struct Array<T, const N: usize>(pub [T; N]);
+#[derive(Clone, Copy, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
+pub struct Array<T, const N: usize>([T; N]);
 
 impl<T, const N: usize> core::ops::Deref for Array<T, N> {
     type Target = [T; N];
@@ -37,31 +38,17 @@ impl<T: Default + Copy, const N: usize> Default for Array<T, N> {
     }
 }
 
-impl<T: core::fmt::Debug, const N: usize> core::fmt::Debug for Array<T, N> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.0.fmt(f)
+impl<T, const N: usize> From<[T; N]> for Array<T, N> {
+    fn from(x: [T; N]) -> Self {
+        Self(x)
     }
 }
 
-impl<T: PartialEq, const N: usize> PartialEq<[T; N]> for Array<T, N> {
-    fn eq(&self, other: &[T; N]) -> bool {
-        self.0.eq(other)
+impl<T, const N: usize> From<Array<T, N>> for [T; N] {
+    fn from(x: Array<T, N>) -> Self {
+        x.0
     }
 }
-
-impl<T: PartialEq, const N: usize> PartialEq for Array<T, N> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.eq(&other.0)
-    }
-}
-
-impl<T: Clone, const N: usize> Clone for Array<T, N> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
-impl<T: Copy, const N: usize> Copy for Array<T, N> {}
 
 /// Returns the number of digits required to format an integer less than `x`.
 const fn digits(x: usize) -> usize {

--- a/src/array.rs
+++ b/src/array.rs
@@ -63,11 +63,12 @@ impl<T: Clone, const N: usize> Clone for Array<T, N> {
 
 impl<T: Copy, const N: usize> Copy for Array<T, N> {}
 
+/// Returns the number of digits required to format an integer less than `x`.
 const fn digits(x: usize) -> usize {
     let mut n = 10;
     let mut num_digits = 1;
 
-    while x >= n {
+    while x > n {
         n *= 10;
         num_digits += 1;
     }
@@ -107,7 +108,7 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
         // Unconditionally account for separator since we add it
         // even if elements that are deferred to (`Options`)
         // may have no further hierarchy to add and remove the separator again.
-        meta.max_length += digits(N - 1) + 1;
+        meta.max_length += digits(N) + 1;
         meta.max_depth += 1;
         meta.count *= N;
 
@@ -188,7 +189,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
 
     fn metadata() -> Metadata {
         Metadata {
-            max_length: digits(N - 1),
+            max_length: digits(N),
             max_depth: 1,
             count: N,
         }

--- a/src/option.rs
+++ b/src/option.rs
@@ -19,7 +19,20 @@
 use super::{Error, IterError, Metadata, Miniconf, Peekable};
 
 /// An `Option` that exposes its value through their [`Miniconf`](trait.Miniconf.html) implementation.
-pub struct Option<T>(pub core::option::Option<T>);
+#[derive(
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    Debug,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct Option<T>(core::option::Option<T>);
 
 impl<T> core::ops::Deref for Option<T> {
     type Target = core::option::Option<T>;
@@ -34,31 +47,17 @@ impl<T> core::ops::DerefMut for Option<T> {
     }
 }
 
-impl<T: Default> Default for Option<T> {
-    fn default() -> Self {
-        Self(Default::default())
+impl<T> From<core::option::Option<T>> for Option<T> {
+    fn from(x: core::option::Option<T>) -> Self {
+        Self(x)
     }
 }
 
-impl<T: core::fmt::Debug> core::fmt::Debug for Option<T> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.0.fmt(f)
+impl<T> From<Option<T>> for core::option::Option<T> {
+    fn from(x: Option<T>) -> Self {
+        x.0
     }
 }
-
-impl<T: PartialEq> PartialEq for Option<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.eq(&other.0)
-    }
-}
-
-impl<T: Clone> Clone for Option<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
-impl<T: Copy> Copy for Option<T> {}
 
 impl<T: Miniconf> Miniconf for Option<T> {
     fn set_path<'a, P: Peekable<Item = &'a str>>(

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,4 +1,4 @@
-use miniconf::{Error, Miniconf};
+use miniconf::{Array, Error, Miniconf};
 use serde::Deserialize;
 
 #[derive(Debug, Default, Miniconf, Deserialize)]
@@ -163,14 +163,26 @@ fn short_array() {
     assert_eq!(meta.count, 1);
 }
 
-/// Zero-length arrays are not supported
 #[test]
-#[should_panic]
 fn null_array() {
     #[derive(Miniconf, Default, PartialEq, Debug)]
     struct S {
         #[miniconf(defer)]
         data: [u32; 0],
     }
-    let _meta = S::metadata();
+    assert!(S::iter_paths::<2, 6>().unwrap().next().is_none());
+}
+
+#[test]
+fn null_miniconf_array() {
+    #[derive(Miniconf, Default, Debug, PartialEq, Copy, Clone)]
+    struct I {
+        a: i32,
+    }
+    #[derive(Miniconf, Default, PartialEq, Debug)]
+    struct S {
+        #[miniconf(defer)]
+        data: Array<I, 0>,
+    }
+    assert!(S::iter_paths::<3, 8>().unwrap().next().is_none());
 }

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -92,3 +92,10 @@ fn struct_with_string() {
     s.set("string", br#""test""#).unwrap();
     assert_eq!(s.string, "test");
 }
+
+#[test]
+fn empty_struct() {
+    #[derive(Miniconf, Default)]
+    struct Settings {}
+    assert!(Settings::iter_paths::<1, 0>().unwrap().next().is_none());
+}


### PR DESCRIPTION
* refactor the derive macro a bit, move out the arms into functions, remove `TypeDefinition`, cancel some common code
* derive common traits for Array and Option
* support zero length arrays and structs