### PR TITLE
rj/complex example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,9 @@ pub enum Error {
     /// The path does not exist at runtime.
     ///
     /// This is the case if a deferred [core::option::Option] or [Option]
-    /// is `None` at runtime.
+    /// is `None` at runtime. `PathAbsent` takes precedence over `PathNotFound`
+    /// if the path is simultaneously masked by a `Option::None` at runtime but
+    /// would still be non-existent if it weren't.
     PathAbsent,
 }
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -79,7 +79,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
         if let Some(inner) = self.0.as_mut() {
             inner.set_path(path_parts, value)
         } else {
-            Err(Error::PathNotFound)
+            Err(Error::PathAbsent)
         }
     }
 
@@ -91,7 +91,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
         if let Some(inner) = self.0.as_ref() {
             inner.get_path(path_parts, value)
         } else {
-            Err(Error::PathNotFound)
+            Err(Error::PathAbsent)
         }
     }
 

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -18,8 +18,18 @@ fn option_get_set_none() {
 
     // Check that if the option is None, the value cannot be get or set.
     settings.value.take();
-    assert!(settings.get("value", &mut data).is_err());
-    assert!(settings.set("value/data", b"5").is_err());
+    assert_eq!(
+        settings.get("value_foo", &mut data),
+        Err(miniconf::Error::PathNotFound)
+    );
+    assert_eq!(
+        settings.get("value", &mut data),
+        Err(miniconf::Error::PathAbsent)
+    );
+    assert_eq!(
+        settings.set("value/data", b"5"),
+        Err(miniconf::Error::PathAbsent)
+    );
 }
 
 #[test]


### PR DESCRIPTION
- option: actually return PathAbsent
- add the Array<Option<Miniconf>> example
