### PR TITLE
Reworking response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [mqtt] The `MqttClient` API has changed to support new Minimq versions
 * [mqtt] The `Get` command now only generates a single message in response to the provided
   ResponseTopic instead of a response type (with success) and a message on the original topic.
+* [mqtt] Handler function singatures now require `Debug` instead of `AsRef<str>` types
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [mqtt] The `MqttClient` API has changed to support new Minimq versions
 * [mqtt] The `Get` command now only generates a single message in response to the provided
   ResponseTopic instead of a response type (with success) and a message on the original topic.
-* [mqtt] Handler function singatures now require `Debug` instead of `AsRef<str>` types
+* [mqtt] Handler function singatures now require `Display` instead of `AsRef<str>` types
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ log = {version = "0.4", optional = true }
 heapless = { version = "0.7", optional=true }
 minimq = { git = "https://github.com/quartiq/minimq", optional = true}
 smlang = { version = "0.6", optional = true }
-embedded-io = { git = "https://github.com/quartiq/embedded-hal", branch = "rs/write-len", optional = true }
+embedded-io = { version = "0.5", optional = true }
 
 [features]
 default = ["mqtt-client"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,12 @@ log = {version = "0.4", optional = true }
 heapless = { version = "0.7", optional=true }
 minimq = { git = "https://github.com/quartiq/minimq", optional = true}
 smlang = { version = "0.6", optional = true }
+embedded-io = { git = "https://github.com/quartiq/embedded-hal", branch = "rs/write-len", optional = true }
 
 [features]
 default = ["mqtt-client"]
 json-core = ["dep:serde-json-core"]
-mqtt-client = ["json-core", "dep:minimq", "dep:smlang", "dep:log", "dep:heapless"]
+mqtt-client = ["json-core", "dep:minimq", "dep:smlang", "dep:log", "dep:heapless", "dep:embedded-io"]
 std = []
 
 [dev-dependencies]

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -25,7 +25,7 @@ async fn mqtt_client() {
     let mut buffer = [0u8; 1024];
     let mut mqtt: minimq::Minimq<'_, _, _, minimq::broker::NamedBroker<Stack>> =
         minimq::Minimq::new(
-            Stack::default(),
+            Stack,
             StandardClock::default(),
             minimq::ConfigBuilder::new(
                 minimq::broker::NamedBroker::new("localhost", Stack).unwrap(),
@@ -92,7 +92,7 @@ async fn main() {
     // Construct a settings configuration interface.
     let mut client: miniconf::MqttClient<'_, _, _, _, minimq::broker::IpBroker, 2> =
         miniconf::MqttClient::new(
-            Stack::default(),
+            Stack,
             "sample/prefix",
             StandardClock::default(),
             Settings::default(),

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -490,7 +490,7 @@ where
 
                     if let Err(minimq::PubError::Serialization(error)) = client.publish(message) {
                         if let Ok(message) =
-                            DeferredPublication::new(|mut buf| write!(buf, "{:?}", error))
+                            DeferredPublication::new(|mut buf| write!(buf, "{}", error))
                                 .properties(&[ResponseCode::Error.as_user_property()])
                                 .reply(properties)
                                 .qos(QoS::AtLeastOnce)
@@ -507,7 +507,7 @@ where
                     let mut new_settings = self.settings.clone();
                     if let Err(err) = new_settings.set_json(path, value) {
                         if let Ok(response) =
-                            DeferredPublication::new(|mut buf| write!(buf, "{:?}", err))
+                            DeferredPublication::new(|mut buf| write!(buf, "{}", err))
                                 .properties(&[ResponseCode::Error.as_user_property()])
                                 .reply(properties)
                                 .qos(QoS::AtLeastOnce)
@@ -533,7 +533,7 @@ where
                         }
                         Err(e) => {
                             if let Ok(response) =
-                                DeferredPublication::new(|mut buf| write!(buf, "{:?}", e))
+                                DeferredPublication::new(|mut buf| write!(buf, "{}", e))
                                     .properties(&[ResponseCode::Error.as_user_property()])
                                     .reply(properties)
                                     .qos(QoS::AtLeastOnce)

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -7,7 +7,7 @@ use minimq::{
     DeferredPublication, Publication, QoS,
 };
 
-use embedded_io::Write as OtherWrite;
+use embedded_io::Write;
 
 // The maximum topic length of any settings path.
 const MAX_TOPIC_LENGTH: usize = 128;

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -378,7 +378,7 @@ where
     pub fn handled_update<F, E>(&mut self, handler: F) -> Result<bool, minimq::Error<Stack::Error>>
     where
         F: FnMut(&str, &mut Settings, &Settings) -> Result<(), E>,
-        E: core::fmt::Debug,
+        E: core::fmt::Display,
     {
         if !self.mqtt.client().is_connected() {
             // Note(unwrap): It's always safe to reset.
@@ -418,7 +418,7 @@ where
     ) -> Result<bool, minimq::Error<Stack::Error>>
     where
         F: FnMut(&str, &mut Settings, &Settings) -> Result<(), E>,
-        E: core::fmt::Debug,
+        E: core::fmt::Display,
     {
         let mut updated = false;
         match self.mqtt.poll(|client, topic, message, properties| {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -44,6 +44,27 @@ pub enum Error<E> {
     PostDeserialization(E),
 }
 
+impl<E: core::fmt::Display> core::fmt::Display for Error<E> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::Absent(index) => write!(f, "Path is not currently available (Depth: {})", index),
+            Error::TooShort(index) => write!(f, "Provided path was too short (Depth: {})", index),
+            Error::NotFound(index) => {
+                write!(f, "The provided path was not found (Depth: {})", index)
+            }
+            Error::TooLong(index) => write!(f, "The provided path was too long (Depth: {})", index),
+            Error::Inner(error) => {
+                write!(f, "Value could not be (de)serialized: ")?;
+                error.fmt(f)
+            }
+            Error::PostDeserialization(error) => {
+                write!(f, "Error after deserialization: ")?;
+                error.fmt(f)
+            }
+        }
+    }
+}
+
 impl<T> From<T> for Error<T> {
     fn from(value: T) -> Self {
         Error::Inner(value)

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -47,12 +47,18 @@ pub enum Error<E> {
 impl<E: core::fmt::Display> core::fmt::Display for Error<E> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Error::Absent(index) => write!(f, "Path is not currently available (Depth: {})", index),
-            Error::TooShort(index) => write!(f, "Provided path was too short (Depth: {})", index),
-            Error::NotFound(index) => {
-                write!(f, "The provided path was not found (Depth: {})", index)
+            Error::Absent(index) => {
+                write!(f, "Path is not currently available (Key level: {})", index)
             }
-            Error::TooLong(index) => write!(f, "The provided path was too long (Depth: {})", index),
+            Error::TooShort(index) => {
+                write!(f, "Provided path was too short (Key level: {})", index)
+            }
+            Error::NotFound(index) => {
+                write!(f, "The provided path was not found (Key level: {})", index)
+            }
+            Error::TooLong(index) => {
+                write!(f, "The provided path was too long (Key level: {})", index)
+            }
             Error::Inner(error) => {
                 write!(f, "Value could not be (de)serialized: ")?;
                 error.fmt(f)

--- a/tests/republish.rs
+++ b/tests/republish.rs
@@ -22,7 +22,7 @@ async fn verify_settings() {
     let mut buffer = [0u8; 1024];
     let localhost: minimq::embedded_nal::IpAddr = "127.0.0.1".parse().unwrap();
     let mut mqtt: minimq::Minimq<'_, _, _, minimq::broker::IpBroker> = minimq::Minimq::new(
-        Stack::default(),
+        Stack,
         StandardClock::default(),
         minimq::ConfigBuilder::new(localhost.into(), &mut buffer)
             .client_id("tester")


### PR DESCRIPTION
This PR refactors how we handle responses to simplify the code base. Now, the function signature of the handler function just needs to `impl Debug` so we can format it into the response message on error.

Responses are now formatted directly into the MQTT payload. As such, there's no longer a limitation on maximum error sizes on the end-user, their limit is now restricted by how much buffer they provide for MQTT.