### PR TITLE
rj/inner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * The `Miniconf` trait is now generic over the `Deserializer`/`Serializer`. It
-  doesn't enforce `serde-json-core` or `u8` buffers anymore.
-* `MiniconfIter` takes the path hierarchy separator and passes it on to
-  `Miniconf::next_path`.
+  doesn't enforce `serde-json-core` or `u8` buffers or `/` as the path hierarchy
+  separator anymore.
 * The `Miniconf` trait has been stripped of the provided functions that depended
   on the `serde`-backend and path hierarchy separator. Those have been
   moved into a super trait `SerDe<S>` that is generic over a specification marker
   struct `S`. `SerDe<JsonCoreSlash>` has been implemented for all `Miniconf`
   to provide the previously existing functionality.
+* `MiniconfIter` takes the path hierarchy separator from `SerDe` and passes it on to
+  `Miniconf::next_path`.
 * The only required change for most downstream crates to adapt to the above is to
   make sure the `SerDe` trait is in scope (`use miniconf::SerDe`).
+* Paths now start with the path separator (unless they are empty).
+* The path iterator does not need to be `Peekable` anymore.
 
 ## [0.7.1] (https://github.com/quartiq/miniconf/compare/v0.7.0...v0.7.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+* The `Miniconf` trait is now generic over the `Deserializer`/`Serializer`. It
+  doesn't enforce `serde-json-core` or `u8` buffers anymore.
+* `MiniconfIter` takes the path hierarchy separator and passes it on to
+  `Miniconf::next_path`.
+* The `Miniconf` trait has been stripped of the provided functions that depended
+  on the `serde`-backend and path hierarchy separator. Those have been
+  moved into a super trait `SerDe<S>` that is generic over a specification marker
+  struct `S`. `SerDe<JsonCoreSlash>` has been implemented for all `Miniconf`
+  to provide the previously existing functionality.
+* The only required change for most downstream crates to adapt to the above is to
+  make sure the `SerDe` trait is in scope (`use miniconf::SerDe`).
+
 ## [0.7.1] (https://github.com/quartiq/miniconf/compare/v0.7.0...v0.7.1)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.65.0"
 
 [dependencies]
 miniconf_derive = { path = "miniconf_derive" , version = "0.6" }
