### PR TITLE
Bumping client, releasing Miniconf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Python client updated to deprecate `command` in favor of `set`
 * Python client now exposes `get()`, `set()`, and `list_paths()` APIs
 * `AsRef`, `AsMut`, `IntoIterator` for `Array` and `Option`.
+* Updated to minimq 0.7
 
 ### Changed
 * Responses now encode status values as strings in a `UserProperty` with key "code"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/quartiq/miniconf/compare/v0.6.3...HEAD)
+## Unreleased
+
+
+## [0.7.0](https://github.com/quartiq/miniconf/compare/v0.6.3...v0.7.0)
 
 ### Added
 * [MQTT client] Getting values is now supported by publishing an empty message to the topic.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,10 @@ std-embedded-nal = "0.1"
 tokio = { version = "1.9", features = ["rt-multi-thread", "time", "macros"] }
 std-embedded-time = "0.1"
 
+[patch.crates-io.std-embedded-nal]
+version = "0.1"
+git = "https://gitlab.com/ryan-summers/std-embedded-nal"
+branch = "feature/0.7"
+
 [[example]]
 name = "mqtt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "miniconf"
 
 # Don't forget to change `miniconf_derive`'s version as well.
-version = "0.6.3"
+version = "0.7.0"
 
 authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@vertigo-designs.com", "Robert Jördens <rj@quartiq.de>"]
 edition = "2021"
@@ -19,7 +19,7 @@ serde-json-core = "0.5.0"
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
 log = "0.4"
 heapless = { version = "0.7", features = ["serde"] }
-minimq = { version = "^0.6.2", optional = true }
+minimq = { version = "0.7", optional = true }
 smlang = { version = "0.6", optional = true }
 itoa = "1.0.4"
 


### PR DESCRIPTION
This PR releases miniconf as 0.7

I'll follow up with a python release to pip as well following this now that things have stabilized a bit.