### PR TITLE
recursion depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ struct Settings {
     array_miniconf: [Inner; 2],
 
     // Hiding paths by setting the Option to `None` at runtime
-    #[miniconf(defer(0))]
+    #[miniconf(defer)]
     option_defer: Option<i32>,
     // Hiding a path and deferring to the inner
-    #[miniconf(defer(1))]
+    #[miniconf(defer(2))]
     option_miniconf: Option<Inner>,
     // Hiding elements of an Array of Miniconf items
-    #[miniconf(defer(2))]
+    #[miniconf(defer(3))]
     array_option_miniconf: [Option<Inner>; 2],
 }
 
@@ -141,8 +141,8 @@ Homogeneous [core::array]s can be made accessible either
 
 `Option` is used
 1. like a standard `serde` Option, or
-2. with `#[miniconf(defer(0))]` to support a value that may be absent (masked) at runtime.
-3. with `#[miniconf(defer(D))]` and `D >= 1` to support mask sub-trees at runtime.
+2. with `#[miniconf(defer(1))]` to support a value that may be absent (masked) at runtime.
+3. with `#[miniconf(defer(D))]` and `D >= 2` to support mask sub-trees at runtime.
 
 Structs, arrays, and Options can then be cascaded to construct more complex trees.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Miniconf
