### PR TITLE
Adding support for a `tree(skip)` field attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Deserializing with borrowed data is now supported.
-* [derive] Added `#[miniconf(skipped)]` macro attribute to allow skipping entries.
+* [derive] Added `#[tree(skip)]` macro attribute to allow skipping entries.
 
 ## [0.8.0](https://github.com/quartiq/miniconf/compare/v0.7.1...v0.8.0) - 2023-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Deserializing with borrowed data is now supported.
+* [derive] Added `#[miniconf(skipped)]` macro attribute to allow skipping entries.
 
 ## [0.8.0](https://github.com/quartiq/miniconf/compare/v0.7.1...v0.8.0) - 2023-08-03
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ struct Inner {
     b: i32,
 }
 
-#[derive(Default)]
-struct ExternalType;
-
 #[derive(Tree, Default)]
 struct Settings {
     // Atomic updtes by field name
@@ -43,9 +40,9 @@ struct Settings {
     array: [i32; 2],
     option: Option<i32>,
 
-    // Exclude an element from the tree
+    // Exclude an element (not Deserialize/Serialize)
     #[tree(skip)]
-    some_other_type: ExternalType,
+    skipped: (),
 
     // Exposing elements of containers
     // ... by field name

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ struct Inner {
     b: i32,
 }
 
+#[derive(Default)]
+struct ExternalType;
+
 #[derive(Tree, Default)]
 struct Settings {
     // Atomic updtes by field name
@@ -39,6 +42,10 @@ struct Settings {
     struct_: Inner,
     array: [i32; 2],
     option: Option<i32>,
+
+    // Exclude an element from the tree
+    #[tree(skip)]
+    some_other_type: ExternalType,
 
     // Exposing elements of containers
     // ... by field name

--- a/src/array.rs
+++ b/src/array.rs
@@ -17,7 +17,7 @@ const fn digits(x: usize) -> usize {
 macro_rules! depth {
     ($($y:literal)+) => {$(
         impl<T: TreeKey<{$y - 1}>, const N: usize> TreeKey<$y> for [T; N] {
-            fn name_to_index(value: &str) -> core::option::Option<usize> {
+            fn name_to_index(value: &str) -> Option<usize> {
                 value.parse().ok()
             }
             fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>
@@ -79,7 +79,7 @@ depth!(2 3 4 5 6 7 8);
 
 // Y == 1
 impl<T, const N: usize> TreeKey for [T; N] {
-    fn name_to_index(value: &str) -> core::option::Option<usize> {
+    fn name_to_index(value: &str) -> Option<usize> {
         value.parse().ok()
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,4 +1,5 @@
 use crate::PathIter;
+use core::fmt::{Display, Formatter, Write};
 use serde::{Deserializer, Serializer};
 
 /// Errors that can occur when using the Tree traits.
@@ -44,8 +45,8 @@ pub enum Error<E> {
     PostDeserialization(E),
 }
 
-impl<E: core::fmt::Display> core::fmt::Display for Error<E> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl<E: core::fmt::Display> Display for Error<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::Absent(index) => {
                 write!(f, "Path is not currently available (Key level: {})", index)
@@ -140,13 +141,13 @@ impl Metadata {
 /// Capability to convert a key into a node index for a given `M: TreeKey`.
 pub trait Key {
     /// Convert the key `self` to a `usize` index.
-    fn find<const Y: usize, M: TreeKey<Y>>(&self) -> core::option::Option<usize>;
+    fn find<const Y: usize, M: TreeKey<Y>>(&self) -> Option<usize>;
 }
 
 // `usize` index as Key
 impl Key for usize {
     #[inline]
-    fn find<const Y: usize, M>(&self) -> core::option::Option<usize> {
+    fn find<const Y: usize, M>(&self) -> Option<usize> {
         Some(*self)
     }
 }
@@ -154,7 +155,7 @@ impl Key for usize {
 // &str name as Key
 impl Key for &str {
     #[inline]
-    fn find<const Y: usize, M: TreeKey<Y>>(&self) -> core::option::Option<usize> {
+    fn find<const Y: usize, M: TreeKey<Y>>(&self) -> Option<usize> {
         M::name_to_index(self)
     }
 }
@@ -322,7 +323,7 @@ pub trait TreeKey<const Y: usize = 1> {
     /// }
     /// assert_eq!(S::name_to_index("bar"), Some(1));
     /// ```
-    fn name_to_index(name: &str) -> core::option::Option<usize>;
+    fn name_to_index(name: &str) -> Option<usize>;
 
     /// Call a function for each node on the path described by keys.
     ///
@@ -414,7 +415,7 @@ pub trait TreeKey<const Y: usize = 1> {
     where
         K: IntoIterator,
         K::Item: Key,
-        P: core::fmt::Write,
+        P: Write,
     {
         Self::traverse_by_key(keys.into_iter(), |_index, name| {
             path.write_str(sep).and_then(|_| path.write_str(name))
@@ -492,7 +493,7 @@ pub trait TreeKey<const Y: usize = 1> {
     /// # Returns
     /// An iterator of paths with a trusted and exact [`Iterator::size_hint()`].
     #[inline]
-    fn iter_paths<P: core::fmt::Write>(sep: &str) -> PathIter<'_, Self, Y, P> {
+    fn iter_paths<P: Write>(sep: &str) -> PathIter<'_, Self, Y, P> {
         PathIter::new(sep)
     }
 
@@ -522,7 +523,7 @@ pub trait TreeKey<const Y: usize = 1> {
     /// # Returns
     /// A iterator of paths.
     #[inline]
-    fn iter_paths_unchecked<P: core::fmt::Write>(sep: &str) -> PathIter<'_, Self, Y, P> {
+    fn iter_paths_unchecked<P: Write>(sep: &str) -> PathIter<'_, Self, Y, P> {
         PathIter::new_unchecked(sep)
     }
 }


### PR DESCRIPTION
Adds support for skipping fields in a miniconf tree.

Fixes #182 