### PR TITLE
make miniconf trait generic over depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to adapt to the above is to make sure the `JsonCoreSlash` trait is in scope
   (`use miniconf::JsonCoreSlash`) and to rename `{set,get}() -> {set,get}_json()`.
   The `MqttClient` has seen no externally visible changes.
+* [breaking] `iter_paths()` and `iter_paths_unchecked()` now don't need the state
+  size anymore as it's computed exactly at compile time.
 * [breaking] `iter_paths`/`PathIter` is now generic over the type
   to write the path into. Downstream crates should replace `iter_paths::<L, TS>()` with
-  e.g. `iter_paths::<L, heapless::String<TS>>()`.
+  e.g. `iter_paths::<heapless::String<TS>>()`.
 * [breaking] Re-exports of `heapless` and `serde-json-core` have been removed as they
   are not needed to work with the public API and would be a semver hazard.
 * [breaking] Metadata is now computed by default without taking into account

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are not needed to work with the public API and would be a semver hazard.
 * [breaking] Metadata is now computed by default without taking into account
   path separators. These can be included using `Metadata::separator()`.
+* [breaking] The `Array` and `Option` newtypes have been removed. Instead in structs
+  the desired `Miniconf<N>` recursion depth for a field is indicated by an attribute
+  `#[miniconf(defer(N))]` where `N` is a `usize` literal. The depth is communicated
+  via the trait. For `[T;N]` and `Option` the depth up to `8` has been implemented.
+  For `structs` it is arbitrary.
 
 ## [0.7.1] (https://github.com/quartiq/miniconf/compare/v0.7.0...v0.7.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Traversal by names or indices has been added through `Miniconf::traverse_by_key()`.
 * The `Miniconf` derive macro supports (unnamed) tuple structs.
 
+### Removed
+
+* [breaking] The `Array` and `Option` newtypes have been removed. Instead in structs
+  the desired `Miniconf<N>` recursion depth for a field is indicated by an attribute
+  `#[miniconf(defer(N))]` where `N` is a `usize` literal. The depth is communicated
+  via the trait. For `[T;N]` and `Option` the depth up to `8` has been implemented.
+  For `structs` it is arbitrary.
+
 ### Changed
 
 * [breaking] The `Miniconf` trait is now generic over the `Deserializer`/`Serializer`. It
@@ -42,11 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are not needed to work with the public API and would be a semver hazard.
 * [breaking] Metadata is now computed by default without taking into account
   path separators. These can be included using `Metadata::separator()`.
-* [breaking] The `Array` and `Option` newtypes have been removed. Instead in structs
-  the desired `Miniconf<N>` recursion depth for a field is indicated by an attribute
-  `#[miniconf(defer(N))]` where `N` is a `usize` literal. The depth is communicated
-  via the trait. For `[T;N]` and `Option` the depth up to `8` has been implemented.
-  For `structs` it is arbitrary.
 
 ## [0.7.1] (https://github.com/quartiq/miniconf/compare/v0.7.0...v0.7.1)
 

--- a/README.md
+++ b/README.md
@@ -49,18 +49,18 @@ struct Settings {
     #[miniconf(defer)]
     array_defer: [i32; 2],
     // ... or deferring to two levels (index and then inner field name)
-    #[miniconf(defer)]
-    array_miniconf: miniconf::Array<Inner, 2>,
+    #[miniconf(defer(2))]
+    array_miniconf: [Inner; 2],
 
     // Hiding paths by setting the Option to `None` at runtime
     #[miniconf(defer)]
     option_defer: Option<i32>,
     // Hiding a path and deferring to the inner
-    #[miniconf(defer)]
-    option_miniconf: miniconf::Option<Inner>,
+    #[miniconf(defer(2))]
+    option_miniconf: Option<Inner>,
     // Hiding elements of an Array of Miniconf items
-    #[miniconf(defer)]
-    array_option_miniconf: miniconf::Array<miniconf::Option<Inner>, 2>,
+    #[miniconf(defer(3))]
+    array_option_miniconf: [Option<Inner>; 2],
 }
 
 let mut settings = Settings::default();

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ struct Settings {
     array_miniconf: [Inner; 2],
 
     // Hiding paths by setting the Option to `None` at runtime
-    #[miniconf(defer)]
+    #[miniconf(defer(0))]
     option_defer: Option<i32>,
     // Hiding a path and deferring to the inner
-    #[miniconf(defer(2))]
+    #[miniconf(defer(1))]
     option_miniconf: Option<Inner>,
     // Hiding elements of an Array of Miniconf items
-    #[miniconf(defer(3))]
+    #[miniconf(defer(2))]
     array_option_miniconf: [Option<Inner>; 2],
 }
 
