### PR TITLE
`serialize/deserialize_by_key`

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -36,7 +36,7 @@ macro_rules! depth {
                 value.parse().ok()
             }
 
-            fn get_by_key<K, S>(&self, mut keys: K, ser: S) -> Result<usize, Error<S::Error>>
+            fn serialize_by_key<K, S>(&self, mut keys: K, ser: S) -> Result<usize, Error<S::Error>>
             where
                 K: Iterator,
                 K::Item: Key,
@@ -45,10 +45,10 @@ macro_rules! depth {
                 let key = keys.next().ok_or(Error::TooShort(0))?;
                 let index = key.find::<$d, Self>().ok_or(Error::NotFound(1))?;
                 let item = self.get(index).ok_or(Error::NotFound(1))?;
-                item.get_by_key(keys, ser).increment()
+                item.serialize_by_key(keys, ser).increment()
             }
 
-            fn set_by_key<'a, K, D>(&mut self, mut keys: K, de: D) -> Result<usize, Error<D::Error>>
+            fn deserialize_by_key<'a, K, D>(&mut self, mut keys: K, de: D) -> Result<usize, Error<D::Error>>
             where
                 K: Iterator,
                 K::Item: Key,
@@ -57,7 +57,7 @@ macro_rules! depth {
                 let key = keys.next().ok_or(Error::TooShort(0))?;
                 let index = key.find::<$d, Self>().ok_or(Error::NotFound(1))?;
                 let item = self.get_mut(index).ok_or(Error::NotFound(1))?;
-                item.set_by_key(keys, de).increment()
+                item.deserialize_by_key(keys, de).increment()
             }
 
             fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>
@@ -95,7 +95,7 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned, const N: usize> Miniconf
         value.parse().ok()
     }
 
-    fn get_by_key<K, S>(&self, mut keys: K, ser: S) -> Result<usize, Error<S::Error>>
+    fn serialize_by_key<K, S>(&self, mut keys: K, ser: S) -> Result<usize, Error<S::Error>>
     where
         K: Iterator,
         K::Item: Key,
@@ -112,7 +112,7 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned, const N: usize> Miniconf
         Ok(1)
     }
 
-    fn set_by_key<'a, K, D>(&mut self, mut keys: K, de: D) -> Result<usize, Error<D::Error>>
+    fn deserialize_by_key<'a, K, D>(&mut self, mut keys: K, de: D) -> Result<usize, Error<D::Error>>
     where
         K: Iterator,
         K::Item: Key,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -74,8 +74,8 @@ where
                     self.state[depth - 2] += 1;
                     continue;
                 }
-                // Found a leaf at the root: bare Option
-                // Since there is no way to end iteration by triggering `NotFound` on a bare Option,
+                // Found a leaf at the root: bare Option/newtype
+                // Since there is no way to end iteration by hoping for `NotFound` on a bare Option,
                 // we force the count to Some(0) and trigger on that.
                 Ok(0) => {
                     if self.count == Some(0) {
@@ -93,11 +93,12 @@ where
                     Some(Ok(path))
                 }
                 // If we end at a leaf node, the state array is too small.
-                Err(e @ (Error::TooShort(_) | Error::Inner(_))) => Some(Err(e)),
-                // Note(`NotFound(0)`) Not having consumed any name/index, the only possible case
-                // is a bare `Miniconf` thing that does not add any hierarchy, e.g. `Option`.
-                // That however can not return `NotFound` at all.
-                // No other errors can be returned by traverse_by_key()
+                Err(e @ Error::Inner(_)) => Some(Err(e)),
+                // * NotFound(0) Not having consumed any name/index, the only possible case
+                //   is a bare `Miniconf` thing that does not use a key, e.g. `Option`.
+                //   That however can not return `NotFound`.
+                // * TooShort is excluded by construction.
+                // * No other errors can be returned by traverse_by_key()/path()
                 _ => unreachable!(),
             };
         }