+
 [![crates.io](https://img.shields.io/crates/v/miniconf.svg)](https://crates.io/crates/miniconf)
 [![docs](https://docs.rs/miniconf/badge.svg)](https://docs.rs/miniconf)
 [![QUARTIQ Matrix Chat](https://img.shields.io/matrix/quartiq:matrix.org)](https://matrix.to/#/#quartiq:matrix.org)
@@ -15,6 +16,7 @@ client](MqttClient) and a Python reference implementation to ineract with it.
 `Miniconf` is completely generic over the `serde::Serializer`/`serde::Deserializer` backend and the path hierarchy separator.
 
 ## Example
+
 ```rust
 use miniconf::{Error, Miniconf, JsonCoreSlash};
 use serde::{Deserialize, Serialize};
@@ -117,6 +119,7 @@ for path in Settings::iter_paths::<String>("/") {
 ```
 
 ## MQTT
+
 There is an [MQTT-based client](MqttClient) that implements settings management over the [MQTT
 protocol](https://mqtt.org) with JSON payloads. A Python reference library is provided that
 interfaces with it.
@@ -127,44 +130,44 @@ interfaces with it.
 python -m miniconf -d quartiq/application/+ foo=true
 ```
 
-## Design
-For structs Miniconf offers a [derive macro](derive.Miniconf.html) to automatically
-assign a unique path to each item in the tree.
+## Derive macro
+
+For structs Miniconf offers a [`macro@Miniconf`] derive macro.
 The macro implements the [Miniconf] trait that exposes access to serialized field values through their path.
-All types supported by [serde] (and the `serde::Serializer`/`serde::Deserializer` backend) or `Miniconf`
+All types supported by either [serde] (and the `serde::Serializer`/`serde::Deserializer` backend) or `Miniconf`
 can be used as fields.
 
-Homogeneous [core::array]s can be made accessible either
-1. as a single leaf in the tree like other serde-capable items, or
-2. by item through their numeric indices (with the attribute `#[miniconf(defer)]` or `#[miniconf(defer(1))]`), or
-3. exposing sub-tree with `#[miniconf(defer(D))]` and `D >= 2`.
-
-`Option` is used
-1. like a standard `serde` Option, or
-2. with `#[miniconf(defer(1))]` to support a value that may be absent (masked) at runtime.
-3. with `#[miniconf(defer(D))]` and `D >= 2` to support mask sub-trees at runtime.
-
 Structs, arrays, and Options can then be cascaded to construct more complex trees.
+When using the derive macro, the behavior and tree recursion depth can be configured for each
+struct field using the `#[miniconf(defer(Y))]` attribute.
+
+See also the [`Miniconf`] trait documentation for details.
+
+## Keys and paths
 
 Lookup into the tree is done using an iterator over [Key] items. `usize` indices or `&str` names are supported.
 
 Path iteration is supported with arbitrary separator between names.
 
 ## Formats
+
 Miniconf is generic over the `serde` backend/payload format and the path hierarchy separator.
 
 Currently support for `/` as the path hierarchy separator and JSON (`serde_json_core`) is implemented
-through the [JsonCoreSlash] style.
+through the [JsonCoreSlash] super trait.
 
 ## Transport
+
 Miniconf is designed to be protocol-agnostic. Any means that can receive key-value input from
 some external source can be used to modify values by path.
 
 ## Limitations
+
 Deferred/deep/non-atomic access to inner elements of some types is not yet supported, e.g. enums
 other than [core::option::Option]. These are still however usable in their atomic `serde` form as leaves.
 
 ## Features
+
 * `mqtt-client` Enable the MQTT client feature. See the example in [MqttClient].
 * `json-core` Enable the [JsonCoreSlash] implementation of serializing from and
   into json slices (using `serde_json_core`).

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -135,7 +135,6 @@ fn derive_struct(
         }
         syn::Fields::Unit => unimplemented!("Unit struct not supported"),
     };
-    // let orig_generics = generics.clone();
     fields.iter().for_each(|f| f.bound_generics(generics));
 
     let serialize_by_key_arms = fields.iter().enumerate().map(serialize_by_key_arm);
@@ -155,8 +154,6 @@ fn derive_struct(
         + 1;
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    // let (impl_generics_orig, ty_generics_orig, _where_clause_orig) = orig_generics.split_for_impl();
-    // eprintln!("new {generics:?}\nimpl_genrs {impl_generics:?}\nwhere {where_clause:?}"); // {_where_clause_orig:?}");
 
     let tokens = quote! {
         impl #impl_generics #ident #ty_generics #where_clause {

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -8,30 +8,7 @@ use field::StructField;
 
 /// Derive the Miniconf trait for custom types.
 ///
-/// Each field of the struct will be recursively used to construct a unique path for all elements.
-///
-/// All paths are similar to file-system paths with variable names separated by forward
-/// slashes.
-///
-/// For arrays, the array index is treated as a unique identifier. That is, to access the first
-/// element of array `data`, the path would be `data/0`.
-///
-/// # Example
-/// ```rust
-/// #[derive(Miniconf)]
-/// struct Nested {
-///     #[miniconf(defer)]
-///     data: [u32; 2],
-/// }
-/// #[derive(Miniconf)]
-/// struct Settings {
-///     // Accessed with path `nested/data/0` or `nested/data/1`
-///     #[miniconf(defer)]
-///     nested: Nested,
-///
-///     // Accessed with path `external`
-///     external: bool,
-/// }
+/// See the trait for documentation.
 #[proc_macro_derive(Miniconf, attributes(miniconf))]
 pub fn derive(input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as DeriveInput);

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -135,7 +135,7 @@ fn derive_struct(
         }
         syn::Fields::Unit => unimplemented!("Unit struct not supported"),
     };
-    let orig_generics = generics.clone();
+    // let orig_generics = generics.clone();
     fields.iter().for_each(|f| f.bound_generics(generics));
 
     let serialize_by_key_arms = fields.iter().enumerate().map(serialize_by_key_arm);
@@ -155,10 +155,11 @@ fn derive_struct(
         + 1;
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let (impl_generics_orig, ty_generics_orig, _where_clause_orig) = orig_generics.split_for_impl();
+    // let (impl_generics_orig, ty_generics_orig, _where_clause_orig) = orig_generics.split_for_impl();
+    // eprintln!("new {generics:?}\nimpl_genrs {impl_generics:?}\nwhere {where_clause:?}"); // {_where_clause_orig:?}");
 
     let tokens = quote! {
-        impl #impl_generics_orig #ident #ty_generics_orig {
+        impl #impl_generics #ident #ty_generics #where_clause {
             const __MINICONF_NAMES: [&str; #fields_len] = [#(#names ,)*];
             const __MINICONF_DEFERS: [bool; #fields_len] = [#(#defers ,)*];
         }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -32,7 +32,7 @@ where
 {
     pub(crate) fn new(separator: &'a str) -> Self {
         let meta = M::metadata();
-        assert!(Y == meta.max_depth);
+        assert!(Y >= meta.max_depth);
         let mut s = Self::new_unchecked(separator);
         s.count = Some(meta.count);
         s

--- a/src/json_core.rs
+++ b/src/json_core.rs
@@ -9,7 +9,7 @@ pub trait JsonCoreSlash<const D: usize = 1>: Miniconf<D> {
     /// Update an element by path.
     ///
     /// # Args
-    /// * `path` - The path to the element.
+    /// * `path` - The path to the element. Everything before the first `'/'` is ignored.
     /// * `data` - The serialized data making up the content.
     ///
     /// # Returns
@@ -29,7 +29,7 @@ pub trait JsonCoreSlash<const D: usize = 1>: Miniconf<D> {
     /// Update an element by indices.
     ///
     /// # Args
-    /// * `indices` - The indices to the element.
+    /// * `indices` - The indices to the element. Everything before the first `'/'` is ignored.
     /// * `data` - The serialized data making up the content.
     ///
     /// # Returns

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,8 +473,9 @@ pub trait Miniconf<const Y: usize = 1> {
     /// # use heapless::String;
     /// #[derive(Miniconf)]
     /// struct S {foo: u32};
-    /// let p: heapless::String<10> = S::iter_paths(["foo"], "/").next().unwrap();
-    /// assert_eq!(p, "/foo");
+    /// for p in S::iter_paths::<String<10>>("/") {
+    ///     assert_eq!(p.unwrap(), "/foo");
+    /// }
     /// # }
     /// ```
     ///
@@ -501,8 +502,9 @@ pub trait Miniconf<const Y: usize = 1> {
     /// # use heapless::String;
     /// #[derive(Miniconf)]
     /// struct S {foo: u32};
-    /// let p: heapless::String<10> = S::iter_paths_unchecked(["foo"], "/").next().unwrap();
-    /// assert_eq!(p, "/foo");
+    /// for p in S::iter_paths::<String<10>>("/") {
+    ///     assert_eq!(p.unwrap(), "/foo");
+    /// }
     /// # }
     /// ```
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,14 +150,19 @@ impl Key for &str {
 /// Trait exposing serialization/deserialization of nodes by keys/paths and traversal.
 ///
 /// The depth parameter `Y` is the maximum miniconf recursion depth.
-/// An implementor may retrieve at most `Z <= Y` keys from the `keys` iterators and may
-/// call the `func` callback at most `Z <= Y` times. It may use at most `Miniconf<Z>`
-/// on its inner types. `Z` needs to be consistent.
+/// An implementor chooses a `Z <= Y` and may then in the recursive methods (directly
+/// and indirectly) retrieve at most `Z` keys from the `keys` and `indices` iterators
+/// and call the `func` callback at most `Z` times. It may
+/// use at most `Miniconf<Z>` on its inner types. `Z` must be consistent, i.e. if
+/// an implementor retrieves `X` keys before recursing to an inner type, it may at
+/// most use `Miniconf<Y - X>` on its inner types.
 ///
 /// Furthermore the `derive(Miniconf)` macro assumes that any implementor of `Miniconf<Y>`
-/// will require its generic types to be exactly `Miniconf<Y - 1>`. This is only relevant
-/// when deriving `Miniconf` for a struct that forwards its own type parameters as type
-/// parameters to its field types.
+/// will require its generic types to be exactly `Miniconf<Y - 1>`. This condition is upheld
+/// by all implementations in this crate. It is only violated
+/// when deriving `Miniconf` for a struct that (a) forwards its own type parameters as type
+/// parameters to its field types, (b) uses `Miniconf` on those fields, and (c) those field
+/// types use their type parameters at other levels than `Miniconf<Y - 1>`.
 ///
 /// The recursion depth `Y` is an upper bound of the maximum key length
 /// (the depth/height of the tree).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,6 +277,7 @@ pub trait Miniconf<const Y: usize = 1> {
     /// Serialize a node by keys.
     ///
     /// ```
+    /// # #[cfg(feature = "serde-core")] {
     /// # use miniconf::{Miniconf};
     /// #[derive(Miniconf)]
     /// struct S {foo: u32};
@@ -286,6 +287,7 @@ pub trait Miniconf<const Y: usize = 1> {
     /// s.serialize_by_key(["foo"].into_iter(), &mut ser).unwrap();
     /// let len = ser.end();
     /// assert_eq!(&buf[..len], b"9");
+    /// # }
     /// ```
     ///
     /// # Args
@@ -303,6 +305,7 @@ pub trait Miniconf<const Y: usize = 1> {
     /// Deserialize an node by keys.
     ///
     /// ```
+    /// # #[cfg(feature = "serde-core")] {
     /// # use miniconf::{Miniconf};
     /// #[derive(Miniconf)]
     /// struct S {foo: u32};
@@ -311,6 +314,7 @@ pub trait Miniconf<const Y: usize = 1> {
     /// s.deserialize_by_key(["foo"].into_iter(), &mut de).unwrap();
     /// de.end().unwrap();
     /// assert_eq!(s.foo, 7);
+    /// # }
     /// ```
     ///
     /// # Args
@@ -384,6 +388,7 @@ pub trait Miniconf<const Y: usize = 1> {
     /// `keys` may be longer than required. Extra items are ignored.
     ///
     /// ```
+    /// # #[cfg(feature = "mqtt-client")] {
     /// # use miniconf::{Miniconf, Metadata};
     /// # use heapless::String;
     /// #[derive(Miniconf)]
@@ -391,6 +396,7 @@ pub trait Miniconf<const Y: usize = 1> {
     /// let mut s = String::<10>::new();
     /// S::path([0], &mut s, "/").unwrap();
     /// assert_eq!(s, "/foo");
+    /// # }
     /// ```
     ///
     /// # Args
@@ -421,6 +427,7 @@ pub trait Miniconf<const Y: usize = 1> {
     /// Entries in `indices` at and beyond the `depth` returned are unaffected.
     ///
     /// ```
+    /// # #[cfg(feature = "mqtt-client")] {
     /// # use miniconf::{Miniconf, Metadata};
     /// # use heapless::String;
     /// #[derive(Miniconf)]
@@ -428,6 +435,7 @@ pub trait Miniconf<const Y: usize = 1> {
     /// let mut i = [0usize; 2];
     /// let depth = S::indices(["foo"], &mut i).unwrap();
     /// assert_eq!(&i[..depth], &[0]);
+    /// # }
     /// ```
     ///
     /// # Args
@@ -460,13 +468,14 @@ pub trait Miniconf<const Y: usize = 1> {
     /// The iterator has an exact and trusted [Iterator::size_hint].
     ///
     /// ```
+    /// # #[cfg(feature = "mqtt-client")] {
     /// # use miniconf::{Miniconf, Metadata};
     /// # use heapless::String;
     /// #[derive(Miniconf)]
     /// struct S {foo: u32};
-    /// let mut i = [0usize; 2];
-    /// let depth = S::indices(["foo"], &mut i).unwrap();
-    /// assert_eq!(&i[..depth], &[0]);
+    /// let p: heapless::String<10> = S::iter_paths(["foo"], "/").next().unwrap();
+    /// assert_eq!(p, "/foo");
+    /// # }
     /// ```
     ///
     /// # Generics
@@ -487,13 +496,14 @@ pub trait Miniconf<const Y: usize = 1> {
     /// See also [Miniconf::iter_paths].
     ///
     /// ```
+    /// # #[cfg(feature = "mqtt-client")] {
     /// # use miniconf::{Miniconf, Metadata};
     /// # use heapless::String;
     /// #[derive(Miniconf)]
     /// struct S {foo: u32};
-    /// let mut i = [0usize; 3];
-    /// let len = S::indices([0], &mut i).unwrap();
-    /// assert_eq!(i[..len], [0]);
+    /// let p: heapless::String<10> = S::iter_paths_unchecked(["foo"], "/").next().unwrap();
+    /// assert_eq!(p, "/foo");
+    /// # }
     /// ```
     ///
     /// # Generics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,18 @@ impl Key for &str {
 
 /// Trait exposing serialization/deserialization of nodes by keys/paths and traversal.
 ///
-/// The depth parameter `Y` is the maximum key length: the depth/height of the tree.
+/// The depth parameter `Y` is the maximum miniconf recursion depth.
+/// An implementor may retrieve at most `Z <= Y` keys from the `keys` iterators and may
+/// call the `func` callback at most `Z <= Y` times. It may use at most `Miniconf<Z>`
+/// on its inner types. `Z` needs to be consistent.
+///
+/// Furthermore the `derive(Miniconf)` macro assumes that any implementor of `Miniconf<Y>`
+/// will require its generic types to be exactly `Miniconf<Y - 1>`. This is only relevant
+/// when deriving `Miniconf` for a struct that forwards its own type parameters as type
+/// parameters to its field types.
+///
+/// The recursion depth `Y` is an upper bound of the maximum key length
+/// (the depth/height of the tree).
 pub trait Miniconf<const Y: usize = 1> {
     /// Convert a node name to a node index.
     fn name_to_index(name: &str) -> core::option::Option<usize>;

--- a/src/option.rs
+++ b/src/option.rs
@@ -13,7 +13,7 @@ use crate::{Error, Key, Metadata, Miniconf};
 /// cases, run-time detection may indicate that some component is not present. In this case,
 /// namespaces will not be exposed for it.
 ///
-/// If the depth specified by the `miniconf(defer(D))` attribute exceeds 0,
+/// If the depth specified by the `miniconf(defer(D))` attribute exceeds 1,
 /// the `Option` can be used to access content within the inner type.
 /// If marked with `#[miniconf(defer(-))]`, and `None` at runtime, the value or the entire sub-tree
 /// is inaccessible through `Miniconf::{get,set}_by_key`.
@@ -22,7 +22,7 @@ use crate::{Error, Key, Metadata, Miniconf};
 
 macro_rules! depth {
     ($($d:literal)+) => {$(
-        impl<T: Miniconf<$d>> Miniconf<$d> for Option<T> {
+        impl<T: Miniconf<{$d - 1}>> Miniconf<$d> for Option<T> {
             fn name_to_index(_value: &str) -> core::option::Option<usize> {
                 None
             }
@@ -69,9 +69,9 @@ macro_rules! depth {
     )+}
 }
 
-depth!(1 2 3 4 5 6 7 8);
+depth!(2 3 4 5 6 7 8);
 
-impl<T: serde::Serialize + serde::de::DeserializeOwned> Miniconf<0> for core::option::Option<T> {
+impl<T: serde::Serialize + serde::de::DeserializeOwned> Miniconf for core::option::Option<T> {
     fn name_to_index(_value: &str) -> core::option::Option<usize> {
         None
     }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -93,3 +93,19 @@ fn generic_atomic() {
     assert_eq!(metadata.max_depth, 3);
     assert_eq!(metadata.max_length, "/opt1/0/0".len());
 }
+
+#[test]
+fn test_failure() {
+    #[derive(Miniconf)]
+    struct T<U>(U);
+    #[derive(Miniconf)]
+    struct S<U>(#[miniconf(defer)] T<U>);
+    #[derive(Miniconf)]
+    struct V<U>(
+        // this applies the wrong bound U: Miniconf<1>, it should be U: SerDe
+        #[miniconf(defer(2))] S<U>,
+        // adding the missing bound indirectly is a workaround
+        // commenting this out breaks it
+        #[miniconf(defer(1))] T<U>,
+    );
+}

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -97,15 +97,13 @@ fn generic_atomic() {
 #[test]
 fn test_failure() {
     #[derive(Miniconf)]
-    struct T<U>(U);
+    struct S<T>(#[miniconf(defer)] [T; 0]);
     #[derive(Miniconf)]
-    struct S<U>(#[miniconf(defer)] T<U>);
-    #[derive(Miniconf)]
-    struct V<U>(
+    struct R<T>(
         // this applies the wrong bound U: Miniconf<1>, it should be U: SerDe
-        #[miniconf(defer(2))] S<U>,
+        #[miniconf(defer(2))] S<T>,
         // adding the missing bound indirectly is a workaround
         // commenting this out breaks it
-        #[miniconf(defer(1))] T<U>,
+        #[miniconf(defer)] [T; 0],
     );
 }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -69,12 +69,16 @@ fn generic_struct() {
 fn generic_atomic() {
     #[derive(Miniconf, Default)]
     struct Settings<T> {
-        pub atomic: Inner<T>,
+        atomic: Inner<T>,
+        #[miniconf(defer(2))]
+        opt: [[Option<T>; 0]; 0],
+        #[miniconf(defer(3))]
+        opt1: [[Option<T>; 0]; 0],
     }
 
     #[derive(Deserialize, Serialize, Default)]
     struct Inner<T> {
-        pub inner: [T; 5],
+        inner: [T; 5],
     }
 
     let mut settings = Settings::<f32>::default();
@@ -86,6 +90,6 @@ fn generic_atomic() {
 
     // Test metadata
     let metadata = Settings::<f32>::metadata().separator("/");
-    assert_eq!(metadata.max_depth, 1);
-    assert_eq!(metadata.max_length, "/atomic".len());
+    assert_eq!(metadata.max_depth, 3);
+    assert_eq!(metadata.max_length, "/opt1/0/0".len());
 }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -112,3 +112,13 @@ fn test_derive_macro_bound_failure() {
         #[miniconf(defer(2))] A<T>,
     );
 }
+
+#[test]
+fn test_depth() {
+    #[derive(miniconf::Miniconf)]
+    struct S<T>(#[miniconf(defer(3))] Option<Option<T>>);
+    // works as array implements Miniconf<1>
+    S::<[u32; 1]>::metadata();
+    // does not compile as u32 does not implement Miniconf<1>
+    // S::<u32>::metadata();
+}

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -96,14 +96,11 @@ fn generic_atomic() {
 
 #[test]
 fn test_failure() {
+    type A<T> = [[T; 0]; 0];
     #[derive(Miniconf)]
-    struct S<T>(#[miniconf(defer)] [T; 0]);
-    #[derive(Miniconf)]
-    struct R<T>(
-        // this applies the wrong bound U: Miniconf<1>, it should be U: SerDe
-        #[miniconf(defer(2))] S<T>,
-        // adding the missing bound indirectly is a workaround
-        // commenting this out breaks it
-        #[miniconf(defer)] [T; 0],
+    struct S<T: serde::Serialize + serde::de::DeserializeOwned>(
+        // this wrongly infers T: Miniconf<1> instead of T: SerDe
+        // adding the missing bound is a workaround
+        #[miniconf(defer(2))] A<T>,
     );
 }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -95,7 +95,15 @@ fn generic_atomic() {
 }
 
 #[test]
-fn test_failure() {
+fn test_derive_macro_bound_failure() {
+    // The derive macro uses a simplistic approach to adding bounds
+    // for generic types.
+    // This is analogous to other standard derive macros.
+    // See also the documentation for the [Miniconf] trait
+    // and the code comments in the derive macro ([StructField::walk_type]
+    // on adding bounds to generics.
+    // This test below shows the issue and tests whether the workaround of
+    // adding the required traits by hand works.
     type A<T> = [[T; 0]; 0];
     #[derive(Miniconf)]
     struct S<T: serde::Serialize + serde::de::DeserializeOwned>(

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -155,3 +155,16 @@ fn option_absent() {
         Err(Error::PostDeserialization(_))
     ));
 }
+
+#[test]
+fn array_option() {
+    #[derive(Copy, Clone, Default, Miniconf)]
+    struct S {
+        #[miniconf(defer(1))]
+        a: Option<u32>,
+        #[miniconf(defer(1))]
+        b: [Option<u32>; 1],
+        #[miniconf(defer(2))]
+        c: [Option<u32>; 1],
+    }
+}

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -158,6 +158,7 @@ fn option_absent() {
 
 #[test]
 fn array_option() {
+    // This tests that no invalid bounds are inferred for Options and Options in arrays.
     #[derive(Copy, Clone, Default, Miniconf)]
     struct S {
         #[miniconf(defer(1))]

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -9,7 +9,7 @@ struct Inner {
 
 #[derive(Debug, Clone, Default, Miniconf)]
 struct Settings {
-    #[miniconf(defer(1))]
+    #[miniconf(defer(2))]
     value: Option<Inner>,
 }
 
@@ -102,7 +102,7 @@ fn option_test_normal_option() {
 fn option_test_defer_option() {
     #[derive(Copy, Clone, Default, Miniconf)]
     struct S {
-        #[miniconf(defer(0))]
+        #[miniconf(defer)]
         data: Option<u32>,
     }
 
@@ -132,9 +132,9 @@ fn option_absent() {
 
     #[derive(Copy, Clone, Default, Miniconf)]
     struct S {
-        #[miniconf(defer(0))]
-        d: Option<u32>,
         #[miniconf(defer(1))]
+        d: Option<u32>,
+        #[miniconf(defer(2))]
         dm: Option<I>,
     }
 

--- a/tests/republish.rs
+++ b/tests/republish.rs
@@ -1,4 +1,4 @@
-#![cfg(features = "mqtt-client")]
+#![cfg(feature = "mqtt-client")]
 
 use miniconf::{
     minimq::{self, types::TopicFilter},
@@ -84,7 +84,7 @@ async fn main() {
     let task = tokio::task::spawn(async move { verify_settings().await });
 
     // Construct a settings configuration interface.
-    let mut interface: miniconf::MqttClient<Settings, _, _, 256> = miniconf::MqttClient::new(
+    let mut interface: miniconf::MqttClient<Settings, _, _, 256, 2> = miniconf::MqttClient::new(
         Stack::default(),
         "",
         "republish/device",


### PR DESCRIPTION
- update the generic bound logic in the derive macro

This rewrites the type bound logic after having analyzed it again and
after the changes due to adding the cont generic in `Miniconf`.

The Miniconf<Y> const generic Y is now the miniconf recursion depth
again. And it's an upper bound to the state size.
Before, the idea of making it exactly the key length war broken:
We had `impl Miniconf<0> for Option<T> where T: SerDe`
but for `#[miniconf(defer(1))] a: [Option<T>; N]` it would not use the
miniconf API of `Option<T>` as desired as it would for
`#[miniconf(defer(0))] a: Option<T>`.
Using the recursion depth as indicator which API to call fixes this.

At the cost of the state size now being potentially a bit too large.