@@ -97,7 +97,7 @@ let len = settings.get_json("/struct_", &mut buf)?;
 assert_eq!(&buf[..len], br#"{"a":3,"b":3}"#);
 
 // Iterating over all paths
-for path in Settings::iter_paths::<3, String>("/").unwrap() {
+for path in Settings::iter_paths::<String>("/") {
     let path = path.unwrap();
     // Serializing each
     match settings.get_json(&path, &mut buf) {
@@ -141,8 +141,8 @@ Homogeneous [core::array]s can be made accessible either
 
 `Option` is used
 1. like a standard `serde` Option, or
-2. with `#[miniconf(defer)]` to support paths that may be absent (masked) at runtime.
-3. with `#[miniconf(defer(D))]` and `D >= 2` to support masking entire sub-trees at runtime.
+2. with `#[miniconf(defer(0))]` to support a value that may be absent (masked) at runtime.
+3. with `#[miniconf(defer(D))]` and `D >= 1` to support mask sub-trees at runtime.
 
 Structs, arrays, and Options can then be cascaded to construct more complex trees.
 

--- a/README.md
+++ b/README.md
@@ -140,13 +140,11 @@ is configured at compile (derive) time using the `#[miniconf(defer)]` attribute.
 `Option` is used with `#[miniconf(defer)]` to support paths that may be absent (masked) at
 runtime.
 
-While the [Miniconf] implementations for [core::array] and [core::option::Option] by provide
-atomic access to their respective inner element(s), [Array] and
-[Option] have alternative [Miniconf] implementations that expose deep access
+The [Miniconf] implementations for [core::array] and [core::option::Option] provide
+atomic access to their respective inner element(s) or expose deep access
 into the inner element(s) through their respective inner [Miniconf] implementations.
 
 ## Formats
-
 Miniconf is generic over the `serde` backend/payload format and the path hierarchy separator
 (as long as the path can be split by it unambiguously).
 
@@ -158,8 +156,8 @@ Miniconf is designed to be protocol-agnostic. Any means that can receive key-val
 some external source can be used to modify values by path.
 
 ## Limitations
-Deferred (non-atomic) access to inner elements of some types is not yet supported. This means that
-`Miniconf` for enums (other than [core::option::Option]) is not yet supported.
+Deferred (non-atomic) access to inner elements of some types is not yet supported, e.g. enums
+other than [core::option::Option].
 
 ## Features
 * `mqtt-client` Enable the MQTT client feature. See the example in [MqttClient].

--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ The macro implements the [Miniconf] trait that exposes access to serialized fiel
 All types supported by [serde] (and the `serde::Serializer`/`serde::Deserializer` backend) or `Miniconf`
 can be used as fields.
 
-Elements of homogeneous [core::array]s can be made accessible either
+Homogeneous [core::array]s can be made accessible either
 1. as a single leaf in the tree like other serde-capable items, or
-2. atomically through their numeric indices (with the attribute `#[miniconf(defer)]` or `#[miniconf(defer(1))]`), or
-3. through their sub-trees with `#[miniconf(defer(D))]` and `D >= 2`.
+2. by item through their numeric indices (with the attribute `#[miniconf(defer)]` or `#[miniconf(defer(1))]`), or
+3. exposing sub-tree with `#[miniconf(defer(D))]` and `D >= 2`.
 
-`Option` is used 
+`Option` is used
 1. like a standard `serde` Option, or
 2. with `#[miniconf(defer)]` to support paths that may be absent (masked) at runtime.
 3. with `#[miniconf(defer(D))]` and `D >= 2` to support masking entire sub-trees at runtime.

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -78,7 +78,7 @@ async fn main() {
     // Spawn a task to send MQTT messages.
     tokio::task::spawn(async move { mqtt_client().await });
 
-    let mut client: MqttClient<Settings, Stack, StandardClock, 256> = MqttClient::new(
+    let mut client: MqttClient<_, _, _, 256, 2> = MqttClient::new(
         Stack::default(),
         "",
         "sample/prefix",

--- a/examples/readback.rs
+++ b/examples/readback.rs
@@ -23,7 +23,7 @@ fn main() {
     };
 
     // Maintains our state of iteration.
-    let mut settings_iter = Settings::iter_paths::<5, String>("/").unwrap();
+    let mut settings_iter = Settings::iter_paths::<String>("/");
 
     // Just get one topic/value from the iterator
     if let Some(topic) = settings_iter.next() {

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -159,7 +159,7 @@ fn derive_struct(
             const __MINICONF_DEFERS: [bool; #fields_len] = [#(#defers ,)*];
         }
 
-        impl #impl_generics miniconf::Miniconf<1> for #ident #ty_generics #where_clause {
+        impl #impl_generics miniconf::Miniconf for #ident #ty_generics #where_clause {
             fn name_to_index(value: &str) -> Option<usize> {
                 Self::__MINICONF_NAMES.iter().position(|&n| n == value)
             }
@@ -258,6 +258,6 @@ fn derive_struct(
         }
     }
     .into();
-    // eprintln!("{}", tokens);
+
     tokens
 }

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -55,9 +55,9 @@ fn name(i: usize, ident: &Option<syn::Ident>) -> proc_macro2::TokenStream {
 fn get_by_key_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::TokenStream {
     // Quote context is a match of the field name with `get_by_key()` args available.
     let ident = name(i, &struct_field.field.ident);
-    if struct_field.defer {
+    if let Some(depth) = struct_field.defer {
         quote! {
-            #i => self.#ident.get_by_key(keys, ser)
+            #i => miniconf::Miniconf::<#depth>::get_by_key(&self.#ident, keys, ser)
         }
     } else {
         quote! {
@@ -72,9 +72,9 @@ fn get_by_key_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::Toke
 fn set_by_key_arm((i, struct_field): (usize, &StructField)) -> proc_macro2::TokenStream {
     // Quote context is a match of the field name with `set_by_key()` args available.
     let ident = name(i, &struct_field.field.ident);
-    if struct_field.defer {
+    if let Some(depth) = struct_field.defer {
         quote! {
-            #i => self.#ident.set_by_key(keys, de)
+            #i => miniconf::Miniconf::<#depth>::set_by_key(&mut self.#ident, keys, de)
         }
     } else {
         quote! {
@@ -90,10 +90,10 @@ fn traverse_by_key_arm(
     (i, struct_field): (usize, &StructField),
 ) -> Option<proc_macro2::TokenStream> {
     // Quote context is a match of the field index with `traverse_by_key()` args available.
-    if struct_field.defer {
+    if let Some(depth) = struct_field.defer {
         let field_type = &struct_field.field.ty;
         Some(quote! {
-            #i => <#field_type>::traverse_by_key(keys, func)
+            #i => <#field_type as miniconf::Miniconf<#depth>>::traverse_by_key(keys, func)
         })
     } else {
         None
@@ -102,10 +102,10 @@ fn traverse_by_key_arm(
 
 fn metadata_arm((i, struct_field): (usize, &StructField)) -> Option<proc_macro2::TokenStream> {
     // Quote context is a match of the field index with `metadata()` args available.
-    if struct_field.defer {
+    if let Some(depth) = struct_field.defer {
         let field_type = &struct_field.field.ty;
         Some(quote! {
-            #i => <#field_type>::metadata()
+            #i => <#field_type as miniconf::Miniconf<#depth>>::metadata()
         })
     } else {
         None
@@ -148,18 +148,24 @@ fn derive_struct(
     });
     let fields_len = fields.len();
 
-    let defers = fields.iter().map(|field| field.defer);
+    let defers = fields.iter().map(|field| {
+        if let Some(depth) = field.defer {
+            quote! {Some(#depth)}
+        } else {
+            quote! {None}
+        }
+    });
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let (impl_generics_orig, ty_generics_orig, _where_clause_orig) = orig_generics.split_for_impl();
 
-    quote! {
+    let tokens = quote! {
         impl #impl_generics_orig #ident #ty_generics_orig {
             const __MINICONF_NAMES: [&str; #fields_len] = [#(#names ,)*];
-            const __MINICONF_DEFERS: [bool; #fields_len] = [#(#defers ,)*];
+            const __MINICONF_DEFERS: [Option<usize>; #fields_len] = [#(#defers ,)*];
         }
 
-        impl #impl_generics miniconf::Miniconf for #ident #ty_generics #where_clause {
+        impl #impl_generics miniconf::Miniconf<1> for #ident #ty_generics #where_clause {
             fn name_to_index(value: &str) -> Option<usize> {
                 Self::__MINICONF_NAMES.iter().position(|&n| n == value)
             }
@@ -172,11 +178,11 @@ fn derive_struct(
             {
                 let key = keys.next()
                     .ok_or(miniconf::Error::TooShort(0))?;
-                let index = miniconf::Key::find::<Self>(&key)
+                let index = miniconf::Key::find::<1, Self>(&key)
                     .ok_or(miniconf::Error::NotFound(1))?;
                 let defer = Self::__MINICONF_DEFERS.get(index)
                     .ok_or(miniconf::Error::NotFound(1))?;
-                if !defer && keys.next().is_some() {
+                if !defer.is_some() && keys.next().is_some() {
                     return Err(miniconf::Error::TooLong(1))
                 }
                 // Note(unreachable) empty structs have diverged by now
@@ -195,11 +201,11 @@ fn derive_struct(
             {
                 let key = keys.next()
                     .ok_or(miniconf::Error::TooShort(0))?;
-                let index = miniconf::Key::find::<Self>(&key)
+                let index = miniconf::Key::find::<1, Self>(&key)
                     .ok_or(miniconf::Error::NotFound(1))?;
                 let defer = Self::__MINICONF_DEFERS.get(index)
                     .ok_or(miniconf::Error::NotFound(1))?;
-                if !defer && keys.next().is_some() {
+                if !defer.is_some() && keys.next().is_some() {
                     return Err(miniconf::Error::TooLong(1))
                 }
                 // Note(unreachable) empty structs have diverged by now
@@ -221,7 +227,7 @@ fn derive_struct(
             {
                 let key = keys.next()
                     .ok_or(miniconf::Error::TooShort(0))?;
-                let index = miniconf::Key::find::<Self>(&key)
+                let index = miniconf::Key::find::<1, Self>(&key)
                     .ok_or(miniconf::Error::NotFound(1))?;
                 let name = Self::__MINICONF_NAMES.get(index)
                     .ok_or(miniconf::Error::NotFound(1))?;
@@ -257,5 +263,7 @@ fn derive_struct(
             }
         }
     }
-    .into()
+    .into();
+    // eprintln!("{}", tokens);
+    tokens
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -7,7 +7,7 @@ use crate::{Error, Increment, Key, Metadata, Miniconf};
 /// With `#[miniconf(defer(D))]` and a depth `D > 1` for an
 /// [`[T; N]`](array), each item of the array is accessed as a [`Miniconf`] tree.
 /// For a depth `D = 0`, the entire array is accessed as one atomic
-/// value. By For `D = 1` each index of the array is is instead accessed as
+/// value. For `D = 1` each index of the array is is instead accessed as
 /// one atomic value.
 ///
 /// The type to use depends on what data is contained in your array. If your array contains
@@ -88,7 +88,7 @@ macro_rules! depth {
 
 depth!(2 3 4 5 6 7 8);
 
-impl<T: serde::Serialize + serde::de::DeserializeOwned, const N: usize> Miniconf<1> for [T; N] {
+impl<T: serde::Serialize + serde::de::DeserializeOwned, const N: usize> Miniconf for [T; N] {
     fn name_to_index(value: &str) -> core::option::Option<usize> {
         value.parse().ok()
     }

--- a/src/array.rs
+++ b/src/array.rs
@@ -14,6 +14,8 @@ use crate::{Error, Increment, Key, Metadata, Miniconf};
 /// `Miniconf` items, you can (and often want to) use `D >= 2`.
 /// However, if each element in your list is individually configurable as a single value (e.g. a list
 /// of `u32`), then you must use `D = 1` or `D = 0` if all items are to be accessed simultaneously.
+/// For e.g. `[[T; 2]; 3] where T: Miniconf<3>` you may want to use `D = 5` (note that `D <= 2`
+/// will also work if `T: Serialize + DeserializeOwned`).
 
 /// Returns the number of digits required to format an integer less than `x`.
 const fn digits(x: usize) -> usize {

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,5 +1,4 @@
 use crate::{Error, Increment, Key, Metadata, Miniconf};
-use core::ops::{Deref, DerefMut};
 
 /// An array that exposes each element through their [`Miniconf`] implementation.
 ///
@@ -22,77 +21,9 @@ use core::ops::{Deref, DerefMut};
 ///
 /// An `Array` can be constructed using [`From<[T; N]>`](From)/[`Into<miniconf::Array>`]
 /// and the contained value can be accessed through [`Deref`]/[`DerefMut`].
-#[derive(Clone, Copy, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
-#[repr(transparent)]
-pub struct Array<T, const N: usize>([T; N]);
 
-impl<T, const N: usize> Deref for Array<T, N> {
-    type Target = [T; N];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T, const N: usize> DerefMut for Array<T, N> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl<T: Default + Copy, const N: usize> Default for Array<T, N> {
-    fn default() -> Self {
-        Self([T::default(); N])
-    }
-}
-
-impl<T, const N: usize> From<[T; N]> for Array<T, N> {
-    fn from(x: [T; N]) -> Self {
-        Self(x)
-    }
-}
-
-impl<T, const N: usize> AsRef<[T; N]> for Array<T, N> {
-    fn as_ref(&self) -> &[T; N] {
-        self
-    }
-}
-
-impl<T, const N: usize> AsMut<[T; N]> for Array<T, N> {
-    fn as_mut(&mut self) -> &mut [T; N] {
-        self
-    }
-}
-
-impl<T, const N: usize> IntoIterator for Array<T, N> {
-    type Item = T;
-    type IntoIter = <[T; N] as IntoIterator>::IntoIter;
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-impl<'a, T, const N: usize> IntoIterator for &'a Array<T, N> {
-    type Item = <&'a [T; N] as IntoIterator>::Item;
-    type IntoIter = <&'a [T; N] as IntoIterator>::IntoIter;
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-impl<'a, T, const N: usize> IntoIterator for &'a mut Array<T, N> {
-    type Item = <&'a mut [T; N] as IntoIterator>::Item;
-    type IntoIter = <&'a mut [T; N] as IntoIterator>::IntoIter;
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter_mut()
-    }
-}
-
-impl<T, const N: usize> From<Array<T, N>> for [T; N] {
-    fn from(x: Array<T, N>) -> Self {
-        x.0
-    }
-}
+/// FIXME: local alias to minimize rename noise
+pub type Array<T, const N: usize> = [T; N];
 
 /// Returns the number of digits required to format an integer less than `x`.
 const fn digits(x: usize) -> usize {
@@ -106,63 +37,68 @@ const fn digits(x: usize) -> usize {
     num_digits
 }
 
-// This overrides the impl on [T; N] through Deref
-impl<T: Miniconf, const N: usize> Miniconf for Array<T, N> {
-    fn name_to_index(value: &str) -> core::option::Option<usize> {
-        value.parse().ok()
-    }
+macro_rules! depth {
+    ($($d:literal)+) => {$(
+        impl<T: Miniconf<{$d - 1}>, const N: usize> Miniconf<$d> for Array<T, N> {
+            fn name_to_index(value: &str) -> core::option::Option<usize> {
+                value.parse().ok()
+            }
 
-    fn get_by_key<K, S>(&self, mut keys: K, ser: S) -> Result<usize, Error<S::Error>>
-    where
-        K: Iterator,
-        K::Item: Key,
-        S: serde::Serializer,
-    {
-        let key = keys.next().ok_or(Error::TooShort(0))?;
-        let index = key.find::<Self>().ok_or(Error::NotFound(1))?;
-        let item = self.0.get(index).ok_or(Error::NotFound(1))?;
-        item.get_by_key(keys, ser).increment()
-    }
+            fn get_by_key<K, S>(&self, mut keys: K, ser: S) -> Result<usize, Error<S::Error>>
+            where
+                K: Iterator,
+                K::Item: Key,
+                S: serde::Serializer,
+            {
+                let key = keys.next().ok_or(Error::TooShort(0))?;
+                let index = key.find::<$d, Self>().ok_or(Error::NotFound(1))?;
+                let item = self.get(index).ok_or(Error::NotFound(1))?;
+                item.get_by_key(keys, ser).increment()
+            }
 
-    fn set_by_key<'a, K, D>(&mut self, mut keys: K, de: D) -> Result<usize, Error<D::Error>>
-    where
-        K: Iterator,
-        K::Item: Key,
-        D: serde::Deserializer<'a>,
-    {
-        let key = keys.next().ok_or(Error::TooShort(0))?;
-        let index = key.find::<Self>().ok_or(Error::NotFound(1))?;
-        let item = self.0.get_mut(index).ok_or(Error::NotFound(1))?;
-        item.set_by_key(keys, de).increment()
-    }
+            fn set_by_key<'a, K, D>(&mut self, mut keys: K, de: D) -> Result<usize, Error<D::Error>>
+            where
+                K: Iterator,
+                K::Item: Key,
+                D: serde::Deserializer<'a>,
+            {
+                let key = keys.next().ok_or(Error::TooShort(0))?;
+                let index = key.find::<$d, Self>().ok_or(Error::NotFound(1))?;
+                let item = self.get_mut(index).ok_or(Error::NotFound(1))?;
+                item.set_by_key(keys, de).increment()
+            }
 
-    fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>
-    where
-        K: Iterator,
-        K::Item: Key,
-        F: FnMut(usize, &str) -> Result<(), E>,
-    {
-        let key = keys.next().ok_or(Error::TooShort(0))?;
-        let index = key.find::<Self>().ok_or(Error::NotFound(1))?;
-        if index >= N {
-            return Err(Error::NotFound(1));
+            fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>
+            where
+                K: Iterator,
+                K::Item: Key,
+                F: FnMut(usize, &str) -> Result<(), E>,
+            {
+                let key = keys.next().ok_or(Error::TooShort(0))?;
+                let index = key.find::<$d, Self>().ok_or(Error::NotFound(1))?;
+                if index >= N {
+                    return Err(Error::NotFound(1));
+                }
+                func(index, itoa::Buffer::new().format(index))?;
+                T::traverse_by_key(keys, func).increment()
+            }
+
+            fn metadata() -> Metadata {
+                let mut meta = T::metadata();
+
+                meta.max_length += digits(N);
+                meta.max_depth += 1;
+                meta.count *= N;
+
+                meta
+            }
         }
-        func(index, itoa::Buffer::new().format(index))?;
-        T::traverse_by_key(keys, func).increment()
-    }
-
-    fn metadata() -> Metadata {
-        let mut meta = T::metadata();
-
-        meta.max_length += digits(N);
-        meta.max_depth += 1;
-        meta.count *= N;
-
-        meta
-    }
+    )+}
 }
 
-impl<T: serde::Serialize + serde::de::DeserializeOwned, const N: usize> Miniconf for [T; N] {
+depth!(2 3 4 5 6 7 8);
+
+impl<T: serde::Serialize + serde::de::DeserializeOwned, const N: usize> Miniconf<1> for [T; N] {
     fn name_to_index(value: &str) -> core::option::Option<usize> {
         value.parse().ok()
     }
@@ -174,7 +110,7 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned, const N: usize> Miniconf
         S: serde::Serializer,
     {
         let key = keys.next().ok_or(Error::TooShort(0))?;
-        let index = key.find::<Self>().ok_or(Error::NotFound(1))?;
+        let index = key.find::<1, Self>().ok_or(Error::NotFound(1))?;
         let item = self.get(index).ok_or(Error::NotFound(1))?;
         // Precedence
         if keys.next().is_some() {
@@ -191,7 +127,7 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned, const N: usize> Miniconf
         D: serde::Deserializer<'a>,
     {
         let key = keys.next().ok_or(Error::TooShort(0))?;
-        let index: usize = key.find::<Self>().ok_or(Error::NotFound(1))?;
+        let index: usize = key.find::<1, Self>().ok_or(Error::NotFound(1))?;
         let item = self.get_mut(index).ok_or(Error::NotFound(1))?;
         // Precedence
         if keys.next().is_some() {
@@ -208,7 +144,7 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned, const N: usize> Miniconf
         F: FnMut(usize, &str) -> Result<(), E>,
     {
         let key = keys.next().ok_or(Error::TooShort(0))?;
-        let index = match key.find::<Self>() {
+        let index = match key.find::<1, Self>() {
             Some(i) if i < N => i,
             _ => return Err(Error::NotFound(1)),
         };

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -32,7 +32,7 @@ where
 {
     pub(crate) fn new(separator: &'a str) -> Result<Self, SliceShort> {
         let meta = M::metadata();
-        if L < meta.max_depth || L < D {
+        if L < meta.max_depth {
             return Err(SliceShort);
         }
         let mut s = Self::new_unchecked(separator);

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -3,7 +3,7 @@ use core::{fmt::Write, iter::FusedIterator, marker::PhantomData};
 
 /// An iterator over the paths in a Miniconf namespace.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct PathIter<'a, M: ?Sized, const L: usize, P> {
+pub struct PathIter<'a, M: ?Sized, const L: usize, P, const D: usize> {
     /// Zero-size markers to allow being generic over M/P (by constraining the type parameters).
     m: PhantomData<M>,
     p: PhantomData<P>,
@@ -26,13 +26,13 @@ pub struct PathIter<'a, M: ?Sized, const L: usize, P> {
     separator: &'a str,
 }
 
-impl<'a, M, const L: usize, P> PathIter<'a, M, L, P>
+impl<'a, M, const L: usize, P, const D: usize> PathIter<'a, M, L, P, D>
 where
-    M: Miniconf + ?Sized,
+    M: Miniconf<D> + ?Sized,
 {
     pub(crate) fn new(separator: &'a str) -> Result<Self, SliceShort> {
         let meta = M::metadata();
-        if L < meta.max_depth {
+        if L < meta.max_depth || L < D {
             return Err(SliceShort);
         }
         let mut s = Self::new_unchecked(separator);
@@ -51,9 +51,9 @@ where
     }
 }
 
-impl<'a, M, const L: usize, P> Iterator for PathIter<'a, M, L, P>
+impl<'a, M, const L: usize, P, const D: usize> Iterator for PathIter<'a, M, L, P, D>
 where
-    M: Miniconf + ?Sized,
+    M: Miniconf<D> + ?Sized,
     P: Write + Default,
 {
     type Item = Result<P, Error<core::fmt::Error>>;
@@ -110,9 +110,9 @@ where
     }
 }
 
-impl<'a, M, const L: usize, P> FusedIterator for PathIter<'a, M, L, P>
+impl<'a, M, const L: usize, P, const D: usize> FusedIterator for PathIter<'a, M, L, P, D>
 where
-    M: Miniconf,
+    M: Miniconf<D>,
     P: core::fmt::Write + Default,
 {
 }

--- a/src/json_core.rs
+++ b/src/json_core.rs
@@ -5,7 +5,7 @@ use serde_json_core::{de, ser};
 ///
 /// Access items with `'/'` as path separator and JSON (from `serde-json-core`)
 /// as serialization/deserialization payload format.
-pub trait JsonCoreSlash: Miniconf {
+pub trait JsonCoreSlash<const D: usize>: Miniconf<D> {
     /// Update an element by path.
     ///
     /// # Args
@@ -55,7 +55,7 @@ pub trait JsonCoreSlash: Miniconf {
     ) -> Result<usize, Error<ser::Error>>;
 }
 
-impl<T: Miniconf> JsonCoreSlash for T {
+impl<T: Miniconf<D>, const D: usize> JsonCoreSlash<D> for T {
     fn set_json(&mut self, path: &str, data: &[u8]) -> Result<usize, Error<de::Error>> {
         let mut de = de::Deserializer::new(data);
         self.set_by_key(path.split('/').skip(1), &mut de)?;

--- a/src/json_core.rs
+++ b/src/json_core.rs
@@ -5,7 +5,7 @@ use serde_json_core::{de, ser};
 ///
 /// Access items with `'/'` as path separator and JSON (from `serde-json-core`)
 /// as serialization/deserialization payload format.
-pub trait JsonCoreSlash<const D: usize>: Miniconf<D> {
+pub trait JsonCoreSlash<const D: usize = 1>: Miniconf<D> {
     /// Update an element by path.
     ///
     /// # Args

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ impl Key for &str {
 ///   but may perform arbitrarily recursion and also have arbitrarily long keys.
 ///   `1` is then the minimum recursion depth for a (non-newtype) struct. No other
 ///   value is needed or valid.
-pub trait Miniconf<const Y: usize> {
+pub trait Miniconf<const Y: usize = 1> {
     /// Convert a node name to a node index.
     fn name_to_index(name: &str) -> core::option::Option<usize>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,20 +133,12 @@ pub trait Key {
     fn find<const D: usize, M: Miniconf<D>>(&self) -> core::option::Option<usize>;
 }
 
-macro_rules! key_integer {
-    ($($ty:ident)+) => {
-        $(
-            impl Key for $ty {
-                #[inline]
-                fn find<const D: usize, M: Miniconf<D>>(&self) -> core::option::Option<usize> {
-                    Some(*self as _)
-                }
-            }
-        )+
+impl Key for usize {
+    #[inline]
+    fn find<const D: usize, M>(&self) -> core::option::Option<usize> {
+        Some(*self)
     }
 }
-
-key_integer!(usize);
 
 impl Key for &str {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,13 +148,16 @@ impl Key for &str {
 }
 
 /// Trait exposing serialization/deserialization of nodes by keys/paths and traversal.
-// Depth `Y` is a lower bound for the Miniconf recursion depth.
-// It deviates from the key tree depth significantly:
-// * `Option` consumes a layer of Miniconf recursion, but doesn't add to key tree height
-// * A struct that has `Miniconf` derived for it will only implement `Miniconf<1>`
-//  but may be arbitrarily deep in terms of recursion and also in terms of keys.
-//  `1` is the minimum recursion depth for a struct.
-//  Deeper recursion it may also may be inhomogeneous.
+///
+/// The parameter `Y` is a lower bound for the recursion depth. It's only non-unity in
+/// `array` and `option` as they need a configurable recursion depth at compile time
+/// and can't be marked up with inner attributes.
+/// The paramter `Y` deviates from the key tree depth significantly:
+/// * `Option` consume a layer of Miniconf recursion, but don't add to key tree height
+/// * A struct that has `Miniconf` derived for it will only implement `Miniconf<1>`
+///   but may perform arbitrarily recursion and also have arbitrarily long keys.
+///   `1` is then the minimum recursion depth for a (non-newtype) struct. No other
+///   value is needed or valid.
 pub trait Miniconf<const Y: usize> {
     /// Convert a node name to a node index.
     fn name_to_index(name: &str) -> core::option::Option<usize>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,15 +149,7 @@ impl Key for &str {
 
 /// Trait exposing serialization/deserialization of nodes by keys/paths and traversal.
 ///
-/// The parameter `Y` is a lower bound for the recursion depth. It's only non-unity in
-/// `array` and `option` as they need a configurable recursion depth at compile time
-/// and can't be marked up with inner attributes.
-/// The paramter `Y` deviates from the key tree depth significantly:
-/// * `Option` consume a layer of Miniconf recursion, but don't add to key tree height
-/// * A struct that has `Miniconf` derived for it will only implement `Miniconf<1>`
-///   but may perform arbitrarily recursion and also have arbitrarily long keys.
-///   `1` is then the minimum recursion depth for a (non-newtype) struct. No other
-///   value is needed or valid.
+/// The depth parameter `Y` is the maximum key length: the depth/height of the tree.
 pub trait Miniconf<const Y: usize = 1> {
     /// Convert a node name to a node index.
     fn name_to_index(name: &str) -> core::option::Option<usize>;
@@ -290,11 +282,9 @@ pub trait Miniconf<const Y: usize = 1> {
     /// # Args
     ///
     /// # Returns
-    /// An iterator of paths or an Error if `L` is insufficient.
+    /// An iterator of paths with a trusted and exact `size_hint()`.
     #[inline]
-    fn iter_paths<const L: usize, P: core::fmt::Write>(
-        separator: &str,
-    ) -> Result<PathIter<'_, Self, L, P, Y>, SliceShort> {
+    fn iter_paths<P: core::fmt::Write>(separator: &str) -> PathIter<'_, Self, Y, P> {
         PathIter::new(separator)
     }
 
@@ -309,9 +299,7 @@ pub trait Miniconf<const Y: usize = 1> {
     /// # Returns
     /// A iterator of paths.
     #[inline]
-    fn iter_paths_unchecked<const L: usize, P: core::fmt::Write>(
-        separator: &str,
-    ) -> PathIter<'_, Self, L, P, Y> {
+    fn iter_paths_unchecked<P: core::fmt::Write>(separator: &str) -> PathIter<'_, Self, Y, P> {
         PathIter::new_unchecked(separator)
     }
 }

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -21,7 +21,7 @@ const MAX_RECURSION_DEPTH: usize = 8;
 // republished.
 const REPUBLISH_TIMEOUT_SECONDS: u32 = 2;
 
-type Iter<M> = crate::PathIter<'static, M, MAX_RECURSION_DEPTH, String<MAX_TOPIC_LENGTH>>;
+type Iter<M> = crate::PathIter<'static, M, MAX_RECURSION_DEPTH, String<MAX_TOPIC_LENGTH>, 1>;
 
 mod sm {
     use minimq::embedded_time::{self, duration::Extensions, Instant};
@@ -48,13 +48,13 @@ mod sm {
         }
     }
 
-    pub struct Context<C: embedded_time::Clock, M: super::Miniconf> {
+    pub struct Context<C: embedded_time::Clock, M: super::Miniconf<1>> {
         clock: C,
         timeout: Option<Instant<C>>,
         pub republish_state: super::Iter<M>,
     }
 
-    impl<C: embedded_time::Clock, M: super::Miniconf> Context<C, M> {
+    impl<C: embedded_time::Clock, M: super::Miniconf<1>> Context<C, M> {
         pub fn new(clock: C) -> Self {
             Self {
                 clock,
@@ -73,7 +73,7 @@ mod sm {
         }
     }
 
-    impl<C: embedded_time::Clock, M: super::Miniconf> StateMachineContext for Context<C, M> {
+    impl<C: embedded_time::Clock, M: super::Miniconf<1>> StateMachineContext for Context<C, M> {
         fn start_republish_timeout(&mut self) {
             self.timeout.replace(
                 self.clock.try_now().unwrap() + super::REPUBLISH_TIMEOUT_SECONDS.seconds(),
@@ -159,7 +159,7 @@ impl<'a> Command<'a> {
 /// ```
 pub struct MqttClient<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
 where
-    Settings: JsonCoreSlash + Clone,
+    Settings: JsonCoreSlash<1> + Clone,
     Stack: TcpClientStack,
     Clock: embedded_time::Clock,
 {
@@ -175,7 +175,7 @@ where
 impl<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
     MqttClient<Settings, Stack, Clock, MESSAGE_SIZE>
 where
-    Settings: JsonCoreSlash + Clone,
+    Settings: JsonCoreSlash<1> + Clone,
     Stack: TcpClientStack,
     Clock: embedded_time::Clock + Clone,
 {

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -48,13 +48,13 @@ mod sm {
         }
     }
 
-    pub struct Context<C: embedded_time::Clock, M: super::Miniconf<1>> {
+    pub struct Context<C: embedded_time::Clock, M: super::Miniconf> {
         clock: C,
         timeout: Option<Instant<C>>,
         pub republish_state: super::Iter<M>,
     }
 
-    impl<C: embedded_time::Clock, M: super::Miniconf<1>> Context<C, M> {
+    impl<C: embedded_time::Clock, M: super::Miniconf> Context<C, M> {
         pub fn new(clock: C) -> Self {
             Self {
                 clock,
@@ -73,7 +73,7 @@ mod sm {
         }
     }
 
-    impl<C: embedded_time::Clock, M: super::Miniconf<1>> StateMachineContext for Context<C, M> {
+    impl<C: embedded_time::Clock, M: super::Miniconf> StateMachineContext for Context<C, M> {
         fn start_republish_timeout(&mut self) {
             self.timeout.replace(
                 self.clock.try_now().unwrap() + super::REPUBLISH_TIMEOUT_SECONDS.seconds(),
@@ -159,7 +159,7 @@ impl<'a> Command<'a> {
 /// ```
 pub struct MqttClient<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
 where
-    Settings: JsonCoreSlash<1> + Clone,
+    Settings: JsonCoreSlash + Clone,
     Stack: TcpClientStack,
     Clock: embedded_time::Clock,
 {
@@ -175,7 +175,7 @@ where
 impl<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
     MqttClient<Settings, Stack, Clock, MESSAGE_SIZE>
 where
-    Settings: JsonCoreSlash<1> + Clone,
+    Settings: JsonCoreSlash + Clone,
     Stack: TcpClientStack,
     Clock: embedded_time::Clock + Clone,
 {

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -14,9 +14,6 @@ const MAX_TOPIC_LENGTH: usize = 128;
 // The keepalive interval to use for MQTT in seconds.
 const KEEPALIVE_INTERVAL_SECONDS: u16 = 60;
 
-// The maximum recursive depth of a settings structure.
-const MAX_RECURSION_DEPTH: usize = 8;
-
 // The delay after not receiving messages after initial connection that settings will be
 // republished.
 const REPUBLISH_TIMEOUT_SECONDS: u32 = 2;
@@ -129,7 +126,7 @@ impl<'a> Command<'a> {
 /// The MQTT client logs failures to subscribe to the settings topic, but does not re-attempt to
 /// connect to it when errors occur.
 ///
-/// The client only supports paths up to 128 byte length and maximum depth of 8.
+/// The client only supports paths up to 128 byte length.
 /// Keepalive interval and re-publication timeout are fixed to 60 and 2 seconds respectively.
 ///
 /// # Example
@@ -219,7 +216,6 @@ where
         )?;
 
         let meta = Settings::metadata().separator("/");
-        assert!(meta.max_depth <= MAX_RECURSION_DEPTH);
         assert!(prefix.len() + "/settings".len() + meta.max_length <= MAX_TOPIC_LENGTH);
 
         Ok(Self {

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -21,7 +21,7 @@ const MAX_RECURSION_DEPTH: usize = 8;
 // republished.
 const REPUBLISH_TIMEOUT_SECONDS: u32 = 2;
 
-type Iter<M> = crate::PathIter<'static, M, MAX_RECURSION_DEPTH, String<MAX_TOPIC_LENGTH>, 1>;
+type Iter<M, const Y: usize> = crate::PathIter<'static, M, Y, String<MAX_TOPIC_LENGTH>>;
 
 mod sm {
     use minimq::embedded_time::{self, duration::Extensions, Instant};
@@ -48,13 +48,13 @@ mod sm {
         }
     }
 
-    pub struct Context<C: embedded_time::Clock, M: super::Miniconf> {
+    pub struct Context<C: embedded_time::Clock, M: super::Miniconf<Y>, const Y: usize> {
         clock: C,
         timeout: Option<Instant<C>>,
-        pub republish_state: super::Iter<M>,
+        pub republish_state: super::Iter<M, Y>,
     }
 
-    impl<C: embedded_time::Clock, M: super::Miniconf> Context<C, M> {
+    impl<C: embedded_time::Clock, M: super::Miniconf<Y>, const Y: usize> Context<C, M, Y> {
         pub fn new(clock: C) -> Self {
             Self {
                 clock,
@@ -73,7 +73,9 @@ mod sm {
         }
     }
 
-    impl<C: embedded_time::Clock, M: super::Miniconf> StateMachineContext for Context<C, M> {
+    impl<C: embedded_time::Clock, M: super::Miniconf<Y>, const Y: usize> StateMachineContext
+        for Context<C, M, Y>
+    {
         fn start_republish_timeout(&mut self) {
             self.timeout.replace(
                 self.clock.try_now().unwrap() + super::REPUBLISH_TIMEOUT_SECONDS.seconds(),
@@ -139,7 +141,7 @@ impl<'a> Command<'a> {
 ///     foo: bool,
 /// }
 ///
-/// let mut client: MqttClient<Settings, _, _, 256> = MqttClient::new(
+/// let mut client: MqttClient<Settings, _, _, 256, 1> = MqttClient::new(
 ///     std_embedded_nal::Stack::default(),
 ///     "",  // client_id auto-assign
 ///     "quartiq/application/12345",  // prefix
@@ -157,25 +159,25 @@ impl<'a> Command<'a> {
 ///     Ok(())
 /// }).unwrap();
 /// ```
-pub struct MqttClient<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
+pub struct MqttClient<Settings, Stack, Clock, const MESSAGE_SIZE: usize, const Y: usize>
 where
-    Settings: JsonCoreSlash + Clone,
+    Settings: JsonCoreSlash<Y> + Clone,
     Stack: TcpClientStack,
     Clock: embedded_time::Clock,
 {
     mqtt: minimq::Minimq<Stack, Clock, MESSAGE_SIZE, 1>,
     settings: Settings,
-    state: sm::StateMachine<sm::Context<Clock, Settings>>,
+    state: sm::StateMachine<sm::Context<Clock, Settings, Y>>,
     prefix: String<MAX_TOPIC_LENGTH>,
-    listing_state: Option<Iter<Settings>>,
+    listing_state: Option<Iter<Settings, Y>>,
     properties_cache: Option<Vec<u8, MESSAGE_SIZE>>,
     pending_response: Option<Response<32>>,
 }
 
-impl<Settings, Stack, Clock, const MESSAGE_SIZE: usize>
-    MqttClient<Settings, Stack, Clock, MESSAGE_SIZE>
+impl<Settings, Stack, Clock, const MESSAGE_SIZE: usize, const Y: usize>
+    MqttClient<Settings, Stack, Clock, MESSAGE_SIZE, Y>
 where
-    Settings: JsonCoreSlash + Clone,
+    Settings: JsonCoreSlash<Y> + Clone,
     Stack: TcpClientStack,
     Clock: embedded_time::Clock + Clone,
 {

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -289,7 +289,7 @@ where
 
             let topic = topic.unwrap();
 
-            // Note: The topic may be absent at runtime (`miniconf::Option` or deferred `Option`).
+            // Note: The topic may be absent at runtime (deferred `Option`).
             let len = match self.settings.get_json(&topic, &mut data) {
                 Err(Error::Absent(_)) => continue,
                 Ok(len) => len,

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -138,7 +138,7 @@ impl<'a> Command<'a> {
 ///     foo: bool,
 /// }
 ///
-/// let mut client: MqttClient<Settings, _, _, 256, 1> = MqttClient::new(
+/// let mut client: MqttClient<_, _, _, 256, 1> = MqttClient::new(
 ///     std_embedded_nal::Stack::default(),
 ///     "",  // client_id auto-assign
 ///     "quartiq/application/12345",  // prefix

--- a/src/option.rs
+++ b/src/option.rs
@@ -32,7 +32,7 @@ macro_rules! depth {
                 K::Item: Key,
                 S: serde::Serializer,
             {
-                if let Some(inner) = self.as_ref() {
+                if let Some(inner) = self {
                     inner.get_by_key(keys, ser)
                 } else {
                     Err(Error::Absent(0))
@@ -45,7 +45,7 @@ macro_rules! depth {
                 K::Item: Key,
                 D: serde::Deserializer<'a>,
             {
-                if let Some(inner) = self.as_mut() {
+                if let Some(inner) = self {
                     inner.set_by_key(keys, de)
                 } else {
                     Err(Error::Absent(0))
@@ -84,7 +84,7 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned> Miniconf<1> for core::op
             return Err(Error::TooLong(0));
         }
 
-        if let Some(inner) = self.as_ref() {
+        if let Some(inner) = self {
             serde::Serialize::serialize(inner, ser)?;
             Ok(0)
         } else {
@@ -101,7 +101,7 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned> Miniconf<1> for core::op
             return Err(Error::TooLong(0));
         }
 
-        if let Some(inner) = self.as_mut() {
+        if let Some(inner) = self {
             *inner = serde::Deserialize::deserialize(de)?;
             Ok(0)
         } else {

--- a/src/option.rs
+++ b/src/option.rs
@@ -15,7 +15,7 @@ use crate::{Error, Key, Metadata, Miniconf};
 ///
 /// If the depth specified by the `miniconf(defer(D))` attribute exceeds 0,
 /// the `Option` can be used to access content within the inner type.
-/// If marked with `#[miniconf(---)]`, and `None` at runtime, the value or the entire sub-tree
+/// If marked with `#[miniconf(defer(-))]`, and `None` at runtime, the value or the entire sub-tree
 /// is inaccessible through `Miniconf::{get,set}_by_key`.
 /// If there is no `miniconf` attribute on an `Option` field in a `struct or in an array,
 /// JSON `null` corresponds to`None` as usual.

--- a/src/option.rs
+++ b/src/option.rs
@@ -13,15 +13,16 @@ use crate::{Error, Key, Metadata, Miniconf};
 /// cases, run-time detection may indicate that some component is not present. In this case,
 /// namespaces will not be exposed for it.
 ///
-/// If the depth specified by the `miniconf(defer(D))` attribute exceeds 1,
+/// If the depth specified by the `miniconf(defer(D))` attribute exceeds 0,
 /// the `Option` can be used to access content within the inner type.
-/// If `None` at runtime, the entire sub-tree is inaccessible through `Miniconf::{get,set}_by_key`.
+/// If marked with `#[miniconf(---)]`, and `None` at runtime, the value or the entire sub-tree
+/// is inaccessible through `Miniconf::{get,set}_by_key`.
 /// If there is no `miniconf` attribute on an `Option` field in a `struct or in an array,
 /// JSON `null` corresponds to`None` as usual.
 
 macro_rules! depth {
     ($($d:literal)+) => {$(
-        impl<T: Miniconf<{$d - 1}>> Miniconf<$d> for Option<T> {
+        impl<T: Miniconf<$d>> Miniconf<$d> for Option<T> {
             fn name_to_index(_value: &str) -> core::option::Option<usize> {
                 None
             }
@@ -68,9 +69,9 @@ macro_rules! depth {
     )+}
 }
 
-depth!(2 3 4 5 6 7 8);
+depth!(1 2 3 4 5 6 7 8);
 
-impl<T: serde::Serialize + serde::de::DeserializeOwned> Miniconf for core::option::Option<T> {
+impl<T: serde::Serialize + serde::de::DeserializeOwned> Miniconf<0> for core::option::Option<T> {
     fn name_to_index(_value: &str) -> core::option::Option<usize> {
         None
     }

--- a/src/option.rs
+++ b/src/option.rs
@@ -70,7 +70,7 @@ macro_rules! depth {
 
 depth!(2 3 4 5 6 7 8);
 
-impl<T: serde::Serialize + serde::de::DeserializeOwned> Miniconf<1> for core::option::Option<T> {
+impl<T: serde::Serialize + serde::de::DeserializeOwned> Miniconf for core::option::Option<T> {
     fn name_to_index(_value: &str) -> core::option::Option<usize> {
         None
     }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,12 +1,10 @@
 use crate::{Error, Key, Metadata, Miniconf};
 
-/// An `Option` that exposes its value through their [`Miniconf`] implementation.
+/// `Miniconf<D>` for `Option`.
 ///
 /// # Design
 ///
-/// Miniconf supports optional values in two forms.
-///
-/// In both forms, the `Option` may be marked with `#[miniconf(defer)]`
+/// An `Option` may be marked with `#[miniconf(defer(D))]`
 /// and be `None` at run-time. This makes the corresponding part of the namespace inaccessible
 /// at run-time. It will still be iterated over by [`Miniconf::iter_paths()`] but attempts to
 /// `get_by_key()` or `set_by_key()` them using the [`Miniconf`] API return in [`Error::Absent`].
@@ -15,22 +13,11 @@ use crate::{Error, Key, Metadata, Miniconf};
 /// cases, run-time detection may indicate that some component is not present. In this case,
 /// namespaces will not be exposed for it.
 ///
-/// The first form is the [`miniconf::Option`](Option) type which optionally exposes its
-/// interior `Miniconf` value as a sub-tree. An [`miniconf::Option`](Option) should usually be
-/// `#[miniconf(defer)]`.
-///
-/// Miniconf also allows for the normal usage of Rust [`core::option::Option`] types. In this case,
-/// the `Option` can be used to atomically access the content within. If marked with `#[miniconf(defer)]`
-/// and `None` at runtime, it is inaccessible through `Miniconf`. Otherwise, JSON `null` corresponds to
-/// `None` as usual.
-///
-/// # Construction
-///
-/// An `miniconf::Option` can be constructed using [`From<core::option::Option>`]/[`Into<miniconf::Option>`]
-/// and the contained value can be accessed through [`Deref`]/[`DerefMut`].
-
-// FIXME: type alias to minimize rename noise
-pub type Option<T> = core::option::Option<T>;
+/// If the depth specified by the `miniconf(defer(D))` attribute exceeds 1,
+/// the `Option` can be used to access content within the inner type.
+/// If `None` at runtime, the entire sub-tree is inaccessible through `Miniconf::{get,set}_by_key`.
+/// If there is no `miniconf` attribute on an `Option` field in a `struct or in an array,
+/// JSON `null` corresponds to`None` as usual.
 
 macro_rules! depth {
     ($($d:literal)+) => {$(

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -117,11 +117,11 @@ fn empty() {
     #[derive(Miniconf, Serialize, Deserialize)]
     struct S {}
 
-    assert!(<[S; 0] as Miniconf<1>>::iter_paths::<2, String>("")
+    assert!(<[S; 0] as Miniconf>::iter_paths::<2, String>("")
         .unwrap()
         .next()
         .is_none());
-    assert!(<[[S; 0]; 0] as Miniconf<1>>::iter_paths::<2, String>("")
+    assert!(<[[S; 0]; 0] as Miniconf>::iter_paths::<2, String>("")
         .unwrap()
         .next()
         .is_none());

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -129,7 +129,7 @@ fn empty() {
     #[derive(Miniconf)]
     struct Q {
         #[miniconf(defer)]
-        a: miniconf::Array<S, 0>,
+        a: [S; 0],
         #[miniconf(defer)]
         b: [S; 0],
     }

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -15,10 +15,10 @@ struct Settings {
     d: [u8; 2],
     #[miniconf(defer)]
     dm: [Inner; 2],
-    #[miniconf(defer)]
-    am: miniconf::Array<Inner, 2>,
-    #[miniconf(defer)]
-    aam: miniconf::Array<miniconf::Array<Inner, 2>, 2>,
+    #[miniconf(defer(2))]
+    am: [Inner; 2],
+    #[miniconf(defer(3))]
+    aam: [[Inner; 2]; 2],
 }
 
 #[test]
@@ -117,16 +117,14 @@ fn empty() {
     #[derive(Miniconf, Serialize, Deserialize)]
     struct S {}
 
-    assert!(miniconf::Array::<S, 0>::iter_paths::<2, String>("")
+    assert!(<[S; 0] as Miniconf<1>>::iter_paths::<2, String>("")
         .unwrap()
         .next()
         .is_none());
-    assert!(
-        miniconf::Array::<miniconf::Array<S, 0>, 0>::iter_paths::<2, String>("")
-            .unwrap()
-            .next()
-            .is_none()
-    );
+    assert!(<[[S; 0]; 0] as Miniconf<1>>::iter_paths::<2, String>("")
+        .unwrap()
+        .next()
+        .is_none());
 
     #[derive(Miniconf)]
     struct Q {

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -109,20 +109,15 @@ fn iter() {
 
 #[test]
 fn empty() {
-    assert!(<[u32; 0]>::iter_paths::<2, String>("")
-        .unwrap()
-        .next()
-        .is_none());
+    assert!(<[u32; 0]>::iter_paths::<String>("").next().is_none());
 
     #[derive(Miniconf, Serialize, Deserialize)]
     struct S {}
 
-    assert!(<[S; 0] as Miniconf>::iter_paths::<2, String>("")
-        .unwrap()
+    assert!(<[S; 0] as Miniconf>::iter_paths::<String>("")
         .next()
         .is_none());
-    assert!(<[[S; 0]; 0] as Miniconf>::iter_paths::<2, String>("")
-        .unwrap()
+    assert!(<[[S; 0]; 0] as Miniconf>::iter_paths::<String>("")
         .next()
         .is_none());
 
@@ -133,5 +128,5 @@ fn empty() {
         #[miniconf(defer)]
         b: [S; 0],
     }
-    assert!(Q::iter_paths::<3, String>("").unwrap().next().is_none());
+    assert!(Q::iter_paths::<String>("").next().is_none());
 }

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -123,7 +123,7 @@ fn empty() {
 
     #[derive(Miniconf)]
     struct Q {
-        #[miniconf(defer)]
+        #[miniconf(defer(2))]
         a: [S; 0],
         #[miniconf(defer)]
         b: [S; 0],

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -69,11 +69,11 @@ fn traverse_empty() {
     );
     assert_eq!(Option::<i32>::traverse_by_key([0].into_iter(), f), Ok(0));
     assert_eq!(
-        miniconf::Option::<S>::traverse_by_key([0].into_iter(), f),
+        Option::<S>::traverse_by_key([0].into_iter(), f),
         Err(Error::NotFound(1))
     );
     assert_eq!(
-        miniconf::Option::<S>::traverse_by_key([0; 0].into_iter(), f),
+        Option::<S>::traverse_by_key([0; 0].into_iter(), f),
         Err(Error::TooShort(0))
     );
 }

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -15,9 +15,9 @@ struct Settings {
     d: [u8; 2],
     #[miniconf(defer)]
     dm: [Inner; 2],
-    #[miniconf(defer)]
+    #[miniconf(defer(2))]
     am: miniconf::Array<Inner, 2>,
-    #[miniconf(defer)]
+    #[miniconf(defer(3))]
     aam: miniconf::Array<miniconf::Array<Inner, 2>, 2>,
 }
 
@@ -96,19 +96,16 @@ fn empty() {
     #[derive(Miniconf, Serialize, Deserialize, Copy, Clone, Default)]
     struct S {}
 
-    assert!(<miniconf::Array::<S, 0> as Default>::default()
-        .set_json_by_index(&[], b"")
-        .is_err());
-    assert!(
-        <miniconf::Array::<miniconf::Array<S, 0>, 0> as Default>::default()
-            .set_json_by_index(&[], b"")
-            .is_err()
-    );
+    let mut s = [S::default(); 0];
+    assert!(JsonCoreSlash::<1>::set_json_by_index(&mut s, &[], b"").is_err());
+
+    let mut s = [[S::default(); 0]; 0];
+    assert!(JsonCoreSlash::<1>::set_json_by_index(&mut s, &[], b"").is_err());
 
     #[derive(Miniconf, Default)]
     struct Q {
-        #[miniconf(defer)]
-        a: miniconf::Array<S, 0>,
+        #[miniconf(defer(2))]
+        a: [S; 0],
         #[miniconf(defer)]
         b: [S; 0],
     }

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -16,9 +16,9 @@ struct Settings {
     #[miniconf(defer)]
     dm: [Inner; 2],
     #[miniconf(defer(2))]
-    am: miniconf::Array<Inner, 2>,
+    am: [Inner; 2],
     #[miniconf(defer(3))]
-    aam: miniconf::Array<miniconf::Array<Inner, 2>, 2>,
+    aam: [[Inner; 2]; 2],
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -102,7 +102,7 @@ fn main() -> std::io::Result<()> {
     .unwrap();
 
     // Construct a settings configuration interface.
-    let mut interface = miniconf::MqttClient::<Settings, _, _, 256>::new(
+    let mut interface = miniconf::MqttClient::<_, _, _, 256, 2>::new(
         Stack::default(),
         "",
         "device",

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -16,26 +16,9 @@ struct Settings {
 }
 
 #[test]
-fn slice_short() {
-    let meta = Settings::metadata().separator("/");
-    assert_eq!(meta.max_depth, 2);
-    assert_eq!(meta.max_length, "/c/inner".len());
-    assert_eq!(meta.count, 3);
-
-    // Ensure that we can't iterate if we make a state vector that is too small.
-    assert_eq!(
-        Settings::iter_paths::<1, String>(""),
-        Err(miniconf::SliceShort)
-    );
-}
-
-#[test]
 fn struct_iter() {
     let mut paths = ["/a", "/b", "/c/inner"].into_iter();
-    for (have, expect) in Settings::iter_paths::<32, String>("/")
-        .unwrap()
-        .zip(&mut paths)
-    {
+    for (have, expect) in Settings::iter_paths::<String>("/").zip(&mut paths) {
         assert_eq!(have.unwrap(), expect);
     }
     // Ensure that all fields were iterated.
@@ -59,7 +42,7 @@ fn array_iter() {
 
     let mut s = Settings::default();
 
-    for field in Settings::iter_paths::<4, String>("/").unwrap() {
+    for field in Settings::iter_paths::<String>("/") {
         let field = field.unwrap();
         s.set_json(&field, b"true").unwrap();
         let mut buf = [0; 32];

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -53,8 +53,8 @@ fn array_iter() {
     struct Settings {
         #[miniconf(defer)]
         a: [bool; 2],
-        #[miniconf(defer)]
-        b: miniconf::Array<I, 3>,
+        #[miniconf(defer(2))]
+        b: [I; 3],
     }
 
     let mut s = Settings::default();

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -9,13 +9,13 @@ struct Inner {
 
 #[derive(Debug, Clone, Default, Miniconf)]
 struct Settings {
-    #[miniconf(defer(2))]
+    #[miniconf(defer(1))]
     value: Option<Inner>,
 }
 
 #[test]
 fn just_option() {
-    let mut it = Option::<u32>::iter_paths::<1, String>("/").unwrap();
+    let mut it = Option::<u32>::iter_paths::<String>("/");
     assert_eq!(it.next(), Some(Ok("".into())));
     assert_eq!(it.next(), None);
 }
@@ -62,13 +62,13 @@ fn option_iterate_some_none() {
 
     // When the value is None, it will still be iterated over as a topic but may not exist at runtime.
     settings.value.take();
-    let mut iterator = Settings::iter_paths::<10, String>("/").unwrap();
+    let mut iterator = Settings::iter_paths::<String>("/");
     assert_eq!(iterator.next(), Some(Ok("/value/data".into())));
     assert!(iterator.next().is_none());
 
     // When the value is Some, it should be iterated over.
     settings.value.replace(Inner { data: 5 });
-    let mut iterator = Settings::iter_paths::<10, String>("/").unwrap();
+    let mut iterator = Settings::iter_paths::<String>("/");
     assert_eq!(iterator.next(), Some(Ok("/value/data".into())));
     assert_eq!(iterator.next(), None);
 }
@@ -83,14 +83,14 @@ fn option_test_normal_option() {
     let mut s = S::default();
     assert!(s.data.is_none());
 
-    let mut iterator = S::iter_paths::<10, String>("/").unwrap();
+    let mut iterator = S::iter_paths::<String>("/");
     assert_eq!(iterator.next(), Some(Ok("/data".into())));
     assert!(iterator.next().is_none());
 
     s.set_json("/data", b"7").unwrap();
     assert_eq!(s.data, Some(7));
 
-    let mut iterator = S::iter_paths::<10, String>("/").unwrap();
+    let mut iterator = S::iter_paths::<String>("/");
     assert_eq!(iterator.next(), Some(Ok("/data".into())));
     assert!(iterator.next().is_none());
 
@@ -102,14 +102,14 @@ fn option_test_normal_option() {
 fn option_test_defer_option() {
     #[derive(Copy, Clone, Default, Miniconf)]
     struct S {
-        #[miniconf(defer)]
+        #[miniconf(defer(0))]
         data: Option<u32>,
     }
 
     let mut s = S::default();
     assert!(s.data.is_none());
 
-    let mut iterator = S::iter_paths::<10, String>("/").unwrap();
+    let mut iterator = S::iter_paths::<String>("/");
     assert_eq!(iterator.next(), Some(Ok("/data".into())));
     assert!(iterator.next().is_none());
 
@@ -118,7 +118,7 @@ fn option_test_defer_option() {
     s.set_json("/data", b"7").unwrap();
     assert_eq!(s.data, Some(7));
 
-    let mut iterator = S::iter_paths::<10, String>("/").unwrap();
+    let mut iterator = S::iter_paths::<String>("/");
     assert_eq!(iterator.next(), Some(Ok("/data".into())));
     assert!(iterator.next().is_none());
 
@@ -132,9 +132,9 @@ fn option_absent() {
 
     #[derive(Copy, Clone, Default, Miniconf)]
     struct S {
-        #[miniconf(defer)]
+        #[miniconf(defer(0))]
         d: Option<u32>,
-        #[miniconf(defer(2))]
+        #[miniconf(defer(1))]
         dm: Option<I>,
     }
 

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -53,7 +53,7 @@ fn option_get_set_some() {
     assert_eq!(&data[..len], b"5");
 
     settings.set_json("/value/data", b"7").unwrap();
-    assert_eq!(settings.value.as_ref().as_ref().unwrap().data, 7);
+    assert_eq!(settings.value.unwrap().data, 7);
 }
 
 #[test]

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -9,8 +9,8 @@ struct Inner {
 
 #[derive(Debug, Clone, Default, Miniconf)]
 struct Settings {
-    #[miniconf(defer)]
-    value: miniconf::Option<Inner>,
+    #[miniconf(defer(2))]
+    value: Option<Inner>,
 }
 
 #[test]
@@ -134,8 +134,8 @@ fn option_absent() {
     struct S {
         #[miniconf(defer)]
         d: Option<u32>,
-        #[miniconf(defer)]
-        dm: miniconf::Option<I>,
+        #[miniconf(defer(2))]
+        dm: Option<I>,
     }
 
     let mut s = S::default();

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -82,8 +82,5 @@ fn recursive_struct() {
 fn empty_struct() {
     #[derive(Miniconf, Default)]
     struct Settings {}
-    assert!(Settings::iter_paths::<1, String>("/")
-        .unwrap()
-        .next()
-        .is_none());
+    assert!(Settings::iter_paths::<String>("/").next().is_none());
 }

--- a/tests/validation_failure.rs
+++ b/tests/validation_failure.rs
@@ -82,7 +82,7 @@ async fn main() {
     tokio::task::spawn(async move { client_task().await });
 
     // Construct a settings configuration interface.
-    let mut interface: miniconf::MqttClient<Settings, _, _, 256> = miniconf::MqttClient::new(
+    let mut interface: miniconf::MqttClient<_, _, _, 256, 1> = miniconf::MqttClient::new(
         Stack::default(),
         "",
         "validation_failure/device",


### PR DESCRIPTION
Removes the need for newtypes
Makes the iterator automatically know the required state size
