### PR TITLE
only reply if response topic set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* [MQTT] Now only subscribes to the `settings/#` and `list` topics to avoid unnecessary
+  MQTT traffic and logging messages.
+* [MQTT] Logging messages about omitted responses in case of missing `ResponseTopic` have been removed.
 
 ## [0.7.0](https://github.com/quartiq/miniconf/compare/v0.6.3...v0.7.0)
 

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -484,7 +484,7 @@ where
                                 .replace(Vec::from_slice(binary_props).unwrap());
                             self.listing_state.replace(Default::default());
                         } else {
-                            log::info!("`List` command without `ResponseTopic`");
+                            log::info!("Discarding `List` without `ResponseTopic`");
                         }
                         // Response sent with listing.
                         return;
@@ -548,9 +548,9 @@ where
                             .properties(&props)
                             .qos(QoS::AtLeastOnce)
                             .finish() else {
-                log::warn!("Failed to build response `Pub`");
-                return;
-            };
+                    log::warn!("Failed to build response `Pub`");
+                    return;
+                };
 
                 // If we cannot publish the response yet (possibly because we just published something
                 // that hasn't completed yet), cache the response for future transmission.

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -459,7 +459,7 @@ where
             };
 
             let Ok(command) = Command::from_message(path, message) else {
-                log::debug!("Unknown Miniconf command: {path}");
+                log::info!("Unknown Miniconf command: {path}");
                 return;
             };
 

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -459,7 +459,7 @@ where
             };
 
             let Ok(command) = Command::from_message(path, message) else {
-                log::info!("Unknown Miniconf command: {path}");
+                log::debug!("Unknown Miniconf command: {path}");
                 return;
             };
 


### PR DESCRIPTION
* [x] only try to build response if ResponseTopic is set
* [x] should subscribe to `/settings/#` and `/list` explicitly, not to `/#` (which captures telemetry, alive, and maybe even response topics, log etc as well)

closes #142 