-serde-json-core = { git = "https://github.com/quartiq/serde-json-core.git", branch = "rj/ser-de-pub" }
+serde-json-core = { git = "https://github.com/rust-embedded-community/serde-json-core.git" }
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
 log = "0.4"
 heapless = { version = "0.7", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.65.0"
 
 [dependencies]
 miniconf_derive = { path = "miniconf_derive" , version = "0.6" }
-serde-json-core = {path = "../serde-json-core"} # "0.5.0"
+serde-json-core = { git = "https://github.com/quartiq/serde-json-core.git", branch = "rj/ser-de-pub" }
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
 log = "0.4"
 heapless = { version = "0.7", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.65.0"
 
 [dependencies]
 miniconf_derive = { path = "miniconf_derive" , version = "0.6" }
-serde-json-core = "0.5.0"
+serde-json-core = {path = "../serde-json-core"} # "0.5.0"
 serde = { version = "1.0.120", features = ["derive"], default-features = false }
 log = "0.4"
 heapless = { version = "0.7", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Miniconf can be used as a very simple and flexible backend for run-time settings
 over any transport. It was originally designed to work with JSON ([serde_json_core](https://docs.rs/serde-json-core))
 payloads over MQTT ([minimq](https://docs.rs/minimq)) and provides a comlete [MQTT settings management
 client](MqttClient) and a Python reference implementation to ineract with it.
+`Miniconf` is generic over the `serde::Serializer`/`serde::Deserializer` backend and the path hierarchy separator.
 
 ## Example
 ```rust
@@ -121,7 +122,7 @@ python -m miniconf -d quartiq/application/+ foo=true
 For structs with named fields, Miniconf offers a [derive macro](derive.Miniconf.html) to automatically
 assign a unique path to each item in the namespace of the struct.
 The macro implements the [Miniconf] trait that exposes access to serialized field values through their path.
-All types supported by [serde_json_core] can be used as fields.
+All types supported by [serde] (and the `serde::Serializer`/`serde::Deserializer` backend) can be used as fields.
 
 Elements of homogeneous [core::array]s are similarly accessed through their numeric indices.
 Structs, arrays, and Options can then be cascaded to construct a multi-level namespace.
@@ -136,9 +137,11 @@ atomic access to their respective inner element(s), [Array] and
 into the inner element(s) through their respective inner [Miniconf] implementations.
 
 ## Formats
-The path hierarchy separator is the slash `/`.
 
-Values are serialized into and deserialized from JSON.
+Miniconf is generic over the `serde` backend/payload format and the path hierarchy separator
+(as long as the path can be split by it unambiguously).
+
+Currently support for `/` as the path hierarchy separator and JSON (`serde_json_core`) is implemented.
 
 ## Transport
 Miniconf is designed to be protocol-agnostic. Any means that can receive key-value input from

--- a/README.md
+++ b/README.md
@@ -67,41 +67,47 @@ let mut settings = Settings::default();
 let mut buf = [0; 64];
 
 // Atomic updates by field name
-settings.set("foo", b"true")?;
+settings.set("/foo", b"true")?;
 assert_eq!(settings.foo, true);
-settings.set("enum_", br#""Good""#)?;
-settings.set("struct_", br#"{"a": 3, "b": 3}"#)?;
-settings.set("array", b"[6, 6]")?;
-settings.set("option", b"12")?;
-settings.set("option", b"null")?;
+settings.set("/enum_", br#""Good""#)?;
+settings.set("/struct_", br#"{"a": 3, "b": 3}"#)?;
+settings.set("/array", b"[6, 6]")?;
+settings.set("/option", b"12")?;
+settings.set("/option", b"null")?;
 
 // Deep access by field name in a struct
-settings.set("struct_defer/a", b"4")?;
+settings.set("/struct_defer/a", b"4")?;
 // ... or by index in an array
-settings.set("array_defer/0", b"7")?;
+settings.set("/array_defer/0", b"7")?;
 // ... or by index and then struct field name
-settings.set("array_miniconf/1/b", b"11")?;
+settings.set("/array_miniconf/1/b", b"11")?;
 
 // If a deferred Option is `None` it is hidden at runtime and can't be accessed
 settings.option_defer = None;
-assert_eq!(settings.set("option_defer", b"13"), Err(Error::PathAbsent));
+assert_eq!(settings.set("/option_defer", b"13"), Err(Error::PathAbsent));
 settings.option_defer = Some(0);
-settings.set("option_defer", b"13")?;
+settings.set("/option_defer", b"13")?;
 settings.option_miniconf = Some(Inner::default()).into();
-settings.set("option_miniconf/a", b"14")?;
+settings.set("/option_miniconf/a", b"14")?;
 settings.array_option_miniconf[1] = Some(Inner::default()).into();
-settings.set("array_option_miniconf/1/a", b"15")?;
+settings.set("/array_option_miniconf/1/a", b"15")?;
 
 // Serializing elements by path
-let len = settings.get("struct_", &mut buf)?;
+let len = settings.get("/struct_", &mut buf)?;
 assert_eq!(&buf[..len], br#"{"a":3,"b":3}"#);
 
 // Iterating over and serializing all paths
 for path in Settings::iter_paths::<3, 32>().unwrap() {
-    let ret = settings.get(&path, &mut buf);
-
-    // Some settings are still `None` and thus their paths are expected to be absent
-    assert!(matches!(ret, Ok(_) | Err(Error::PathAbsent)));
+    match settings.get(&path, &mut buf) {
+        Ok(len) => {
+            settings.set(&path, &buf[..len]).unwrap();
+        }
+        // Some settings are still `None` and thus their paths are expected to be absent
+        Err(Error::PathAbsent) => {},
+        e => {
+            e.unwrap();
+        }
+    }
 }
 
 # Ok::<(), miniconf::Error>(())

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ client](MqttClient) and a Python reference implementation to ineract with it.
 
 ## Example
 ```rust
-use miniconf::{Error, Miniconf, MiniconfSpec};
+use miniconf::{Error, Miniconf, SerDe};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Copy, Clone, Default)]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ client](MqttClient) and a Python reference implementation to ineract with it.
 
 ## Example
 ```rust
-use miniconf::{Error, Miniconf, MiniconfJson};
+use miniconf::{Error, Miniconf, MiniconfSpec};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Copy, Clone, Default)]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ client](MqttClient) and a Python reference implementation to ineract with it.
 
 ## Example
 ```rust
-use miniconf::{Error, Miniconf};
+use miniconf::{Error, Miniconf, MiniconfJson};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Copy, Clone, Default)]

--- a/examples/readback.rs
+++ b/examples/readback.rs
@@ -1,4 +1,4 @@
-use miniconf::Miniconf;
+use miniconf::{Miniconf, MiniconfJson};
 
 #[derive(Debug, Default, Miniconf)]
 struct AdditionalSettings {

--- a/examples/readback.rs
+++ b/examples/readback.rs
@@ -42,7 +42,6 @@ fn main() {
 
     for topic in settings_iter {
         let mut value = [0; 256];
-        println!("{topic}");
         let len = s.get(&topic, &mut value).unwrap();
         println!(
             "{:?}: {:?}",

--- a/examples/readback.rs
+++ b/examples/readback.rs
@@ -1,4 +1,4 @@
-use miniconf::{Miniconf, MiniconfJson};
+use miniconf::{Miniconf, MiniconfSpec};
 
 #[derive(Debug, Default, Miniconf)]
 struct AdditionalSettings {
@@ -23,7 +23,7 @@ fn main() {
     };
 
     // Maintains our state of iteration.
-    let mut settings_iter = Settings::iter_paths::<5, 128>('/').unwrap();
+    let mut settings_iter = Settings::iter_paths::<5, 128>().unwrap();
 
     // Just get one topic/value from the iterator
     if let Some(topic) = settings_iter.next() {

--- a/examples/readback.rs
+++ b/examples/readback.rs
@@ -23,7 +23,7 @@ fn main() {
     };
 
     // Maintains our state of iteration.
-    let mut settings_iter = Settings::iter_paths::<5, 128>().unwrap();
+    let mut settings_iter = Settings::iter_paths::<5, 128>('/').unwrap();
 
     // Just get one topic/value from the iterator
     if let Some(topic) = settings_iter.next() {

--- a/examples/readback.rs
+++ b/examples/readback.rs
@@ -42,6 +42,7 @@ fn main() {
 
     for topic in settings_iter {
         let mut value = [0; 256];
+        println!("{topic}");
         let len = s.get(&topic, &mut value).unwrap();
         println!(
             "{:?}: {:?}",

--- a/examples/readback.rs
+++ b/examples/readback.rs
@@ -1,4 +1,4 @@
-use miniconf::{Miniconf, MiniconfSpec};
+use miniconf::{Miniconf, SerDe};
 
 #[derive(Debug, Default, Miniconf)]
 struct AdditionalSettings {

--- a/miniconf_derive/src/attributes.rs
+++ b/miniconf_derive/src/attributes.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum MiniconfAttribute {
     Defer,
+    Inner,
 }
 
 impl FromStr for MiniconfAttribute {
@@ -12,6 +13,7 @@ impl FromStr for MiniconfAttribute {
     fn from_str(s: &str) -> Result<Self, String> {
         let attr = match s {
             "defer" => MiniconfAttribute::Defer,
+            "inner" => MiniconfAttribute::Inner,
             other => return Err(format!("Unknown attribute: {other}")),
         };
 

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -58,8 +58,7 @@ fn get_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
                 if peek {
                     Err(miniconf::Error::PathTooLong)
                 } else {
-                    serde::ser::Serialize::serialize(&self.#match_name, ser).map_err(|_| miniconf::Error::Serialization)?;
-                    Ok(())
+                    serde::ser::Serialize::serialize(&self.#match_name, ser).map_err(|_| miniconf::Error::Serialization)
                 }
             }
         }
@@ -195,7 +194,7 @@ fn derive_struct(
                 }
             }
 
-            fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<(), miniconf::Error>
+            fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<S::Ok, miniconf::Error>
             where
                 P: miniconf::Peekable<Item = &'a str>,
                 S: serde::Serializer,

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -99,7 +99,7 @@ fn next_path_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::Token
                 path.push_str(concat!(stringify!(#field_name), "/"))
                     .map_err(|_| miniconf::IterError::PathLength)?;
 
-                if <#field_type>::next_path(&mut state[1..], path)? {
+                if <#field_type>::next_path(&mut state[1..], path, separator)? {
                     return Ok(true);
                 }
             }
@@ -211,7 +211,8 @@ fn derive_struct(
 
             fn next_path<const TS: usize>(
                 state: &mut [usize],
-                path: &mut miniconf::heapless::String<TS>
+                path: &mut miniconf::heapless::String<TS>,
+                separator: char,
             ) -> Result<bool, miniconf::IterError> {
                 let original_length = path.len();
                 loop {

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -49,7 +49,7 @@ fn get_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
     if struct_field.deferred {
         quote! {
             stringify!(#match_name) => {
-                self.#match_name.get_path(path_parts, value)
+                self.#match_name.get_path(path_parts, ser)
             }
         }
     } else {
@@ -58,7 +58,8 @@ fn get_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
                 if peek {
                     Err(miniconf::Error::PathTooLong)
                 } else {
-                    Ok(miniconf::serde_json_core::to_slice(&self.#match_name, value)?)
+                    serde::ser::Serialize::serialize(&self.#match_name, ser).unwrap();
+                    Ok(())
                 }
             }
         }
@@ -71,7 +72,7 @@ fn set_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
     if struct_field.deferred {
         quote! {
             stringify!(#match_name) => {
-                self.#match_name.set_path(path_parts, value)
+                self.#match_name.set_path(path_parts, de)
             }
         }
     } else {
@@ -80,9 +81,8 @@ fn set_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
                 if peek {
                     Err(miniconf::Error::PathTooLong)
                 } else {
-                    let (value, len) = miniconf::serde_json_core::from_slice(value)?;
-                    self.#match_name = value;
-                    Ok(len)
+                    self.#match_name = serde::de::Deserialize::deserialize(de).unwrap();
+                    Ok(())
                 }
             }
         }
@@ -181,31 +181,35 @@ fn derive_struct(
 
     quote! {
         impl #impl_generics miniconf::Miniconf for #ident #ty_generics #where_clause {
-            fn set_path<'a, P: miniconf::Peekable<Item = &'a str>>(
-                &mut self,
-                path_parts: &'a mut P,
-                value: &[u8]
-            ) -> Result<usize, miniconf::Error> {
+            fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: &'a mut D) -> Result<(), miniconf::Error>
+            where
+                P: miniconf::Peekable<Item = &'a str>,
+                &'a mut D: serde::de::Deserializer<'b>,
+            {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
                 let peek = path_parts.peek().is_some();
 
                 match field {
                     #(#set_path_arms ,)*
-                    _ => Err(miniconf::Error::PathNotFound)
+                    _ => {
+                        Err(miniconf::Error::PathNotFound)
+                    }
                 }
             }
 
-            fn get_path<'a, P: miniconf::Peekable<Item = &'a str>>(
-                &self,
-                path_parts: &'a mut P,
-                value: &mut [u8]
-            ) -> Result<usize, miniconf::Error> {
+            fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), miniconf::Error>
+            where
+                P: miniconf::Peekable<Item = &'a str>,
+                &'a mut S: serde::ser::Serializer,
+            {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
                 let peek = path_parts.peek().is_some();
 
                 match field {
                     #(#get_path_arms ,)*
-                    _ => Err(miniconf::Error::PathNotFound)
+                    _ => {
+                        Err(miniconf::Error::PathNotFound)
+                    }
                 }
             }
 

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -184,7 +184,7 @@ fn derive_struct(
             fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: &'a mut D) -> Result<(), miniconf::Error>
             where
                 P: miniconf::Peekable<Item = &'a str>,
-                &'a mut D: serde::de::Deserializer<'b>,
+                &'a mut D: serde::Deserializer<'b>,
             {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
                 let peek = path_parts.peek().is_some();
@@ -198,7 +198,7 @@ fn derive_struct(
             fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), miniconf::Error>
             where
                 P: miniconf::Peekable<Item = &'a str>,
-                &'a mut S: serde::ser::Serializer,
+                &'a mut S: serde::Serializer,
             {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
                 let peek = path_parts.peek().is_some();

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -119,13 +119,8 @@ fn metadata_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::TokenS
         quote! {
             #i => {
                 let mut meta = <#field_type>::metadata();
-
-                // Unconditionally account for separator since we add it
-                // even if elements that are deferred to (`Options`)
-                // may have no further hierarchy to add and remove the separator again.
                 meta.max_length += 1 + stringify!(#field_name).len();
                 meta.max_depth += 1;
-
                 meta
             }
         }
@@ -133,11 +128,9 @@ fn metadata_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::TokenS
         quote! {
             #i => {
                 let mut meta = miniconf::Metadata::default();
-
                 meta.max_length = 1 + stringify!(#field_name).len();
                 meta.max_depth = 1;
                 meta.count = 1;
-
                 meta
             }
         }
@@ -211,8 +204,6 @@ fn derive_struct(
             }
 
             fn metadata() -> miniconf::Metadata {
-                // Loop through all child elements, collecting the maximum length + depth of any
-                // member.
                 let mut meta = miniconf::Metadata::default();
 
                 for index in 0.. {

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -191,9 +191,7 @@ fn derive_struct(
 
                 match field {
                     #(#set_path_arms ,)*
-                    _ => {
-                        Err(miniconf::Error::PathNotFound)
-                    }
+                    _ => Err(miniconf::Error::PathNotFound)
                 }
             }
 
@@ -207,9 +205,7 @@ fn derive_struct(
 
                 match field {
                     #(#get_path_arms ,)*
-                    _ => {
-                        Err(miniconf::Error::PathNotFound)
-                    }
+                    _ => Err(miniconf::Error::PathNotFound)
                 }
             }
 

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -46,7 +46,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 fn get_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
     // Quote context is a match of the field name with `self`, `path_parts`, and `value` available.
     let match_name = &struct_field.field.ident;
-    if struct_field.deferred {
+    if struct_field.defer {
         quote! {
             stringify!(#match_name) => {
                 self.#match_name.get_path(path_parts, ser)
@@ -68,7 +68,7 @@ fn get_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
 fn set_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
     // Quote context is a match of the field name with `self`, `path_parts`, and `value` available.
     let match_name = &struct_field.field.ident;
-    if struct_field.deferred {
+    if struct_field.defer {
         quote! {
             stringify!(#match_name) => {
                 self.#match_name.set_path(path_parts, de)
@@ -92,7 +92,7 @@ fn next_path_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::Token
     // Quote context is a match of the field index with `self`, `state`, and `path` available.
     let field_type = &struct_field.field.ty;
     let field_name = &struct_field.field.ident;
-    if struct_field.deferred {
+    if struct_field.defer {
         quote! {
             Some(#i) => {
                 path.write_str(concat!("/", stringify!(#field_name)))
@@ -115,7 +115,7 @@ fn metadata_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::TokenS
     // Quote context is a match of the field index.
     let field_type = &struct_field.field.ty;
     let field_name = &struct_field.field.ident;
-    if struct_field.deferred {
+    if struct_field.defer {
         quote! {
             #i => {
                 let mut meta = <#field_type>::metadata();
@@ -167,7 +167,7 @@ fn derive_struct(
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     quote! {
-        impl #impl_generics miniconf::Miniconf for #ident #ty_generics #where_clause {
+        impl #impl_generics miniconf::Miniconf<miniconf::Outer> for #ident #ty_generics #where_clause {
             fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), miniconf::Error>
             where
                 P: Iterator<Item = &'a str>,

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -58,7 +58,7 @@ fn get_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
                 if peek {
                     Err(miniconf::Error::PathTooLong)
                 } else {
-                    serde::ser::Serialize::serialize(&self.#match_name, ser).unwrap();
+                    serde::ser::Serialize::serialize(&self.#match_name, ser).map_err(|_| miniconf::Error::Serialization)?;
                     Ok(())
                 }
             }
@@ -81,7 +81,7 @@ fn set_path_arm(struct_field: &StructField) -> proc_macro2::TokenStream {
                 if peek {
                     Err(miniconf::Error::PathTooLong)
                 } else {
-                    self.#match_name = serde::de::Deserialize::deserialize(de).unwrap();
+                    self.#match_name = serde::de::Deserialize::deserialize(de).map_err(|_| miniconf::Error::Deserialization)?;
                     Ok(())
                 }
             }

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -180,9 +180,7 @@ fn derive_struct(
                 P: Iterator<Item = &'a str>,
                 D: serde::Deserializer<'b>,
             {
-                let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
-
-                match field {
+                match path_parts.next().ok_or(miniconf::Error::PathTooShort)? {
                     #(#set_path_arms ,)*
                     _ => Err(miniconf::Error::PathNotFound),
                 }
@@ -193,9 +191,7 @@ fn derive_struct(
                 P: Iterator<Item = &'a str>,
                 S: serde::Serializer,
             {
-                let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
-
-                match field {
+                match path_parts.next().ok_or(miniconf::Error::PathTooShort)? {
                     #(#get_path_arms ,)*
                     _ => Err(miniconf::Error::PathNotFound)
                 }

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -180,10 +180,10 @@ fn derive_struct(
 
     quote! {
         impl #impl_generics miniconf::Miniconf for #ident #ty_generics #where_clause {
-            fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: &'a mut D) -> Result<(), miniconf::Error>
+            fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), miniconf::Error>
             where
                 P: miniconf::Peekable<Item = &'a str>,
-                &'a mut D: serde::Deserializer<'b>,
+                D: serde::Deserializer<'b>,
             {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
                 let peek = path_parts.peek().is_some();

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -195,10 +195,10 @@ fn derive_struct(
                 }
             }
 
-            fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), miniconf::Error>
+            fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<(), miniconf::Error>
             where
                 P: miniconf::Peekable<Item = &'a str>,
-                &'a mut S: serde::Serializer,
+                S: serde::Serializer,
             {
                 let field = path_parts.next().ok_or(miniconf::Error::PathTooShort)?;
                 let peek = path_parts.peek().is_some();

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,4 +1,4 @@
-use super::{Error, IterError, Metadata, Miniconf, Peekable};
+use super::{Error, IterError, Metadata, Miniconf};
 use core::{
     fmt::Write,
     ops::{Deref, DerefMut},
@@ -112,7 +112,7 @@ const fn digits(x: usize) -> usize {
 impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
     fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), Error>
     where
-        P: Peekable<Item = &'a str>,
+        P: Iterator<Item = &'a str>,
         D: serde::Deserializer<'b>,
     {
         let i = self.0.index(path_parts.next())?;
@@ -125,7 +125,7 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
 
     fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<S::Ok, Error>
     where
-        P: Peekable<Item = &'a str>,
+        P: Iterator<Item = &'a str>,
         S: serde::Serializer,
     {
         let i = self.0.index(path_parts.next())?;
@@ -182,7 +182,7 @@ impl<T, const N: usize> IndexLookup for [T; N] {
 impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for [T; N] {
     fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), Error>
     where
-        P: Peekable<Item = &'a str>,
+        P: Iterator<Item = &'a str>,
         D: serde::Deserializer<'b>,
     {
         let i = self.index(path_parts.next())?;
@@ -198,7 +198,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
 
     fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<S::Ok, Error>
     where
-        P: Peekable<Item = &'a str>,
+        P: Iterator<Item = &'a str>,
         S: serde::Serializer,
     {
         let i = self.index(path_parts.next())?;

--- a/src/array.rs
+++ b/src/array.rs
@@ -107,30 +107,30 @@ const fn digits(x: usize) -> usize {
 }
 
 impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
-    fn set_path<'a, P: Peekable<Item = &'a str>>(
-        &mut self,
-        path_parts: &'a mut P,
-        value: &[u8],
-    ) -> Result<usize, Error> {
+    fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: &'a mut D) -> Result<(), Error>
+    where
+        P: Peekable<Item = &'a str>,
+        &'a mut D: serde::de::Deserializer<'b>,
+    {
         let i = self.0.index(path_parts.next())?;
 
         self.0
             .get_mut(i)
             .ok_or(Error::BadIndex)?
-            .set_path(path_parts, value)
+            .set_path(path_parts, de)
     }
 
-    fn get_path<'a, P: Peekable<Item = &'a str>>(
-        &self,
-        path_parts: &'a mut P,
-        value: &mut [u8],
-    ) -> Result<usize, Error> {
+    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), Error>
+    where
+        P: Peekable<Item = &'a str>,
+        &'a mut S: serde::ser::Serializer,
+    {
         let i = self.0.index(path_parts.next())?;
 
         self.0
             .get(i)
             .ok_or(Error::BadIndex)?
-            .get_path(path_parts, value)
+            .get_path(path_parts, ser)
     }
 
     fn metadata() -> Metadata {
@@ -189,11 +189,11 @@ impl<T, const N: usize> IndexLookup for [T; N] {
 }
 
 impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for [T; N] {
-    fn set_path<'a, P: Peekable<Item = &'a str>>(
-        &mut self,
-        path_parts: &mut P,
-        value: &[u8],
-    ) -> Result<usize, Error> {
+    fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: &'a mut D) -> Result<(), Error>
+    where
+        P: Peekable<Item = &'a str>,
+        &'a mut D: serde::de::Deserializer<'b>,
+    {
         let i = self.index(path_parts.next())?;
 
         if path_parts.peek().is_some() {
@@ -201,16 +201,15 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         }
 
         let item = <[T]>::get_mut(self, i).ok_or(Error::BadIndex)?;
-        let (value, len) = serde_json_core::from_slice(value)?;
-        *item = value;
-        Ok(len)
+        *item = serde::de::Deserialize::deserialize(de).unwrap();
+        Ok(())
     }
 
-    fn get_path<'a, P: Peekable<Item = &'a str>>(
-        &self,
-        path_parts: &mut P,
-        value: &mut [u8],
-    ) -> Result<usize, Error> {
+    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), Error>
+    where
+        P: Peekable<Item = &'a str>,
+        &'a mut S: serde::ser::Serializer,
+    {
         let i = self.index(path_parts.next())?;
 
         if path_parts.peek().is_some() {
@@ -218,7 +217,8 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         }
 
         let item = <[T]>::get(self, i).ok_or(Error::BadIndex)?;
-        Ok(serde_json_core::to_slice(item, value)?)
+        serde::ser::Serialize::serialize(item, ser).unwrap();
+        Ok(())
     }
 
     fn metadata() -> Metadata {

--- a/src/array.rs
+++ b/src/array.rs
@@ -107,10 +107,10 @@ const fn digits(x: usize) -> usize {
 }
 
 impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
-    fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: &'a mut D) -> Result<(), Error>
+    fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut D: serde::Deserializer<'b>,
+        D: serde::Deserializer<'b>,
     {
         let i = self.0.index(path_parts.next())?;
 
@@ -190,10 +190,10 @@ impl<T, const N: usize> IndexLookup for [T; N] {
 }
 
 impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for [T; N] {
-    fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: &'a mut D) -> Result<(), Error>
+    fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut D: serde::Deserializer<'b>,
+        D: serde::Deserializer<'b>,
     {
         let i = self.index(path_parts.next())?;
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -120,7 +120,7 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
             .set_path(path_parts, de)
     }
 
-    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<(), Error>
+    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<S::Ok, Error>
     where
         P: Peekable<Item = &'a str>,
         S: serde::Serializer,
@@ -206,7 +206,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         Ok(())
     }
 
-    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<(), Error>
+    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<S::Ok, Error>
     where
         P: Peekable<Item = &'a str>,
         S: serde::Serializer,
@@ -218,8 +218,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         }
 
         let item = <[T]>::get(self, i).ok_or(Error::BadIndex)?;
-        serde::Serialize::serialize(item, ser).map_err(|_| Error::Serialization)?;
-        Ok(())
+        serde::Serialize::serialize(item, ser).map_err(|_| Error::Serialization)
     }
 
     fn metadata() -> Metadata {

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,4 +1,4 @@
-use super::{Error, IterError, Metadata, Miniconf};
+use super::{Error, Inner, IterError, Metadata, Miniconf, Outer};
 use core::{
     fmt::Write,
     ops::{Deref, DerefMut},
@@ -109,7 +109,7 @@ const fn digits(x: usize) -> usize {
     num_digits
 }
 
-impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
+impl<T: Miniconf<Outer>, const N: usize> Miniconf<Inner> for Array<T, N> {
     fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), Error>
     where
         P: Iterator<Item = &'a str>,
@@ -179,7 +179,7 @@ impl<T, const N: usize> IndexLookup for [T; N] {
     }
 }
 
-impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for [T; N] {
+impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf<Outer> for [T; N] {
     fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), Error>
     where
         P: Iterator<Item = &'a str>,

--- a/src/array.rs
+++ b/src/array.rs
@@ -201,7 +201,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         }
 
         let item = <[T]>::get_mut(self, i).ok_or(Error::BadIndex)?;
-        *item = serde::de::Deserialize::deserialize(de).unwrap();
+        *item = serde::de::Deserialize::deserialize(de).map_err(|_| Error::Deserialization)?;
         Ok(())
     }
 
@@ -217,7 +217,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         }
 
         let item = <[T]>::get(self, i).ok_or(Error::BadIndex)?;
-        serde::ser::Serialize::serialize(item, ser).unwrap();
+        serde::ser::Serialize::serialize(item, ser).map_err(|_| Error::Serialization)?;
         Ok(())
     }
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -149,6 +149,7 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
     fn next_path<const TS: usize>(
         state: &mut [usize],
         topic: &mut heapless::String<TS>,
+        separator: char,
     ) -> Result<bool, IterError> {
         let original_length = topic.len();
 
@@ -156,10 +157,10 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
             // Add the array index and separator to the topic name.
             topic
                 .push_str(itoa::Buffer::new().format(state[0]))
-                .and_then(|_| topic.push('/'))
+                .and_then(|_| topic.push(separator))
                 .map_err(|_| IterError::PathLength)?;
 
-            if T::next_path(&mut state[1..], topic)? {
+            if T::next_path(&mut state[1..], topic, separator)? {
                 return Ok(true);
             }
 
@@ -232,6 +233,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
     fn next_path<const TS: usize>(
         state: &mut [usize],
         path: &mut heapless::String<TS>,
+        _separator: char,
     ) -> Result<bool, IterError> {
         if *state.first().ok_or(IterError::PathDepth)? < N {
             // Add the array index to the topic name.

--- a/src/array.rs
+++ b/src/array.rs
@@ -158,7 +158,7 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
                     .write_char(separator)
                     .and_then(|_| topic.write_str(itoa::Buffer::new().format(i)))
                     .map_err(|_| IterError::Length)?;
-                T::next_path(state, depth, topic, separator)
+                T::next_path(state, depth + 1, topic, separator)
             }
             Some(_) => Err(IterError::Next(depth)),
             None => Err(IterError::Depth),

--- a/src/array.rs
+++ b/src/array.rs
@@ -120,10 +120,10 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
             .set_path(path_parts, de)
     }
 
-    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), Error>
+    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut S: serde::Serializer,
+        S: serde::Serializer,
     {
         let i = self.0.index(path_parts.next())?;
 
@@ -206,10 +206,10 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         Ok(())
     }
 
-    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), Error>
+    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut S: serde::Serializer,
+        S: serde::Serializer,
     {
         let i = self.index(path_parts.next())?;
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -110,7 +110,7 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
     fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: &'a mut D) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut D: serde::de::Deserializer<'b>,
+        &'a mut D: serde::Deserializer<'b>,
     {
         let i = self.0.index(path_parts.next())?;
 
@@ -123,7 +123,7 @@ impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
     fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut S: serde::ser::Serializer,
+        &'a mut S: serde::Serializer,
     {
         let i = self.0.index(path_parts.next())?;
 
@@ -193,7 +193,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
     fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: &'a mut D) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut D: serde::de::Deserializer<'b>,
+        &'a mut D: serde::Deserializer<'b>,
     {
         let i = self.index(path_parts.next())?;
 
@@ -202,14 +202,14 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         }
 
         let item = <[T]>::get_mut(self, i).ok_or(Error::BadIndex)?;
-        *item = serde::de::Deserialize::deserialize(de).map_err(|_| Error::Deserialization)?;
+        *item = serde::Deserialize::deserialize(de).map_err(|_| Error::Deserialization)?;
         Ok(())
     }
 
     fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut S: serde::ser::Serializer,
+        &'a mut S: serde::Serializer,
     {
         let i = self.index(path_parts.next())?;
 
@@ -218,7 +218,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned, const N: usize> Miniconf for
         }
 
         let item = <[T]>::get(self, i).ok_or(Error::BadIndex)?;
-        serde::ser::Serialize::serialize(item, ser).map_err(|_| Error::Serialization)?;
+        serde::Serialize::serialize(item, ser).map_err(|_| Error::Serialization)?;
         Ok(())
     }
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,8 +1,5 @@
 use super::{Error, Inner, IterError, Metadata, Miniconf, Outer};
-use core::{
-    fmt::Write,
-    ops::{Deref, DerefMut},
-};
+use core::fmt::Write;
 
 /// An array that exposes each element through their [`Miniconf`] implementation.
 ///
@@ -25,77 +22,8 @@ use core::{
 ///
 /// An `Array` can be constructed using [`From<[T; N]>`](From)/[`Into<miniconf::Array>`]
 /// and the contained value can be accessed through [`Deref`]/[`DerefMut`].
-#[derive(Clone, Copy, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
-#[repr(transparent)]
-pub struct Array<T, const N: usize>([T; N]);
 
-impl<T, const N: usize> Deref for Array<T, N> {
-    type Target = [T; N];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T, const N: usize> DerefMut for Array<T, N> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl<T: Default + Copy, const N: usize> Default for Array<T, N> {
-    fn default() -> Self {
-        Self([T::default(); N])
-    }
-}
-
-impl<T, const N: usize> From<[T; N]> for Array<T, N> {
-    fn from(x: [T; N]) -> Self {
-        Self(x)
-    }
-}
-
-impl<T, const N: usize> AsRef<[T; N]> for Array<T, N> {
-    fn as_ref(&self) -> &[T; N] {
-        self
-    }
-}
-
-impl<T, const N: usize> AsMut<[T; N]> for Array<T, N> {
-    fn as_mut(&mut self) -> &mut [T; N] {
-        self
-    }
-}
-
-impl<T, const N: usize> IntoIterator for Array<T, N> {
-    type Item = T;
-    type IntoIter = <[T; N] as IntoIterator>::IntoIter;
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-impl<'a, T, const N: usize> IntoIterator for &'a Array<T, N> {
-    type Item = <&'a [T; N] as IntoIterator>::Item;
-    type IntoIter = <&'a [T; N] as IntoIterator>::IntoIter;
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-impl<'a, T, const N: usize> IntoIterator for &'a mut Array<T, N> {
-    type Item = <&'a mut [T; N] as IntoIterator>::Item;
-    type IntoIter = <&'a mut [T; N] as IntoIterator>::IntoIter;
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter_mut()
-    }
-}
-
-impl<T, const N: usize> From<Array<T, N>> for [T; N] {
-    fn from(x: Array<T, N>) -> Self {
-        x.0
-    }
-}
+pub type Array<T, const N: usize> = [T; N];
 
 /// Returns the number of digits required to format an integer less than `x`.
 const fn digits(x: usize) -> usize {
@@ -115,10 +43,9 @@ impl<T: Miniconf<Outer>, const N: usize> Miniconf<Inner> for Array<T, N> {
         P: Iterator<Item = &'a str>,
         D: serde::Deserializer<'b>,
     {
-        let i = self.0.index(path_parts.next())?;
+        let i = self.index(path_parts.next())?;
 
-        self.0
-            .get_mut(i)
+        self.get_mut(i)
             .ok_or(Error::BadIndex)?
             .set_path(path_parts, de)
     }
@@ -128,10 +55,9 @@ impl<T: Miniconf<Outer>, const N: usize> Miniconf<Inner> for Array<T, N> {
         P: Iterator<Item = &'a str>,
         S: serde::Serializer,
     {
-        let i = self.0.index(path_parts.next())?;
+        let i = self.index(path_parts.next())?;
 
-        self.0
-            .get(i)
+        self.get(i)
             .ok_or(Error::BadIndex)?
             .get_path(path_parts, ser)
     }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -77,6 +77,8 @@ impl<M: Miniconf + SerDe<S> + ?Sized, const L: usize, const TS: usize, S> Iterat
                     return None;
                 }
                 Err(IterError::Next(depth)) => {
+                    path.clear();
+                    self.state[depth] = 0;
                     self.state[depth - 1] += 1;
                 }
                 e => {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,12 +1,24 @@
-use super::Miniconf;
+use super::{Metadata, Miniconf, SerDe};
 use core::marker::PhantomData;
 use heapless::String;
 
+/// Errors that occur during iteration over topic paths.
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum IterError {
+    /// The provided state vector is not long enough.
+    PathDepth,
+
+    /// The provided topic length is not long enough.
+    PathLength,
+}
+
 /// An iterator over the paths in a Miniconf namespace.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct MiniconfIter<M: ?Sized, const L: usize, const TS: usize> {
+pub struct MiniconfIter<M: ?Sized, const L: usize, const TS: usize, S> {
     /// Zero-size marker field to allow being generic over M and gaining access to M.
-    marker: PhantomData<M>,
+    miniconf: PhantomData<M>,
+    spec: PhantomData<S>,
 
     /// The iteration state.
     ///
@@ -21,28 +33,50 @@ pub struct MiniconfIter<M: ?Sized, const L: usize, const TS: usize> {
     ///
     /// It may be None to indicate unknown length.
     count: Option<usize>,
-
-    separator: char,
 }
 
-impl<M: ?Sized, const L: usize, const TS: usize> MiniconfIter<M, L, TS> {
-    pub fn new(count: Option<usize>, separator: char) -> Self {
+impl<M: ?Sized + Miniconf, const L: usize, const TS: usize, S> MiniconfIter<M, L, TS, S> {
+    pub fn metadata() -> Result<Metadata, IterError> {
+        let meta = M::metadata();
+        if TS < meta.max_length {
+            return Err(IterError::PathLength);
+        }
+
+        if L < meta.max_depth {
+            return Err(IterError::PathDepth);
+        }
+        Ok(meta)
+    }
+
+    pub fn new() -> Result<Self, IterError> {
+        let meta = Self::metadata()?;
+        Ok(Self {
+            count: Some(meta.count),
+            ..Default::default()
+        })
+    }
+}
+
+impl<M: ?Sized, const L: usize, const TS: usize, S> Default for MiniconfIter<M, L, TS, S> {
+    fn default() -> Self {
         Self {
-            count,
-            separator,
-            marker: PhantomData,
+            count: None,
+            miniconf: PhantomData,
+            spec: PhantomData,
             state: [0; L],
         }
     }
 }
 
-impl<M: Miniconf + ?Sized, const L: usize, const TS: usize> Iterator for MiniconfIter<M, L, TS> {
+impl<M: Miniconf + SerDe<S> + ?Sized, const L: usize, const TS: usize, S> Iterator
+    for MiniconfIter<M, L, TS, S>
+{
     type Item = String<TS>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut path = Self::Item::new();
 
-        if M::next_path(&mut self.state, &mut path, self.separator).unwrap() {
+        if M::next_path(&mut self.state, &mut path, <M as SerDe<S>>::SEPARATOR).unwrap() {
             self.count = self.count.map(|c| c - 1);
             Some(path)
         } else {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -21,23 +21,17 @@ pub struct MiniconfIter<M: ?Sized, const L: usize, const TS: usize> {
     ///
     /// It may be None to indicate unknown length.
     count: Option<usize>,
-}
 
-impl<M: ?Sized, const L: usize, const TS: usize> Default for MiniconfIter<M, L, TS> {
-    fn default() -> Self {
-        MiniconfIter {
-            marker: PhantomData,
-            state: [0; L],
-            count: None,
-        }
-    }
+    separator: char,
 }
 
 impl<M: ?Sized, const L: usize, const TS: usize> MiniconfIter<M, L, TS> {
-    pub fn new(count: Option<usize>) -> Self {
+    pub fn new(count: Option<usize>, separator: char) -> Self {
         Self {
             count,
-            ..Default::default()
+            separator,
+            marker: PhantomData,
+            state: [0; L],
         }
     }
 }
@@ -48,7 +42,7 @@ impl<M: Miniconf + ?Sized, const L: usize, const TS: usize> Iterator for Minicon
     fn next(&mut self) -> Option<Self::Item> {
         let mut path = Self::Item::new();
 
-        if M::next_path(&mut self.state, &mut path).unwrap() {
+        if M::next_path(&mut self.state, &mut path, self.separator).unwrap() {
             self.count = self.count.map(|c| c - 1);
             Some(path)
         } else {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,17 +1,6 @@
-use super::{Metadata, Miniconf, SerDe};
+use super::{IterError, Metadata, Miniconf, SerDe};
 use core::marker::PhantomData;
 use heapless::String;
-
-/// Errors that occur during iteration over topic paths.
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum IterError {
-    /// The provided state vector is not long enough.
-    PathDepth,
-
-    /// The provided topic length is not long enough.
-    PathLength,
-}
 
 /// An iterator over the paths in a Miniconf namespace.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -50,11 +39,11 @@ impl<M: ?Sized + Miniconf, const L: usize, const TS: usize, S> MiniconfIter<M, L
     pub fn metadata() -> Result<Metadata, IterError> {
         let meta = M::metadata();
         if TS < meta.max_length {
-            return Err(IterError::PathLength);
+            return Err(IterError::Length);
         }
 
         if L < meta.max_depth {
-            return Err(IterError::PathDepth);
+            return Err(IterError::Depth);
         }
         Ok(meta)
     }
@@ -76,12 +65,24 @@ impl<M: Miniconf + SerDe<S> + ?Sized, const L: usize, const TS: usize, S> Iterat
     fn next(&mut self) -> Option<Self::Item> {
         let mut path = Self::Item::new();
 
-        if M::next_path(&mut self.state, &mut path, M::SEPARATOR).unwrap() {
-            self.count = self.count.map(|c| c - 1);
-            Some(path)
-        } else {
-            debug_assert_eq!(self.count.unwrap_or_default(), 0);
-            None
+        loop {
+            match M::next_path(&self.state, 0, &mut path, M::SEPARATOR) {
+                Ok(depth) => {
+                    self.count = self.count.map(|c| c - 1);
+                    self.state[depth] += 1;
+                    return Some(path);
+                }
+                Err(IterError::Next(0)) => {
+                    debug_assert_eq!(self.count.unwrap_or_default(), 0);
+                    return None;
+                }
+                Err(IterError::Next(depth)) => {
+                    self.state[depth - 1] += 1;
+                }
+                e => {
+                    e.unwrap();
+                }
+            }
         }
     }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -35,6 +35,17 @@ pub struct MiniconfIter<M: ?Sized, const L: usize, const TS: usize, S> {
     count: Option<usize>,
 }
 
+impl<M: ?Sized, const L: usize, const TS: usize, S> Default for MiniconfIter<M, L, TS, S> {
+    fn default() -> Self {
+        Self {
+            count: None,
+            miniconf: PhantomData,
+            spec: PhantomData,
+            state: [0; L],
+        }
+    }
+}
+
 impl<M: ?Sized + Miniconf, const L: usize, const TS: usize, S> MiniconfIter<M, L, TS, S> {
     pub fn metadata() -> Result<Metadata, IterError> {
         let meta = M::metadata();
@@ -57,17 +68,6 @@ impl<M: ?Sized + Miniconf, const L: usize, const TS: usize, S> MiniconfIter<M, L
     }
 }
 
-impl<M: ?Sized, const L: usize, const TS: usize, S> Default for MiniconfIter<M, L, TS, S> {
-    fn default() -> Self {
-        Self {
-            count: None,
-            miniconf: PhantomData,
-            spec: PhantomData,
-            state: [0; L],
-        }
-    }
-}
-
 impl<M: Miniconf + SerDe<S> + ?Sized, const L: usize, const TS: usize, S> Iterator
     for MiniconfIter<M, L, TS, S>
 {
@@ -76,7 +76,7 @@ impl<M: Miniconf + SerDe<S> + ?Sized, const L: usize, const TS: usize, S> Iterat
     fn next(&mut self) -> Option<Self::Item> {
         let mut path = Self::Item::new();
 
-        if M::next_path(&mut self.state, &mut path, <M as SerDe<S>>::SEPARATOR).unwrap() {
+        if M::next_path(&mut self.state, &mut path, M::SEPARATOR).unwrap() {
             self.count = self.count.map(|c| c - 1);
             Some(path)
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![doc = include_str!("../README.md")]
 
 use core::fmt::Write;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ pub trait Miniconf {
 
 pub trait Spec {}
 
-pub trait MiniconfSpec<S: Spec>: Miniconf {
+pub trait SerDe<S: Spec>: Miniconf {
     const SEPARATOR: char;
 
     /// Create an iterator of all possible paths.
@@ -268,7 +268,7 @@ impl Spec for JsonCoreSlash {}
 
 /// Access items with `'/'` as path separator and JSON (from `serde-json-core`)
 /// as serialization/deserialization format.
-impl<T> MiniconfSpec<JsonCoreSlash> for T
+impl<T> SerDe<JsonCoreSlash> for T
 where
     T: Miniconf,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,7 @@ pub trait Miniconf {
 }
 
 pub trait SerDe<S>: Miniconf {
+    /// The path hierarchy separator.
     const SEPARATOR: char;
 
     /// Create an iterator of all possible paths.
@@ -249,23 +250,13 @@ where
 
     fn set(&mut self, path: &str, data: &[u8]) -> Result<usize, Error> {
         let mut de = serde_json_core::de::Deserializer::new(data);
-        self.set_path(
-            &mut path
-                .split(<Self as SerDe<JsonCoreSlash>>::SEPARATOR)
-                .peekable(),
-            &mut de,
-        )?;
+        self.set_path(&mut path.split(Self::SEPARATOR).peekable(), &mut de)?;
         de.end().map_err(|_| Error::Deserialization)
     }
 
     fn get(&self, path: &str, data: &mut [u8]) -> Result<usize, Error> {
         let mut ser = serde_json_core::ser::Serializer::new(data);
-        self.get_path(
-            &mut path
-                .split(<Self as SerDe<JsonCoreSlash>>::SEPARATOR)
-                .peekable(),
-            &mut ser,
-        )?;
+        self.get_path(&mut path.split(Self::SEPARATOR).peekable(), &mut ser)?;
         Ok(ser.end())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,7 @@ pub trait Miniconf {
     /// # Returns
     /// A [MiniconfIter] of paths or an [IterError] if `L` or `TS` are insufficient.
     fn iter_paths<const L: usize, const TS: usize>(
+        separator: char,
     ) -> Result<iter::MiniconfIter<Self, L, TS>, IterError> {
         let meta = Self::metadata();
 
@@ -152,7 +153,7 @@ pub trait Miniconf {
             return Err(IterError::PathDepth);
         }
 
-        Ok(Self::unchecked_iter_paths(Some(meta.count)))
+        Ok(Self::unchecked_iter_paths(Some(meta.count), separator))
     }
 
     /// Create an iterator of all possible paths.
@@ -172,8 +173,9 @@ pub trait Miniconf {
     /// * `TS` - The maximum length of the path in bytes.
     fn unchecked_iter_paths<const L: usize, const TS: usize>(
         count: core::option::Option<usize>,
+        separator: char,
     ) -> iter::MiniconfIter<Self, L, TS> {
-        iter::MiniconfIter::new(count)
+        iter::MiniconfIter::new(count, separator)
     }
 
     /// Deserialize an element by path.
@@ -225,6 +227,7 @@ pub trait Miniconf {
     fn next_path<const TS: usize>(
         state: &mut [usize],
         path: &mut heapless::String<TS>,
+        separator: char,
     ) -> Result<bool, IterError>;
 
     /// Get metadata about the paths in the namespace.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,9 +212,8 @@ pub trait SerDe<S>: Miniconf {
     ///
     /// # Returns
     /// A [MiniconfIter] of paths or an [IterError] if `L` or `TS` are insufficient.
-    fn unchecked_iter_paths<const L: usize, const TS: usize>() -> iter::MiniconfIter<Self, L, TS, S>
-    {
-        iter::MiniconfIter::default()
+    fn unchecked_iter_paths<const L: usize, const TS: usize>() -> MiniconfIter<Self, L, TS, S> {
+        MiniconfIter::default()
     }
 
     /// Update an element by path.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ pub trait Miniconf {
     ) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut D: serde::de::Deserializer<'b>;
+        &'a mut D: serde::Deserializer<'b>;
 
     /// Serialize an element by path.
     ///
@@ -156,7 +156,7 @@ pub trait Miniconf {
     fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut S: serde::ser::Serializer;
+        &'a mut S: serde::Serializer;
 
     /// Get the next path in the namespace.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,10 +142,10 @@ pub trait Miniconf {
     ///
     /// # Returns
     /// May return an [Error].
-    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), Error>
+    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut S: serde::Serializer;
+        S: serde::Serializer;
 
     /// Get the next path in the namespace.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ pub trait Miniconf {
     ///
     /// # Returns
     /// May return an [Error].
-    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<(), Error>
+    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<S::Ok, Error>
     where
         P: Peekable<Item = &'a str>,
         S: serde::Serializer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,14 +125,10 @@ pub trait Miniconf {
     ///
     /// # Returns
     /// May return an [Error].
-    fn set_path<'a, 'b: 'a, P, D>(
-        &mut self,
-        path_parts: &mut P,
-        de: &'a mut D,
-    ) -> Result<(), Error>
+    fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut D: serde::Deserializer<'b>;
+        D: serde::Deserializer<'b>;
 
     /// Serialize an element by path.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,17 +153,17 @@ pub trait Miniconf {
     /// This is usually not called directly but through a [MiniconfIter] returned by [SerDe::iter_paths].
     ///
     /// # Args
-    /// * `state`: A state array indicating the path to be retrieved.
-    ///   A zeroed vector indicates the first path. The vector is advanced
-    ///   such that the next element will be retrieved when called again.
-    ///   The array needs to be at least as long as the maximum path depth.
+    /// * `state`: A state slice indicating the path to be retrieved.
+    ///   A zeroed vector indicates the first path.
+    ///   The slice needs to be at least as long as the maximum path depth.
+    /// * `depth`: The path depth this struct is at.
     /// * `path`: A string to write the path into.
     /// * `separator` - The path hierarchy separator.
     ///
     /// # Returns
-    /// A `bool` indicating a valid path was written to `path` from the given `state`.
-    /// If `false`, `path` is invalid and there are no more paths within `self` at and
-    /// beyond `state`.
+    /// A `usize` indicating the final depth of the valid path.
+    /// Must return `IterError::Next(usize)` with the final depth if there are
+    /// no more elements at that index and depth.
     /// May return `IterError` indicating insufficient `state` or `path` size.
     fn next_path(
         state: &[usize],

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -1,6 +1,6 @@
 use serde_json_core::heapless::{String, Vec};
 
-use crate::MiniconfJson;
+use crate::{Miniconf, MiniconfSpec};
 use minimq::{
     embedded_nal::{IpAddr, TcpClientStack},
     embedded_time,
@@ -50,13 +50,13 @@ mod sm {
         }
     }
 
-    pub struct Context<C: embedded_time::Clock, M: super::MiniconfJson + ?Sized> {
+    pub struct Context<C: embedded_time::Clock, M: super::Miniconf + ?Sized> {
         clock: C,
         timeout: Option<Instant<C>>,
         pub republish_state: super::MiniconfIter<M>,
     }
 
-    impl<C: embedded_time::Clock, M: super::MiniconfJson> Context<C, M> {
+    impl<C: embedded_time::Clock, M: super::Miniconf> Context<C, M> {
         pub fn new(clock: C) -> Self {
             Self {
                 clock,
@@ -74,7 +74,7 @@ mod sm {
         }
     }
 
-    impl<C: embedded_time::Clock, M: super::MiniconfJson> StateMachineContext for Context<C, M> {
+    impl<C: embedded_time::Clock, M: super::Miniconf> StateMachineContext for Context<C, M> {
         fn start_republish_timeout(&mut self) {
             self.timeout.replace(
                 self.clock.try_now().unwrap() + super::REPUBLISH_TIMEOUT_SECONDS.seconds(),
@@ -117,7 +117,7 @@ impl<'a> Command<'a> {
 /// MQTT settings interface.
 ///
 /// # Design
-/// The MQTT client places the [MiniconfJson] paths `<path>` at the MQTT `<prefix>/settings/<path>` topic,
+/// The MQTT client places the [Miniconf] paths `<path>` at the MQTT `<prefix>/settings/<path>` topic,
 /// where `<prefix>` is provided in the client constructor.
 ///
 /// It publishes its alive-ness as a `1` to `<prefix>/alive` and sets a will to publish `0` there when
@@ -159,7 +159,7 @@ impl<'a> Command<'a> {
 /// ```
 pub struct MqttClient<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
 where
-    Settings: MiniconfJson + Clone,
+    Settings: Miniconf + Clone,
     Stack: TcpClientStack,
     Clock: embedded_time::Clock,
 {
@@ -175,7 +175,7 @@ where
 impl<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
     MqttClient<Settings, Stack, Clock, MESSAGE_SIZE>
 where
-    Settings: MiniconfJson + Clone,
+    Settings: Miniconf + Clone,
     Stack: TcpClientStack,
     Clock: embedded_time::Clock + Clone,
 {

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -1,6 +1,6 @@
 use serde_json_core::heapless::{String, Vec};
 
-use crate::Miniconf;
+use crate::MiniconfJson;
 use minimq::{
     embedded_nal::{IpAddr, TcpClientStack},
     embedded_time,
@@ -50,13 +50,13 @@ mod sm {
         }
     }
 
-    pub struct Context<C: embedded_time::Clock, M: super::Miniconf + ?Sized> {
+    pub struct Context<C: embedded_time::Clock, M: super::MiniconfJson + ?Sized> {
         clock: C,
         timeout: Option<Instant<C>>,
         pub republish_state: super::MiniconfIter<M>,
     }
 
-    impl<C: embedded_time::Clock, M: super::Miniconf> Context<C, M> {
+    impl<C: embedded_time::Clock, M: super::MiniconfJson> Context<C, M> {
         pub fn new(clock: C) -> Self {
             Self {
                 clock,
@@ -74,7 +74,7 @@ mod sm {
         }
     }
 
-    impl<C: embedded_time::Clock, M: super::Miniconf> StateMachineContext for Context<C, M> {
+    impl<C: embedded_time::Clock, M: super::MiniconfJson> StateMachineContext for Context<C, M> {
         fn start_republish_timeout(&mut self) {
             self.timeout.replace(
                 self.clock.try_now().unwrap() + super::REPUBLISH_TIMEOUT_SECONDS.seconds(),
@@ -117,7 +117,7 @@ impl<'a> Command<'a> {
 /// MQTT settings interface.
 ///
 /// # Design
-/// The MQTT client places the [Miniconf] paths `<path>` at the MQTT `<prefix>/settings/<path>` topic,
+/// The MQTT client places the [MiniconfJson] paths `<path>` at the MQTT `<prefix>/settings/<path>` topic,
 /// where `<prefix>` is provided in the client constructor.
 ///
 /// It publishes its alive-ness as a `1` to `<prefix>/alive` and sets a will to publish `0` there when
@@ -159,7 +159,7 @@ impl<'a> Command<'a> {
 /// ```
 pub struct MqttClient<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
 where
-    Settings: Miniconf + Clone,
+    Settings: MiniconfJson + Clone,
     Stack: TcpClientStack,
     Clock: embedded_time::Clock,
 {
@@ -175,7 +175,7 @@ where
 impl<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
     MqttClient<Settings, Stack, Clock, MESSAGE_SIZE>
 where
-    Settings: Miniconf + Clone,
+    Settings: MiniconfJson + Clone,
     Stack: TcpClientStack,
     Clock: embedded_time::Clock + Clone,
 {

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -61,7 +61,7 @@ mod sm {
             Self {
                 clock,
                 timeout: None,
-                republish_state: super::MiniconfIter::default(),
+                republish_state: Default::default(),
             }
         }
 
@@ -82,7 +82,7 @@ mod sm {
         }
 
         fn start_republish(&mut self) {
-            self.republish_state = super::MiniconfIter::default();
+            self.republish_state = Default::default();
         }
     }
 }
@@ -481,7 +481,7 @@ where
                             // always fit into it.
                             self.properties_cache
                                 .replace(Vec::from_slice(binary_props).unwrap());
-                            self.listing_state.replace(super::MiniconfIter::default());
+                            self.listing_state.replace(Default::default());
                         } else {
                             log::info!("Discarding `List` without `ResponseTopic`");
                         }

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -100,8 +100,8 @@ impl<'a> Command<'a> {
         if path == "list" {
             Ok(Command::List)
         } else {
-            match path.split_once('/') {
-                Some(("settings", path)) => {
+            match path.strip_prefix("settings") {
+                Some(path) => {
                     if value.is_empty() {
                         Ok(Command::Get { path })
                     } else {
@@ -217,7 +217,7 @@ where
         )?;
 
         let meta = MiniconfIter::<Settings>::metadata().unwrap();
-        assert!(prefix.len() + "/settings/".len() + meta.max_length <= MAX_TOPIC_LENGTH);
+        assert!(prefix.len() + "/settings".len() + meta.max_length <= MAX_TOPIC_LENGTH);
 
         Ok(Self {
             mqtt,
@@ -295,7 +295,7 @@ where
 
             let mut prefixed_topic = self.prefix.clone();
             prefixed_topic
-                .push_str("/settings/")
+                .push_str("/settings")
                 .and_then(|_| prefixed_topic.push_str(&topic))
                 .unwrap();
 
@@ -502,7 +502,7 @@ where
                             // Note(unwrap): We check that the string will fit during
                             // construction.
                             topic
-                                .push_str("/settings/")
+                                .push_str("/settings")
                                 .and_then(|_| topic.push_str(path))
                                 .unwrap();
 

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -61,7 +61,7 @@ mod sm {
             Self {
                 clock,
                 timeout: None,
-                republish_state: Default::default(),
+                republish_state: super::MiniconfIter::new(None, '/'),
             }
         }
 
@@ -82,7 +82,7 @@ mod sm {
         }
 
         fn start_republish(&mut self) {
-            self.republish_state = Default::default();
+            self.republish_state = super::MiniconfIter::new(None, '/');
         }
     }
 }
@@ -482,7 +482,8 @@ where
                             // always fit into it.
                             self.properties_cache
                                 .replace(Vec::from_slice(binary_props).unwrap());
-                            self.listing_state.replace(Default::default());
+                            self.listing_state
+                                .replace(super::MiniconfIter::new(None, '/'));
                         } else {
                             log::info!("Discarding `List` without `ResponseTopic`");
                         }

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -1,6 +1,6 @@
 use serde_json_core::heapless::{String, Vec};
 
-use crate::{Miniconf, MiniconfSpec};
+use crate::{Miniconf, SerDe};
 use minimq::{
     embedded_nal::{IpAddr, TcpClientStack},
     embedded_time,

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,4 +1,4 @@
-use super::{Error, IterError, Metadata, Miniconf, Peekable};
+use super::{Error, IterError, Metadata, Miniconf};
 use core::{
     fmt::Write,
     ops::{Deref, DerefMut},
@@ -89,7 +89,7 @@ impl<T> From<Option<T>> for core::option::Option<T> {
 impl<T: Miniconf> Miniconf for Option<T> {
     fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), Error>
     where
-        P: Peekable<Item = &'a str>,
+        P: Iterator<Item = &'a str>,
         D: serde::Deserializer<'b>,
     {
         if let Some(inner) = self.0.as_mut() {
@@ -101,7 +101,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
 
     fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<S::Ok, Error>
     where
-        P: Peekable<Item = &'a str>,
+        P: Iterator<Item = &'a str>,
         S: serde::Serializer,
     {
         if let Some(inner) = self.0.as_ref() {
@@ -128,7 +128,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
 impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::Option<T> {
     fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), Error>
     where
-        P: Peekable<Item = &'a str>,
+        P: Iterator<Item = &'a str>,
         D: serde::Deserializer<'b>,
     {
         if path_parts.next().is_some() {
@@ -145,7 +145,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
 
     fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<S::Ok, Error>
     where
-        P: Peekable<Item = &'a str>,
+        P: Iterator<Item = &'a str>,
         S: serde::Serializer,
     {
         if path_parts.next().is_some() {

--- a/src/option.rs
+++ b/src/option.rs
@@ -96,10 +96,10 @@ impl<T: Miniconf> Miniconf for Option<T> {
         }
     }
 
-    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), Error>
+    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut S: serde::Serializer,
+        S: serde::Serializer,
     {
         if let Some(inner) = self.0.as_ref() {
             inner.get_path(path_parts, ser)
@@ -139,10 +139,10 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
         Ok(())
     }
 
-    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), Error>
+    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut S: serde::Serializer,
+        S: serde::Serializer,
     {
         if path_parts.peek().is_some() {
             return Err(Error::PathTooLong);

--- a/src/option.rs
+++ b/src/option.rs
@@ -9,7 +9,7 @@ use core::ops::{Deref, DerefMut};
 ///
 /// In both forms, the `Option` may be marked with `#[miniconf(defer)]`
 /// and be `None` at run-time. This makes the corresponding part of the namespace inaccessible
-/// at run-time. It will still be iterated over by [`Miniconf::iter_paths()`] but cannot be
+/// at run-time. It will still be iterated over by [`crate::SerDe::iter_paths()`] but cannot be
 /// `get()` or `set()` using the [`Miniconf`] API.
 ///
 /// This is intended as a mechanism to provide run-time construction of the namespace. In some

--- a/src/option.rs
+++ b/src/option.rs
@@ -84,10 +84,10 @@ impl<T> From<Option<T>> for core::option::Option<T> {
 }
 
 impl<T: Miniconf> Miniconf for Option<T> {
-    fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: &'a mut D) -> Result<(), Error>
+    fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut D: serde::Deserializer<'b>,
+        D: serde::Deserializer<'b>,
     {
         if let Some(inner) = self.0.as_mut() {
             inner.set_path(path_parts, de)
@@ -122,10 +122,10 @@ impl<T: Miniconf> Miniconf for Option<T> {
 }
 
 impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::Option<T> {
-    fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: &'a mut D) -> Result<(), Error>
+    fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut D: serde::Deserializer<'b>,
+        D: serde::Deserializer<'b>,
     {
         if path_parts.peek().is_some() {
             return Err(Error::PathTooLong);

--- a/src/option.rs
+++ b/src/option.rs
@@ -96,7 +96,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
         }
     }
 
-    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<(), Error>
+    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<S::Ok, Error>
     where
         P: Peekable<Item = &'a str>,
         S: serde::Serializer,
@@ -139,7 +139,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
         Ok(())
     }
 
-    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<(), Error>
+    fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: S) -> Result<S::Ok, Error>
     where
         P: Peekable<Item = &'a str>,
         S: serde::Serializer,
@@ -149,8 +149,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
         }
 
         let data = self.as_ref().ok_or(Error::PathAbsent)?;
-        serde::Serialize::serialize(data, ser).map_err(|_| Error::Serialization)?;
-        Ok(())
+        serde::Serialize::serialize(data, ser).map_err(|_| Error::Serialization)
     }
 
     fn metadata() -> Metadata {

--- a/src/option.rs
+++ b/src/option.rs
@@ -134,7 +134,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
             return Err(Error::PathAbsent);
         }
 
-        *self = Some(serde::de::Deserialize::deserialize(de).unwrap());
+        *self = Some(serde::de::Deserialize::deserialize(de).map_err(|_| Error::Deserialization)?);
         Ok(())
     }
 
@@ -148,7 +148,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
         }
 
         let data = self.as_ref().ok_or(Error::PathAbsent)?;
-        serde::ser::Serialize::serialize(data, ser).unwrap();
+        serde::ser::Serialize::serialize(data, ser).map_err(|_| Error::Serialization)?;
         Ok(())
     }
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -115,8 +115,9 @@ impl<T: Miniconf> Miniconf for Option<T> {
     fn next_path<const TS: usize>(
         state: &mut [usize],
         path: &mut heapless::String<TS>,
+        separator: char,
     ) -> Result<bool, IterError> {
-        T::next_path(state, path)
+        T::next_path(state, path, separator)
     }
 }
 
@@ -162,12 +163,13 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
     fn next_path<const TS: usize>(
         state: &mut [usize],
         path: &mut heapless::String<TS>,
+        separator: char,
     ) -> Result<bool, IterError> {
         if *state.first().ok_or(IterError::PathDepth)? == 0 {
             state[0] += 1;
 
             // Remove trailing slash added by a deferring container (array or struct).
-            if path.ends_with('/') {
+            if path.ends_with(separator) {
                 path.pop();
             }
             Ok(true)

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,4 +1,4 @@
-use super::{Error, IterError, Metadata, Miniconf};
+use super::{Error, Inner, IterError, Metadata, Miniconf, Outer};
 use core::{
     fmt::Write,
     ops::{Deref, DerefMut},
@@ -86,7 +86,7 @@ impl<T> From<Option<T>> for core::option::Option<T> {
     }
 }
 
-impl<T: Miniconf> Miniconf for Option<T> {
+impl<T: Miniconf<Outer>> Miniconf<Inner> for Option<T> {
     fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), Error>
     where
         P: Iterator<Item = &'a str>,
@@ -125,7 +125,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
     }
 }
 
-impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::Option<T> {
+impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf<Outer> for core::option::Option<T> {
     fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: D) -> Result<(), Error>
     where
         P: Iterator<Item = &'a str>,

--- a/src/option.rs
+++ b/src/option.rs
@@ -87,7 +87,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
     fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: &'a mut D) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut D: serde::de::Deserializer<'b>,
+        &'a mut D: serde::Deserializer<'b>,
     {
         if let Some(inner) = self.0.as_mut() {
             inner.set_path(path_parts, de)
@@ -99,7 +99,7 @@ impl<T: Miniconf> Miniconf for Option<T> {
     fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut S: serde::ser::Serializer,
+        &'a mut S: serde::Serializer,
     {
         if let Some(inner) = self.0.as_ref() {
             inner.get_path(path_parts, ser)
@@ -125,7 +125,7 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
     fn set_path<'a, 'b: 'a, P, D>(&mut self, path_parts: &mut P, de: &'a mut D) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut D: serde::de::Deserializer<'b>,
+        &'a mut D: serde::Deserializer<'b>,
     {
         if path_parts.peek().is_some() {
             return Err(Error::PathTooLong);
@@ -135,21 +135,21 @@ impl<T: crate::Serialize + crate::DeserializeOwned> Miniconf for core::option::O
             return Err(Error::PathAbsent);
         }
 
-        *self = Some(serde::de::Deserialize::deserialize(de).map_err(|_| Error::Deserialization)?);
+        *self = Some(serde::Deserialize::deserialize(de).map_err(|_| Error::Deserialization)?);
         Ok(())
     }
 
     fn get_path<'a, P, S>(&self, path_parts: &mut P, ser: &'a mut S) -> Result<(), Error>
     where
         P: Peekable<Item = &'a str>,
-        &'a mut S: serde::ser::Serializer,
+        &'a mut S: serde::Serializer,
     {
         if path_parts.peek().is_some() {
             return Err(Error::PathTooLong);
         }
 
         let data = self.as_ref().ok_or(Error::PathAbsent)?;
-        serde::ser::Serialize::serialize(data, ser).map_err(|_| Error::Serialization)?;
+        serde::Serialize::serialize(data, ser).map_err(|_| Error::Serialization)?;
         Ok(())
     }
 

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -74,6 +74,7 @@ fn simple_array_indexing() {
     assert_eq!(metadata.count, 3);
 }
 
+/*
 #[test]
 fn array_iter() {
     #[derive(Miniconf, Default, Clone, Copy, Debug, PartialEq)]
@@ -95,6 +96,7 @@ fn array_iter() {
 
     for _i in s.a.iter_mut().flatten() {}
 }
+ */
 
 #[test]
 fn array_of_structs_indexing() {

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,4 +1,4 @@
-use miniconf::{Array, Error, Miniconf, MiniconfJson};
+use miniconf::{Array, Error, Miniconf, MiniconfSpec};
 use serde::Deserialize;
 
 #[derive(Debug, Default, Miniconf, Deserialize)]
@@ -192,7 +192,7 @@ fn null_array() {
         #[miniconf(defer)]
         data: [u32; 0],
     }
-    assert!(S::iter_paths::<2, 6>('/').unwrap().next().is_none());
+    assert!(S::iter_paths::<2, 6>().unwrap().next().is_none());
 }
 
 #[test]
@@ -206,5 +206,5 @@ fn null_miniconf_array() {
         #[miniconf(defer)]
         data: Array<I, 0>,
     }
-    assert!(S::iter_paths::<3, 8>('/').unwrap().next().is_none());
+    assert!(S::iter_paths::<3, 8>().unwrap().next().is_none());
 }

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -24,14 +24,14 @@ fn simple_array() {
     let mut s = S::default();
 
     // Updating a single field should succeed.
-    s.set("a/0", "99".as_bytes()).unwrap();
+    s.set("/a/0", "99".as_bytes()).unwrap();
     assert_eq!(99, s.a[0]);
 
     // Updating entire array atomically is not supported.
-    assert!(s.set("a", "[1,2,3]".as_bytes()).is_err());
+    assert!(s.set("/a", "[1,2,3]".as_bytes()).is_err());
 
     // Invalid index should generate an error.
-    assert!(s.set("a/100", "99".as_bytes()).is_err());
+    assert!(s.set("/a/100", "99".as_bytes()).is_err());
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn nonexistent_field() {
 
     let mut s = S::default();
 
-    assert!(s.set("a/1/b", "7".as_bytes()).is_err());
+    assert!(s.set("/a/1/b", "7".as_bytes()).is_err());
 }
 
 #[test]
@@ -57,20 +57,20 @@ fn simple_array_indexing() {
 
     let mut s = S::default();
 
-    s.set("a/1", "7".as_bytes()).unwrap();
+    s.set("/a/1", "7".as_bytes()).unwrap();
 
     assert_eq!([0, 7, 0], s.a);
 
     // Ensure that setting an out-of-bounds index generates an error.
     assert!(matches!(
-        s.set("a/3", "7".as_bytes()).unwrap_err(),
+        s.set("/a/3", "7".as_bytes()).unwrap_err(),
         Error::BadIndex
     ));
 
     // Test metadata
     let metadata = S::metadata();
     assert_eq!(metadata.max_depth, 2);
-    assert_eq!(metadata.max_length, "a/2".len());
+    assert_eq!(metadata.max_length, "/a/2".len());
     assert_eq!(metadata.count, 3);
 }
 
@@ -111,7 +111,7 @@ fn array_of_structs_indexing() {
 
     let mut s = S::default();
 
-    s.set("a/1/b", "7".as_bytes()).unwrap();
+    s.set("/a/1/b", "7".as_bytes()).unwrap();
 
     let expected = {
         let mut e = S::default();
@@ -124,7 +124,7 @@ fn array_of_structs_indexing() {
     // Test metadata
     let metadata = S::metadata();
     assert_eq!(metadata.max_depth, 3);
-    assert_eq!(metadata.max_length, "a/2/b".len());
+    assert_eq!(metadata.max_length, "/a/2/b".len());
     assert_eq!(metadata.count, 3);
 }
 
@@ -138,7 +138,7 @@ fn array_of_arrays() {
 
     let mut s = S::default();
 
-    s.set("data/0/0", "7".as_bytes()).unwrap();
+    s.set("/data/0/0", "7".as_bytes()).unwrap();
 
     let expected = {
         let mut e = S::default();
@@ -158,7 +158,7 @@ fn atomic_array() {
 
     let mut s = S::default();
 
-    s.set("data", "[1, 2]".as_bytes()).unwrap();
+    s.set("/data", "[1, 2]".as_bytes()).unwrap();
 
     let expected = {
         let mut e = S::default();
@@ -181,7 +181,7 @@ fn short_array() {
     // Test metadata
     let meta = S::metadata();
     assert_eq!(meta.max_depth, 2);
-    assert_eq!(meta.max_length, "data/0".len());
+    assert_eq!(meta.max_length, "/data/0".len());
     assert_eq!(meta.count, 1);
 }
 

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -192,7 +192,7 @@ fn null_array() {
         #[miniconf(defer)]
         data: [u32; 0],
     }
-    assert!(S::iter_paths::<2, 6>().unwrap().next().is_none());
+    assert!(S::iter_paths::<2, 6>('/').unwrap().next().is_none());
 }
 
 #[test]
@@ -206,5 +206,5 @@ fn null_miniconf_array() {
         #[miniconf(defer)]
         data: Array<I, 0>,
     }
-    assert!(S::iter_paths::<3, 8>().unwrap().next().is_none());
+    assert!(S::iter_paths::<3, 8>('/').unwrap().next().is_none());
 }

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -192,7 +192,7 @@ fn null_array() {
         #[miniconf(defer)]
         data: [u32; 0],
     }
-    assert!(S::iter_paths::<2, 6>().unwrap().next().is_none());
+    assert!(S::iter_paths::<2, 7>().unwrap().next().is_none());
 }
 
 #[test]
@@ -206,5 +206,5 @@ fn null_miniconf_array() {
         #[miniconf(defer)]
         data: Array<I, 0>,
     }
-    assert!(S::iter_paths::<3, 8>().unwrap().next().is_none());
+    assert!(S::iter_paths::<3, 9>().unwrap().next().is_none());
 }

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,4 +1,4 @@
-use miniconf::{Array, Error, Miniconf, MiniconfSpec};
+use miniconf::{Array, Error, Miniconf, SerDe};
 use serde::Deserialize;
 
 #[derive(Debug, Default, Miniconf, Deserialize)]

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,4 +1,4 @@
-use miniconf::{Array, Error, Miniconf};
+use miniconf::{Array, Error, Miniconf, MiniconfJson};
 use serde::Deserialize;
 
 #[derive(Debug, Default, Miniconf, Deserialize)]

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -1,4 +1,4 @@
-use miniconf::{Miniconf, MiniconfJson};
+use miniconf::{Miniconf, MiniconfSpec};
 use serde::{Deserialize, Serialize};
 
 #[test]

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -16,14 +16,14 @@ fn simple_enum() {
 
     let mut s = S { v: Variant::A };
 
-    s.set("v", "\"B\"".as_bytes()).unwrap();
+    s.set("/v", "\"B\"".as_bytes()).unwrap();
 
     assert_eq!(s.v, Variant::B);
 
     // Test metadata
     let metadata = S::metadata();
     assert_eq!(metadata.max_depth, 1);
-    assert_eq!(metadata.max_length, "v".len());
+    assert_eq!(metadata.max_length, "/v".len());
     assert_eq!(metadata.count, 1);
 }
 

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -1,4 +1,4 @@
-use miniconf::Miniconf;
+use miniconf::{Miniconf, MiniconfJson};
 use serde::{Deserialize, Serialize};
 
 #[test]

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -1,4 +1,4 @@
-use miniconf::{Miniconf, MiniconfSpec};
+use miniconf::{Miniconf, SerDe};
 use serde::{Deserialize, Serialize};
 
 #[test]

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -1,4 +1,4 @@
-use miniconf::{Miniconf, MiniconfJson};
+use miniconf::{Miniconf, MiniconfSpec};
 use serde::{Deserialize, Serialize};
 
 #[test]

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -9,13 +9,13 @@ fn generic_type() {
     }
 
     let mut settings = Settings::<f32>::default();
-    settings.set("data", b"3.0").unwrap();
+    settings.set("/data", b"3.0").unwrap();
     assert_eq!(settings.data, 3.0);
 
     // Test metadata
     let metadata = Settings::<f32>::metadata();
     assert_eq!(metadata.max_depth, 1);
-    assert_eq!(metadata.max_length, "data".len());
+    assert_eq!(metadata.max_length, "/data".len());
     assert_eq!(metadata.count, 1);
 }
 
@@ -28,14 +28,14 @@ fn generic_array() {
     }
 
     let mut settings = Settings::<f32>::default();
-    settings.set("data/0", b"3.0").unwrap();
+    settings.set("/data/0", b"3.0").unwrap();
 
     assert_eq!(settings.data[0], 3.0);
 
     // Test metadata
     let metadata = Settings::<f32>::metadata();
     assert_eq!(metadata.max_depth, 2);
-    assert_eq!(metadata.max_length, "data/0".len());
+    assert_eq!(metadata.max_length, "/data/0".len());
     assert_eq!(metadata.count, 2);
 }
 
@@ -52,14 +52,14 @@ fn generic_struct() {
     }
 
     let mut settings = Settings::<Inner>::default();
-    settings.set("inner", b"{\"data\": 3.0}").unwrap();
+    settings.set("/inner", b"{\"data\": 3.0}").unwrap();
 
     assert_eq!(settings.inner.data, 3.0);
 
     // Test metadata
     let metadata = Settings::<Inner>::metadata();
     assert_eq!(metadata.max_depth, 1);
-    assert_eq!(metadata.max_length, "inner".len());
+    assert_eq!(metadata.max_length, "/inner".len());
     assert_eq!(metadata.count, 1);
 }
 
@@ -77,7 +77,7 @@ fn generic_atomic() {
 
     let mut settings = Settings::<f32>::default();
     settings
-        .set("atomic", b"{\"inner\": [3.0, 0, 0, 0, 0]}")
+        .set("/atomic", b"{\"inner\": [3.0, 0, 0, 0, 0]}")
         .unwrap();
 
     assert_eq!(settings.atomic.inner[0], 3.0);
@@ -85,5 +85,5 @@ fn generic_atomic() {
     // Test metadata
     let metadata = Settings::<f32>::metadata();
     assert_eq!(metadata.max_depth, 1);
-    assert_eq!(metadata.max_length, "atomic".len());
+    assert_eq!(metadata.max_length, "/atomic".len());
 }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -1,4 +1,4 @@
-use miniconf::Miniconf;
+use miniconf::{Miniconf, MiniconfJson};
 use serde::{Deserialize, Serialize};
 
 #[test]

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -1,4 +1,4 @@
-use miniconf::{Miniconf, MiniconfSpec};
+use miniconf::{Miniconf, SerDe};
 use serde::{Deserialize, Serialize};
 
 #[test]

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,4 +1,4 @@
-use miniconf::Miniconf;
+use miniconf::{Miniconf, MiniconfJson};
 
 #[derive(Miniconf, Default)]
 struct Inner {

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -30,9 +30,9 @@ fn insufficient_space() {
 #[test]
 fn test_iteration() {
     let mut iterated = std::collections::HashMap::from([
-        ("a".to_string(), false),
-        ("b".to_string(), false),
-        ("c/inner".to_string(), false),
+        ("/a".to_string(), false),
+        ("/b".to_string(), false),
+        ("/c/inner".to_string(), false),
     ]);
 
     for field in Settings::iter_paths::<32, 256>().unwrap() {

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -21,10 +21,10 @@ fn insufficient_space() {
     assert_eq!(meta.count, 3);
 
     // Ensure that we can't iterate if we make a state vector that is too small.
-    assert!(Settings::iter_paths::<1, 256>().is_err());
+    assert!(Settings::iter_paths::<1, 256>('/').is_err());
 
     // Ensure that we can't iterate if the topic buffer is too small.
-    assert!(Settings::iter_paths::<10, 1>().is_err());
+    assert!(Settings::iter_paths::<10, 1>('/').is_err());
 }
 
 #[test]
@@ -35,7 +35,7 @@ fn test_iteration() {
         ("c/inner".to_string(), false),
     ]);
 
-    for field in Settings::iter_paths::<32, 256>().unwrap() {
+    for field in Settings::iter_paths::<32, 256>('/').unwrap() {
         assert!(iterated.contains_key(&field.as_str().to_string()));
         iterated.insert(field.as_str().to_string(), true);
     }
@@ -54,7 +54,7 @@ fn test_array_iteration() {
 
     let mut settings = Settings::default();
 
-    for field in Settings::iter_paths::<32, 256>().unwrap() {
+    for field in Settings::iter_paths::<32, 256>('/').unwrap() {
         settings.set(&field, b"true").unwrap();
     }
 

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -17,7 +17,7 @@ struct Settings {
 fn insufficient_space() {
     let meta = Settings::metadata();
     assert_eq!(meta.max_depth, 2);
-    assert_eq!(meta.max_length, "c/inner".len());
+    assert_eq!(meta.max_length, "/c/inner".len());
     assert_eq!(meta.count, 3);
 
     // Ensure that we can't iterate if we make a state vector that is too small.

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,4 +1,4 @@
-use miniconf::{Miniconf, MiniconfSpec};
+use miniconf::{Miniconf, SerDe};
 
 #[derive(Miniconf, Default)]
 struct Inner {

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,4 +1,4 @@
-use miniconf::{Miniconf, MiniconfJson};
+use miniconf::{Miniconf, MiniconfSpec};
 
 #[derive(Miniconf, Default)]
 struct Inner {
@@ -21,10 +21,10 @@ fn insufficient_space() {
     assert_eq!(meta.count, 3);
 
     // Ensure that we can't iterate if we make a state vector that is too small.
-    assert!(Settings::iter_paths::<1, 256>('/').is_err());
+    assert!(Settings::iter_paths::<1, 256>().is_err());
 
     // Ensure that we can't iterate if the topic buffer is too small.
-    assert!(Settings::iter_paths::<10, 1>('/').is_err());
+    assert!(Settings::iter_paths::<10, 1>().is_err());
 }
 
 #[test]
@@ -35,7 +35,7 @@ fn test_iteration() {
         ("c/inner".to_string(), false),
     ]);
 
-    for field in Settings::iter_paths::<32, 256>('/').unwrap() {
+    for field in Settings::iter_paths::<32, 256>().unwrap() {
         assert!(iterated.contains_key(&field.as_str().to_string()));
         iterated.insert(field.as_str().to_string(), true);
     }
@@ -54,7 +54,7 @@ fn test_array_iteration() {
 
     let mut settings = Settings::default();
 
-    for field in Settings::iter_paths::<32, 256>('/').unwrap() {
+    for field in Settings::iter_paths::<32, 256>().unwrap() {
         settings.set(&field, b"true").unwrap();
     }
 

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -12,6 +12,13 @@ struct Settings {
 }
 
 #[test]
+fn just_option() {
+    let mut it = Option::<u32>::iter_paths::<1, 0>().unwrap();
+    assert_eq!(it.next(), Some("".into()));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
 fn option_get_set_none() {
     let mut settings = Settings::default();
     let mut data = [0; 100];

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -53,13 +53,13 @@ fn option_iterate_some_none() {
 
     // When the value is None, it will still be iterated over as a topic but may not exist at runtime.
     settings.value.take();
-    let mut iterator = Settings::iter_paths::<10, 128>().unwrap();
+    let mut iterator = Settings::iter_paths::<10, 128>('/').unwrap();
     assert_eq!(iterator.next().unwrap(), "value/data");
     assert!(iterator.next().is_none());
 
     // When the value is Some, it should be iterated over.
     settings.value.replace(Inner { data: 5 });
-    let mut iterator = Settings::iter_paths::<10, 128>().unwrap();
+    let mut iterator = Settings::iter_paths::<10, 128>('/').unwrap();
     assert_eq!(iterator.next().unwrap(), "value/data");
     assert!(iterator.next().is_none());
 }
@@ -74,14 +74,14 @@ fn option_test_normal_option() {
     let mut s = S::default();
     assert!(s.data.is_none());
 
-    let mut iterator = S::iter_paths::<10, 128>().unwrap();
+    let mut iterator = S::iter_paths::<10, 128>('/').unwrap();
     assert_eq!(iterator.next(), Some("data".into()));
     assert!(iterator.next().is_none());
 
     s.set("data", b"7").unwrap();
     assert_eq!(s.data, Some(7));
 
-    let mut iterator = S::iter_paths::<10, 128>().unwrap();
+    let mut iterator = S::iter_paths::<10, 128>('/').unwrap();
     assert_eq!(iterator.next(), Some("data".into()));
     assert!(iterator.next().is_none());
 
@@ -100,7 +100,7 @@ fn option_test_defer_option() {
     let mut s = S::default();
     assert!(s.data.is_none());
 
-    let mut iterator = S::iter_paths::<10, 128>().unwrap();
+    let mut iterator = S::iter_paths::<10, 128>('/').unwrap();
     assert_eq!(iterator.next(), Some("data".into()));
     assert!(iterator.next().is_none());
 
@@ -109,7 +109,7 @@ fn option_test_defer_option() {
     s.set("data", b"7").unwrap();
     assert_eq!(s.data, Some(7));
 
-    let mut iterator = S::iter_paths::<10, 128>().unwrap();
+    let mut iterator = S::iter_paths::<10, 128>('/').unwrap();
     assert_eq!(iterator.next(), Some("data".into()));
     assert!(iterator.next().is_none());
 

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -1,4 +1,4 @@
-use miniconf::Miniconf;
+use miniconf::{Miniconf, MiniconfJson};
 
 #[derive(PartialEq, Debug, Clone, Default, Miniconf)]
 struct Inner {

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -1,4 +1,4 @@
-use miniconf::{Miniconf, MiniconfSpec};
+use miniconf::{Miniconf, SerDe};
 
 #[derive(PartialEq, Debug, Clone, Default, Miniconf)]
 struct Inner {

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -1,4 +1,4 @@
-use miniconf::{Miniconf, MiniconfJson};
+use miniconf::{Miniconf, MiniconfSpec};
 
 #[derive(PartialEq, Debug, Clone, Default, Miniconf)]
 struct Inner {
@@ -53,13 +53,13 @@ fn option_iterate_some_none() {
 
     // When the value is None, it will still be iterated over as a topic but may not exist at runtime.
     settings.value.take();
-    let mut iterator = Settings::iter_paths::<10, 128>('/').unwrap();
+    let mut iterator = Settings::iter_paths::<10, 128>().unwrap();
     assert_eq!(iterator.next().unwrap(), "value/data");
     assert!(iterator.next().is_none());
 
     // When the value is Some, it should be iterated over.
     settings.value.replace(Inner { data: 5 });
-    let mut iterator = Settings::iter_paths::<10, 128>('/').unwrap();
+    let mut iterator = Settings::iter_paths::<10, 128>().unwrap();
     assert_eq!(iterator.next().unwrap(), "value/data");
     assert!(iterator.next().is_none());
 }
@@ -74,14 +74,14 @@ fn option_test_normal_option() {
     let mut s = S::default();
     assert!(s.data.is_none());
 
-    let mut iterator = S::iter_paths::<10, 128>('/').unwrap();
+    let mut iterator = S::iter_paths::<10, 128>().unwrap();
     assert_eq!(iterator.next(), Some("data".into()));
     assert!(iterator.next().is_none());
 
     s.set("data", b"7").unwrap();
     assert_eq!(s.data, Some(7));
 
-    let mut iterator = S::iter_paths::<10, 128>('/').unwrap();
+    let mut iterator = S::iter_paths::<10, 128>().unwrap();
     assert_eq!(iterator.next(), Some("data".into()));
     assert!(iterator.next().is_none());
 
@@ -100,7 +100,7 @@ fn option_test_defer_option() {
     let mut s = S::default();
     assert!(s.data.is_none());
 
-    let mut iterator = S::iter_paths::<10, 128>('/').unwrap();
+    let mut iterator = S::iter_paths::<10, 128>().unwrap();
     assert_eq!(iterator.next(), Some("data".into()));
     assert!(iterator.next().is_none());
 
@@ -109,7 +109,7 @@ fn option_test_defer_option() {
     s.set("data", b"7").unwrap();
     assert_eq!(s.data, Some(7));
 
-    let mut iterator = S::iter_paths::<10, 128>('/').unwrap();
+    let mut iterator = S::iter_paths::<10, 128>().unwrap();
     assert_eq!(iterator.next(), Some("data".into()));
     assert!(iterator.next().is_none());
 

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -19,15 +19,15 @@ fn option_get_set_none() {
     // Check that if the option is None, the value cannot be get or set.
     settings.value.take();
     assert_eq!(
-        settings.get("value_foo", &mut data),
+        settings.get("/value_foo", &mut data),
         Err(miniconf::Error::PathNotFound)
     );
     assert_eq!(
-        settings.get("value", &mut data),
+        settings.get("/value", &mut data),
         Err(miniconf::Error::PathAbsent)
     );
     assert_eq!(
-        settings.set("value/data", b"5"),
+        settings.set("/value/data", b"5"),
         Err(miniconf::Error::PathAbsent)
     );
 }
@@ -40,10 +40,10 @@ fn option_get_set_some() {
     // Check that if the option is Some, the value can be get or set.
     settings.value.replace(Inner { data: 5 });
 
-    let len = settings.get("value/data", &mut data).unwrap();
+    let len = settings.get("/value/data", &mut data).unwrap();
     assert_eq!(&data[..len], b"5");
 
-    settings.set("value/data", b"7").unwrap();
+    settings.set("/value/data", b"7").unwrap();
     assert_eq!((*settings.value).as_ref().unwrap().data, 7);
 }
 
@@ -54,13 +54,13 @@ fn option_iterate_some_none() {
     // When the value is None, it will still be iterated over as a topic but may not exist at runtime.
     settings.value.take();
     let mut iterator = Settings::iter_paths::<10, 128>().unwrap();
-    assert_eq!(iterator.next().unwrap(), "value/data");
+    assert_eq!(iterator.next().unwrap(), "/value/data");
     assert!(iterator.next().is_none());
 
     // When the value is Some, it should be iterated over.
     settings.value.replace(Inner { data: 5 });
     let mut iterator = Settings::iter_paths::<10, 128>().unwrap();
-    assert_eq!(iterator.next().unwrap(), "value/data");
+    assert_eq!(iterator.next().unwrap(), "/value/data");
     assert!(iterator.next().is_none());
 }
 
@@ -75,17 +75,17 @@ fn option_test_normal_option() {
     assert!(s.data.is_none());
 
     let mut iterator = S::iter_paths::<10, 128>().unwrap();
-    assert_eq!(iterator.next(), Some("data".into()));
+    assert_eq!(iterator.next(), Some("/data".into()));
     assert!(iterator.next().is_none());
 
-    s.set("data", b"7").unwrap();
+    s.set("/data", b"7").unwrap();
     assert_eq!(s.data, Some(7));
 
     let mut iterator = S::iter_paths::<10, 128>().unwrap();
-    assert_eq!(iterator.next(), Some("data".into()));
+    assert_eq!(iterator.next(), Some("/data".into()));
     assert!(iterator.next().is_none());
 
-    s.set("data", b"null").unwrap();
+    s.set("/data", b"null").unwrap();
     assert!(s.data.is_none());
 }
 
@@ -101,17 +101,17 @@ fn option_test_defer_option() {
     assert!(s.data.is_none());
 
     let mut iterator = S::iter_paths::<10, 128>().unwrap();
-    assert_eq!(iterator.next(), Some("data".into()));
+    assert_eq!(iterator.next(), Some("/data".into()));
     assert!(iterator.next().is_none());
 
-    assert!(s.set("data", b"7").is_err());
+    assert!(s.set("/data", b"7").is_err());
     s.data = Some(0);
-    s.set("data", b"7").unwrap();
+    s.set("/data", b"7").unwrap();
     assert_eq!(s.data, Some(7));
 
     let mut iterator = S::iter_paths::<10, 128>().unwrap();
-    assert_eq!(iterator.next(), Some("data".into()));
+    assert_eq!(iterator.next(), Some("/data".into()));
     assert!(iterator.next().is_none());
 
-    assert!(s.set("data", b"null").is_err());
+    assert!(s.set("/data", b"null").is_err());
 }

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -1,4 +1,4 @@
-use miniconf::{Miniconf, MiniconfJson};
+use miniconf::{Miniconf, MiniconfSpec};
 use serde::{Deserialize, Serialize};
 
 #[test]
@@ -97,5 +97,5 @@ fn struct_with_string() {
 fn empty_struct() {
     #[derive(Miniconf, Default)]
     struct Settings {}
-    assert!(Settings::iter_paths::<1, 0>('/').unwrap().next().is_none());
+    assert!(Settings::iter_paths::<1, 0>().unwrap().next().is_none());
 }

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -97,5 +97,5 @@ fn struct_with_string() {
 fn empty_struct() {
     #[derive(Miniconf, Default)]
     struct Settings {}
-    assert!(Settings::iter_paths::<1, 0>().unwrap().next().is_none());
+    assert!(Settings::iter_paths::<1, 0>('/').unwrap().next().is_none());
 }

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -1,4 +1,4 @@
-use miniconf::Miniconf;
+use miniconf::{Miniconf, MiniconfJson};
 use serde::{Deserialize, Serialize};
 
 #[test]

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -19,10 +19,10 @@ fn atomic_struct() {
     let mut settings = Settings::default();
 
     // Inner settings structure is atomic, so cannot be set.
-    assert!(settings.set("c/a", b"4").is_err());
+    assert!(settings.set("/c/a", b"4").is_err());
 
     // Inner settings can be updated atomically.
-    settings.set("c", b"{\"a\": 5, \"b\": 3}").unwrap();
+    settings.set("/c", b"{\"a\": 5, \"b\": 3}").unwrap();
 
     let expected = {
         let mut expected = Settings::default();
@@ -36,7 +36,7 @@ fn atomic_struct() {
     // Check that metadata is correct.
     let metadata = Settings::metadata();
     assert_eq!(metadata.max_depth, 1);
-    assert_eq!(metadata.max_length, "c".len());
+    assert_eq!(metadata.max_length, "/c".len());
     assert_eq!(metadata.count, 3);
 }
 
@@ -57,7 +57,7 @@ fn recursive_struct() {
 
     let mut settings = Settings::default();
 
-    settings.set("c/a", b"3").unwrap();
+    settings.set("/c/a", b"3").unwrap();
     let expected = {
         let mut expected = Settings::default();
         expected.c.a = 3;
@@ -67,12 +67,12 @@ fn recursive_struct() {
     assert_eq!(settings, expected);
 
     // It is not allowed to set a non-terminal node.
-    assert!(settings.set("c", b"{\"a\": 5}").is_err());
+    assert!(settings.set("/c", b"{\"a\": 5}").is_err());
 
     // Check that metadata is correct.
     let metadata = Settings::metadata();
     assert_eq!(metadata.max_depth, 2);
-    assert_eq!(metadata.max_length, "c/a".len());
+    assert_eq!(metadata.max_length, "/c/a".len());
     assert_eq!(metadata.count, 3);
 }
 
@@ -86,10 +86,10 @@ fn struct_with_string() {
     let mut s = Settings::default();
 
     let mut buf = [0u8; 256];
-    let len = s.get("string", &mut buf).unwrap();
+    let len = s.get("/string", &mut buf).unwrap();
     assert_eq!(&buf[..len], b"\"\"");
 
-    s.set("string", br#""test""#).unwrap();
+    s.set("/string", br#""test""#).unwrap();
     assert_eq!(s.string, "test");
 }
 

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -1,4 +1,4 @@
-use miniconf::{Miniconf, MiniconfSpec};
+use miniconf::{Miniconf, SerDe};
 use serde::{Deserialize, Serialize};
 
 #[test]


### PR DESCRIPTION
- be generic over the serde format
- no unwrap
- factor out MiniconfJson trait
- pass separator as argument
- use marker struct and trait for separator
- move separator to spec trait
- rename MiniconfSpec -> SerDe
- remove marker trait
- use git serde-json-core
- add changelog entries
- shorten paths
- move metadata checking to iterator
- update docs
- style
- simplify ser lifetimes
- return serializer Ok
- simplify deserializer lifetimes
- simpler default
- cleanup
- refactor path building/parsing
- fixups
- remove peekable
- add test
- more changelog
- refactor
- serde-json-core git
- style
- remove old comments
- fix comment
- add Miniconf Inner/Outer type parameter and use
- remove Array, wip