--- a/src/json_core.rs
+++ b/src/json_core.rs
@@ -58,13 +58,13 @@ pub trait JsonCoreSlash<const D: usize = 1>: Miniconf<D> {
 impl<T: Miniconf<D>, const D: usize> JsonCoreSlash<D> for T {
     fn set_json(&mut self, path: &str, data: &[u8]) -> Result<usize, Error<de::Error>> {
         let mut de = de::Deserializer::new(data);
-        self.set_by_key(path.split('/').skip(1), &mut de)?;
+        self.deserialize_by_key(path.split('/').skip(1), &mut de)?;
         de.end().map_err(Error::PostDeserialization)
     }
 
     fn get_json(&self, path: &str, data: &mut [u8]) -> Result<usize, Error<ser::Error>> {
         let mut ser = ser::Serializer::new(data);
-        self.get_by_key(path.split('/').skip(1), &mut ser)?;
+        self.serialize_by_key(path.split('/').skip(1), &mut ser)?;
         Ok(ser.end())
     }
 
@@ -74,7 +74,7 @@ impl<T: Miniconf<D>, const D: usize> JsonCoreSlash<D> for T {
         data: &[u8],
     ) -> Result<usize, Error<de::Error>> {
         let mut de = de::Deserializer::new(data);
-        self.set_by_key(indices.iter().copied(), &mut de)?;
+        self.deserialize_by_key(indices.iter().copied(), &mut de)?;
         de.end().map_err(Error::PostDeserialization)
     }
 
@@ -84,7 +84,7 @@ impl<T: Miniconf<D>, const D: usize> JsonCoreSlash<D> for T {
         data: &mut [u8],
     ) -> Result<usize, Error<ser::Error>> {
         let mut ser = ser::Serializer::new(data);
-        self.get_by_key(indices.iter().copied(), &mut ser)?;
+        self.serialize_by_key(indices.iter().copied(), &mut ser)?;
         Ok(ser.end())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub trait Miniconf<const Y: usize = 1> {
     ///
     /// # Returns
     /// Node depth on success.
-    fn get_by_key<K, S>(&self, keys: K, ser: S) -> Result<usize, Error<S::Error>>
+    fn serialize_by_key<K, S>(&self, keys: K, ser: S) -> Result<usize, Error<S::Error>>
     where
         K: Iterator,
         K::Item: Key,
@@ -176,7 +176,7 @@ pub trait Miniconf<const Y: usize = 1> {
     ///
     /// # Returns
     /// Node depth on success
-    fn set_by_key<'a, K, D>(&mut self, keys: K, de: D) -> Result<usize, Error<D::Error>>
+    fn deserialize_by_key<'a, K, D>(&mut self, keys: K, de: D) -> Result<usize, Error<D::Error>>
     where
         K: Iterator,
         K::Item: Key,

--- a/src/option.rs
+++ b/src/option.rs
@@ -7,7 +7,7 @@ use crate::{Error, Key, Metadata, Miniconf};
 /// An `Option` may be marked with `#[miniconf(defer(D))]`
 /// and be `None` at run-time. This makes the corresponding part of the namespace inaccessible
 /// at run-time. It will still be iterated over by [`Miniconf::iter_paths()`] but attempts to
-/// `get_by_key()` or `set_by_key()` them using the [`Miniconf`] API return in [`Error::Absent`].
+/// `serialize_by_key()` or `deserialize_by_key()` them using the [`Miniconf`] API return in [`Error::Absent`].
 ///
 /// This is intended as a mechanism to provide run-time construction of the namespace. In some
 /// cases, run-time detection may indicate that some component is not present. In this case,
@@ -27,27 +27,27 @@ macro_rules! depth {
                 None
             }
 
-            fn get_by_key<K, S>(&self, keys: K, ser: S) -> Result<usize, Error<S::Error>>
+            fn serialize_by_key<K, S>(&self, keys: K, ser: S) -> Result<usize, Error<S::Error>>
             where
                 K: Iterator,
                 K::Item: Key,
                 S: serde::Serializer,
             {
                 if let Some(inner) = self {
-                    inner.get_by_key(keys, ser)
+                    inner.serialize_by_key(keys, ser)
                 } else {
                     Err(Error::Absent(0))
                 }
             }
 
-            fn set_by_key<'a, K, D>(&mut self, keys: K, de: D) -> Result<usize, Error<D::Error>>
+            fn deserialize_by_key<'a, K, D>(&mut self, keys: K, de: D) -> Result<usize, Error<D::Error>>
             where
                 K: Iterator,
                 K::Item: Key,
                 D: serde::Deserializer<'a>,
             {
                 if let Some(inner) = self {
-                    inner.set_by_key(keys, de)
+                    inner.deserialize_by_key(keys, de)
                 } else {
                     Err(Error::Absent(0))
                 }
@@ -76,7 +76,7 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned> Miniconf<0> for core::op
         None
     }
 
-    fn get_by_key<K, S>(&self, mut keys: K, ser: S) -> Result<usize, Error<S::Error>>
+    fn serialize_by_key<K, S>(&self, mut keys: K, ser: S) -> Result<usize, Error<S::Error>>
     where
         K: Iterator,
         S: serde::Serializer,
@@ -93,7 +93,7 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned> Miniconf<0> for core::op
         }
     }
 
-    fn set_by_key<'a, K, D>(&mut self, mut keys: K, de: D) -> Result<usize, Error<D::Error>>
+    fn deserialize_by_key<'a, K, D>(&mut self, mut keys: K, de: D) -> Result<usize, Error<D::Error>>
     where
         K: Iterator,
         D: serde::Deserializer<'a>,


### PR DESCRIPTION
- also iter: TooShort is unreachable
- {serialize,deserialize}_by_key