### PR TITLE
pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.67.0  # keep in sync with manifest MSRV
+          - 1.70.0  # keep in sync with manifest MSRV
         target:
           - thumbv7em-none-eabihf
 
@@ -125,7 +125,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.67.0  # keep in sync with manifest MSRV
+          - 1.70.0  # keep in sync with manifest MSRV
         args:
           - ""
           - --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.65.0  # keep in sync with manifest MSRV
+          - 1.67.0  # keep in sync with manifest MSRV
         target:
           - thumbv7em-none-eabihf
 
@@ -125,7 +125,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.65.0  # keep in sync with manifest MSRV
+          - 1.67.0  # keep in sync with manifest MSRV
         args:
           - ""
           - --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The trait methods are now generic over `Keys` and not over `Iterator<Item: Key>`.
   A blanket implementation has been provided.
 * `JsonCoreSlash::{set,get}_json_by_indices()` removed in favor of `{get,set}_json_by_key()`.
+* [breaking] `Error::PostDeserialization` renamed to `Error::Finalization`.
+* [breaking] `json-core` removed from default features.
 
 ### Added
 
@@ -29,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `TreeKey::iter_indices()` and `iter_indices_unchecked()`
 * Derive macros: Support for fallible getter/setter/validation callbacks
 * Support for bit-packed keys `Packed` and `iter_packed()`/`iter_packed_unchecked()`
+* A `postcard` feature and `Postcard` trait and blanket implementation
 
 ## [0.9.0](https://github.com/quartiq/miniconf/compare/v0.8.0...v0.9.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [breaking] The MQTT client has been split into its own `miniconf_mqtt` crate.
 * [breaking] The attribute syntax has changed from `#[tree(depth(1))]` to `#[tree(depth=1)]`.
 * [breaking] The default depth is `0`, also in the case where a `#[tree()]` without `depth` has been specified.
-* The `traverse_by_key` callback also receives the number of indices at the given level.
-* The trait methods are not generic over `Iterator<Item: Key>` but over `Keys`.
+* [breaking] The `traverse_by_key` callback also receives the number of indices at the given level.
+* The trait methods are now generic over `Keys` and not over `Iterator<Item: Key>`.
+  A blanket implementation has been provided.
 
 ### Added
 
@@ -97,7 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [breaking] Metadata is now computed by default without taking into account
   path separators. These can be included using `Metadata::separator()`.
 
-## [0.7.1] (https://github.com/quartiq/miniconf/compare/v0.7.0...v0.7.1)
+## [0.7.1](https://github.com/quartiq/miniconf/compare/v0.7.0...v0.7.1)
 
 ### Fixed
 
@@ -108,6 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.7.0](https://github.com/quartiq/miniconf/compare/v0.6.3...v0.7.0)
 
 ### Added
+
 * [MQTT client] Getting values is now supported by publishing an empty message to the topic.
 * [MQTT client] New `list` command is exposed under the Miniconf prefix to allow host software to
   discover current device settings tree structure.
@@ -117,12 +119,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Updated to minimq 0.7
 
 ### Changed
+
 * Responses now encode status values as strings in a `UserProperty` with key "code"
 
 ### Fixed
+
 * `miniconf::Option`'s `get_path()` and `set_path()` return `Err(Error::PathAbsent)`
   if `None`
-
 
 ## [0.6.3](https://github.com/quartiq/miniconf/compare/v0.6.2...v0.6.3) - 2022-12-09
 
@@ -140,6 +143,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.0](https://github.com/quartiq/miniconf/compare/v0.5.0...v0.6.0) - 2022-11-04
 
 ### Changed
+
 * python module: don't emite whitespace in JSON to match serde-json-core (#92)
 * `heapless::String` now implements `Miniconf` directly.
 * Python client API is no longer retain by default. CLI is unchanged
@@ -165,15 +169,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * MQTT client no longer uses correlation data to ignore local transmissions.
 
 ### Fixed
+
 * Python device discovery now only discovers unique device identifiers. See [#97](https://github.com/quartiq/miniconf/issues/97)
 * Python requests API updated to use a static response topic
 * Python requests now have a timeout
 * Generic trait bound requirements have been made more specific.
 
-
 ## [0.5.0] - 2022-05-12
 
 ### Changed
+
 * **breaking** The Miniconf trait for iteration was renamed from `unchecked_iter()` and `iter()` to
   `unchecked_iter_settings()` and `iter_settings()` respectively to avoid issues with slice iteration
   name conflicts. See [#87](https://github.com/quartiq/miniconf/issues/87)
@@ -181,10 +186,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.0] - 2022-05-11
 
 ### Added
+
 * Added support for custom handling of settings updates.
 * `Option` support added to enable run-time settings tree presence.
 
 ### Changed
+
 * [breaking] MqttClient constructor now accepts initial settings values.
 * Settings republish will no longer register as incoming configuration requests. See
   [#71](https://github.com/quartiq/miniconf/issues/71)
@@ -192,11 +199,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   respectively to conform with standard conventions.
 
 ### Removed
+
 * The client no longer resets the republish timeout when receiving messages.
 
 ## [0.3.0] - 2021-12-13
 
 ### Added
+
 * Added key iteration
 * Added support for retrieving serialized values via keys.
 * Added APIs to the Miniconf trait for asynchronous iteration.
@@ -205,16 +214,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support for republishing settings after a predefined delay.
 
 ### Changed
+
 * `miniconf::update()` replaced with `Miniconf::set()`, which is part of the trait and now
   directly available on structures.
 
 ## [0.2.0] - 2021-10-28
 
 ### Added
+
 * Added support for generic maximum MQTT message size
 * `derive_miniconf` added support for generic types
 
 ### Changed
+
 * Updated minimq dependency to support ping TCP reconnection support
 
 ## [0.1.0] - 2021-08-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `JsonCoreSlash::{set,get}_json_by_indices()` removed in favor of `{get,set}_json_by_key()`.
 * [breaking] `Error::PostDeserialization` renamed to `Error::Finalization`.
 * [breaking] `json-core` removed from default features.
-* [breaking] Bumped MSRV to 1.67.0
+* [breaking] Bumped MSRV to 1.70.0
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `JsonCoreSlash::{set,get}_json_by_indices()` removed in favor of `{get,set}_json_by_key()`.
 * [breaking] `Error::PostDeserialization` renamed to `Error::Finalization`.
 * [breaking] `json-core` removed from default features.
+* [breaking] Bumped MSRV to 1.67.0
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [breaking] The `traverse_by_key` callback also receives the number of indices at the given level.
 * The trait methods are now generic over `Keys` and not over `Iterator<Item: Key>`.
   A blanket implementation has been provided.
+* `JsonCoreSlash::{set,get}_json_by_indices()` removed in favor of `{get,set}_json_by_key()`.
 
 ### Added
 
-* Python lib: Support for clearing a retained setting
-* Python CLI: get() support
+* Python MQTT lib: Support for clearing a retained setting
+* Python MQTT CLI: get() support
 * `TreeKey::iter_indices()` and `iter_indices_unchecked()`
 * Derive macros: Support for fallible getter/setter/validation callbacks
 * Support for bit-packed keys `Packed` and `iter_packed()`/`iter_packed_unchecked()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [breaking] The MQTT client has been split into its own `miniconf_mqtt` crate.
 * [breaking] The attribute syntax has changed from `#[tree(depth(1))]` to `#[tree(depth=1)]`.
 * [breaking] The default depth is `0`, also in the case where a `#[tree()]` without `depth` has been specified.
+* The `traverse_by_key` callback also receives the number of indices at the given level.
+* The trait methods are not generic over `Iterator<Item: Key>` but over `Keys`.
 
 ### Added
 
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Python CLI: get() support
 * `TreeKey::iter_indices()` and `iter_indices_unchecked()`
 * Derive macros: Support for fallible getter/setter/validation callbacks
+* Support for bit-packed keys `Packed` and `iter_packed()`/`iter_packed_unchecked()`
 
 ## [0.9.0](https://github.com/quartiq/miniconf/compare/v0.8.0...v0.9.0)
 

--- a/README.md
+++ b/README.md
@@ -126,11 +126,17 @@ client and a Python reference implementation to interact with it. Now it is agno
 
 ## Formats
 
-`Miniconf` can be used with any `serde::Serializer`/`serde::Deserializer` backend, path
-hierarchy separator, and key lookup algorithm.
+`Miniconf` can be used with any `serde::Serializer`/`serde::Deserializer` backend, and key format.
 
 Currently support for `/` as the path hierarchy separator and JSON (`serde_json_core`) is implemented
 through the [`JsonCoreSlash`] super trait.
+
+The [`Postcard`] super trait supports the `postcard` wire format with any `postcard` flavor and
+any [`Keys`] type. Combined with the [`Packed`] key representation, this is a very
+space-efficient key-serde API.
+
+Blanket implementations are provided for all
+`TreeSerialize`+`TreeDeserialize` types for all formats.
 
 ## Transport
 
@@ -162,9 +168,14 @@ See also the [`TreeKey`] trait documentation for details.
 
 ## Keys and paths
 
-Lookup into the tree is done using an iterator over [`Key`] items. `usize` indices or `&str` names are supported.
+Lookup into the tree is done using a [`Keys`] implementation. A blanket implementation through [`IntoKeys`]
+is provided for `IntoIterator`s over [`Key`] items. The [`Key`] lookup capability is implemented
+for `usize` indices and `&str` names.
 
 Path iteration is supported with arbitrary separator between names.
+
+Very compact hierarchical indices encodings can be obtained from the [`Packed`] structure.
+It implements [`Keys`].
 
 ## Limitations
 

--- a/miniconf/Cargo.toml
+++ b/miniconf/Cargo.toml
@@ -9,7 +9,7 @@ description = "Serialize/deserialize/access  Inspect serde namespaces by path"
 repository = "https://github.com/quartiq/miniconf"
 keywords = ["settings", "serde", "no_std", "json", "mqtt"]
 categories = ["no-std", "config", "rust-patterns", "parsing"]
-rust-version = "1.67.0" # keep in sync with CI and with other crates and with github branch protection
+rust-version = "1.70.0" # keep in sync with CI and with other crates and with github branch protection
 resolver = "2"
 
 [dependencies]

--- a/miniconf/Cargo.toml
+++ b/miniconf/Cargo.toml
@@ -9,7 +9,7 @@ description = "Serialize/deserialize/access  Inspect serde namespaces by path"
 repository = "https://github.com/quartiq/miniconf"
 keywords = ["settings", "serde", "no_std", "json", "mqtt"]
 categories = ["no-std", "config", "rust-patterns", "parsing"]
-rust-version = "1.65.0"  # keep in sync with CI and with other crates
+rust-version = "1.67.0" # keep in sync with CI and with other crates and with github branch protection
 resolver = "2"
 
 [dependencies]

--- a/miniconf/Cargo.toml
+++ b/miniconf/Cargo.toml
@@ -14,11 +14,16 @@ resolver = "2"
 
 [dependencies]
 serde = { version = "1.0.120", default-features = false }
-miniconf_derive = { path = "../miniconf_derive" , version = "0.9" }
+miniconf_derive = { path = "../miniconf_derive", version = "0.9" }
 itoa = "1.0.4"
-serde-json-core = { version = "0.5.1" , optional = true }
+serde-json-core = { version = "0.5.1", optional = true }
+postcard = { version = "1.0.8", optional = true }
 
 [features]
-default = ["json-core"]
+default = []
 json-core = ["dep:serde-json-core"]
+postcard = ["dep:postcard"]
 std = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -21,10 +21,6 @@ macro_rules! depth {
                 value.parse().ok()
             }
 
-            fn len() -> usize {
-                N
-            }
-
             fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>
             where
                 K: Keys,
@@ -83,10 +79,6 @@ depth!(2 3 4 5 6 7 8);
 impl<T, const N: usize> TreeKey for [T; N] {
     fn name_to_index(value: &str) -> Option<usize> {
         value.parse().ok()
-    }
-
-    fn len() -> usize {
-        N
     }
 
     fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -30,7 +30,7 @@ macro_rules! depth {
                 K: Keys,
                 F: FnMut(usize, &str, usize) -> Result<(), E>,
             {
-                let key = keys.next::<$y, Self>().ok_or(Error::TooShort(0))?;
+                let key = keys.next(N).ok_or(Error::TooShort(0))?;
                 let index = key.find::<$y, Self>().ok_or(Error::NotFound(1))?;
                 if index >= N {
                     return Err(Error::NotFound(1));
@@ -56,7 +56,7 @@ macro_rules! depth {
                 K: Keys,
                 S: Serializer,
             {
-                let key = keys.next::<$y, Self>().ok_or(Error::TooShort(0))?;
+                let key = keys.next(N).ok_or(Error::TooShort(0))?;
                 let index = key.find::<$y, Self>().ok_or(Error::NotFound(1))?;
                 let item = self.get(index).ok_or(Error::NotFound(1))?;
                 item.serialize_by_key(keys, ser).increment()
@@ -69,7 +69,7 @@ macro_rules! depth {
                 K: Keys,
                 D: Deserializer<'de>,
             {
-                let key = keys.next::<$y, Self>().ok_or(Error::TooShort(0))?;
+                let key = keys.next(N).ok_or(Error::TooShort(0))?;
                 let index = key.find::<$y, Self>().ok_or(Error::NotFound(1))?;
                 let item = self.get_mut(index).ok_or(Error::NotFound(1))?;
                 item.deserialize_by_key(keys, de).increment()
@@ -94,7 +94,7 @@ impl<T, const N: usize> TreeKey for [T; N] {
         K: Keys,
         F: FnMut(usize, &str, usize) -> Result<(), E>,
     {
-        let key = keys.next::<1, Self>().ok_or(Error::TooShort(0))?;
+        let key = keys.next(N).ok_or(Error::TooShort(0))?;
         match key.find::<1, Self>() {
             Some(index) if index < N => {
                 func(index, itoa::Buffer::new().format(index), N)?;
@@ -119,11 +119,11 @@ impl<T: Serialize, const N: usize> TreeSerialize for [T; N] {
         K: Keys,
         S: Serializer,
     {
-        let key = keys.next::<1, Self>().ok_or(Error::TooShort(0))?;
+        let key = keys.next(N).ok_or(Error::TooShort(0))?;
         let index = key.find::<1, Self>().ok_or(Error::NotFound(1))?;
         let item = self.get(index).ok_or(Error::NotFound(1))?;
         // Precedence
-        if keys.next::<1, Self>().is_some() {
+        if keys.next(N).is_some() {
             Err(Error::TooLong(1))
         } else {
             item.serialize(ser)?;
@@ -138,11 +138,11 @@ impl<'de, T: Deserialize<'de>, const N: usize> TreeDeserialize<'de> for [T; N] {
         K: Keys,
         D: Deserializer<'de>,
     {
-        let key = keys.next::<1, Self>().ok_or(Error::TooShort(0))?;
+        let key = keys.next(N).ok_or(Error::TooShort(0))?;
         let index = key.find::<1, Self>().ok_or(Error::NotFound(1))?;
         let item = self.get_mut(index).ok_or(Error::NotFound(1))?;
         // Precedence
-        if keys.next::<1, Self>().is_some() {
+        if keys.next(N).is_some() {
             Err(Error::TooLong(1))
         } else {
             *item = T::deserialize(de)?;

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -122,8 +122,8 @@ impl<T: Serialize, const N: usize> TreeSerialize for [T; N] {
         let key = keys.next(N).ok_or(Error::TooShort(0))?;
         let index = key.find::<1, Self>().ok_or(Error::NotFound(1))?;
         let item = self.get(index).ok_or(Error::NotFound(1))?;
-        // Precedence
-        if keys.next(N).is_some() {
+        // ensure no non-trivial key is left
+        if keys.next(1).is_some() {
             Err(Error::TooLong(1))
         } else {
             item.serialize(ser)?;
@@ -141,8 +141,8 @@ impl<'de, T: Deserialize<'de>, const N: usize> TreeDeserialize<'de> for [T; N] {
         let key = keys.next(N).ok_or(Error::TooShort(0))?;
         let index = key.find::<1, Self>().ok_or(Error::NotFound(1))?;
         let item = self.get_mut(index).ok_or(Error::NotFound(1))?;
-        // Precedence
-        if keys.next(N).is_some() {
+        // ensure no non-trivial key is left
+        if keys.next(1).is_some() {
             Err(Error::TooLong(1))
         } else {
             *item = T::deserialize(de)?;

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -26,7 +26,7 @@ macro_rules! depth {
                 K: Keys,
                 F: FnMut(usize, &str, usize) -> Result<(), E>,
             {
-                let index = keys.lookup::<$y, Self, E>(N)?;
+                let index = keys.lookup::<$y, Self, _>(N)?;
                 if index >= N {
                     return Err(Error::NotFound(1));
                 }
@@ -51,7 +51,7 @@ macro_rules! depth {
                 K: Keys,
                 S: Serializer,
             {
-                let index = keys.lookup::<$y, Self, S::Error>(N)?;
+                let index = keys.lookup::<$y, Self, _>(N)?;
                 let item = self.get(index).ok_or(Error::NotFound(1))?;
                 item.serialize_by_key(keys, ser).increment()
             }
@@ -63,7 +63,7 @@ macro_rules! depth {
                 K: Keys,
                 D: Deserializer<'de>,
             {
-                let index = keys.lookup::<$y, Self, D::Error>(N)?;
+                let index = keys.lookup::<$y, Self, _>(N)?;
                 let item = self.get_mut(index).ok_or(Error::NotFound(1))?;
                 item.deserialize_by_key(keys, de).increment()
             }
@@ -108,7 +108,7 @@ impl<T: Serialize, const N: usize> TreeSerialize for [T; N] {
         K: Keys,
         S: Serializer,
     {
-        let index = keys.lookup::<1, Self, S::Error>(N)?;
+        let index = keys.lookup::<1, Self, _>(N)?;
         let item = self.get(index).ok_or(Error::NotFound(1))?;
         // Precedence
         if !keys.is_empty() {
@@ -126,7 +126,7 @@ impl<'de, T: Deserialize<'de>, const N: usize> TreeDeserialize<'de> for [T; N] {
         K: Keys,
         D: Deserializer<'de>,
     {
-        let index = keys.lookup::<1, Self, D::Error>(N)?;
+        let index = keys.lookup::<1, Self, _>(N)?;
         let item = self.get_mut(index).ok_or(Error::NotFound(1))?;
         // Precedence
         if !keys.is_empty() {

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -114,8 +114,8 @@ impl<T: Serialize, const N: usize> TreeSerialize for [T; N] {
         let key = keys.next(N).ok_or(Error::TooShort(0))?;
         let index = key.find::<1, Self>().ok_or(Error::NotFound(1))?;
         let item = self.get(index).ok_or(Error::NotFound(1))?;
-        // ensure no non-trivial key is left
-        if keys.next(1).is_some() {
+        // Precedence
+        if keys.next(0).is_some() {
             Err(Error::TooLong(1))
         } else {
             item.serialize(ser)?;
@@ -133,8 +133,8 @@ impl<'de, T: Deserialize<'de>, const N: usize> TreeDeserialize<'de> for [T; N] {
         let key = keys.next(N).ok_or(Error::TooShort(0))?;
         let index = key.find::<1, Self>().ok_or(Error::NotFound(1))?;
         let item = self.get_mut(index).ok_or(Error::NotFound(1))?;
-        // ensure no non-trivial key is left
-        if keys.next(1).is_some() {
+        // Precedence
+        if keys.next(0).is_some() {
             Err(Error::TooLong(1))
         } else {
             *item = T::deserialize(de)?;

--- a/miniconf/src/iter.rs
+++ b/miniconf/src/iter.rs
@@ -1,6 +1,8 @@
 use crate::{Error, Packed, TreeKey};
 use core::{fmt::Write, marker::PhantomData};
 
+// core::iter::ExactSizeIterator would be applicable if `count.is_some()`.`
+
 /// An iterator over nodes in a `TreeKey`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct Iter<const Y: usize> {

--- a/miniconf/src/iter.rs
+++ b/miniconf/src/iter.rs
@@ -59,7 +59,7 @@ where
         let mut path = P::default();
 
         loop {
-            return match M::path(self.state, &mut path, self.separator) {
+            return match M::path(self.state.iter().copied(), &mut path, self.separator) {
                 // Out of valid indices at the root: iteration done
                 Err(Error::NotFound(1)) => {
                     debug_assert_eq!(self.count.unwrap_or_default(), 0);
@@ -165,7 +165,8 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            return match M::traverse_by_key(self.state.iter().copied(), |_, _| Ok::<(), ()>(())) {
+            return match M::traverse_by_key(self.state.iter().copied(), |_, _, _| Ok::<(), ()>(()))
+            {
                 // Out of valid indices at the root: iteration done
                 Err(Error::NotFound(1)) => {
                     debug_assert_eq!(self.count.unwrap_or_default(), 0);

--- a/miniconf/src/iter.rs
+++ b/miniconf/src/iter.rs
@@ -72,7 +72,8 @@ impl<const Y: usize> Iter<Y> {
             // NotFound(0): Not having consumed any name/index, the only possible case
             // is a root leaf (e.g. `Option` or newtype), those however can not return
             // `NotFound` as they don't do key lookup.
-            Err(Error::NotFound(0)) |
+            // We write NotFound(_) as e.g. rust 1.70.0 isn't smart enough to prove coverage.
+            Err(Error::NotFound(_)) |
             // TooShort: Excluded by construction (`state.len() == Y` and `Y` being an
             // upper bound to key length as per the `TreeKey<Y>` contract.
             Err(Error::TooShort(_)) |

--- a/miniconf/src/json_core.rs
+++ b/miniconf/src/json_core.rs
@@ -78,7 +78,7 @@ impl<'de, T: TreeSerialize<Y> + TreeDeserialize<'de, Y>, const Y: usize> JsonCor
     ) -> Result<usize, Error<de::Error>> {
         let mut de = de::Deserializer::new(data);
         self.deserialize_by_key(keys.into_keys(), &mut de)?;
-        de.end().map_err(Error::PostDeserialization)
+        de.end().map_err(Error::Finalization)
     }
 
     #[inline]

--- a/miniconf/src/json_core.rs
+++ b/miniconf/src/json_core.rs
@@ -1,4 +1,4 @@
-use crate::{Error, TreeDeserialize, TreeSerialize};
+use crate::{Error, IntoKeys, TreeDeserialize, TreeSerialize};
 use serde_json_core::{de, ser};
 
 /// Miniconf with "JSON and `/`".
@@ -8,10 +8,10 @@ use serde_json_core::{de, ser};
 pub trait JsonCoreSlash<'de, const Y: usize = 1>:
     TreeSerialize<Y> + TreeDeserialize<'de, Y>
 {
-    /// Update an element by path.
+    /// Update a node by path.
     ///
     /// # Args
-    /// * `path` - The path to the element. Everything before the first `'/'` is ignored.
+    /// * `path` - The path to the node. Everything before the first `'/'` is ignored.
     /// * `data` - The serialized data making up the content.
     ///
     /// # Returns
@@ -21,38 +21,38 @@ pub trait JsonCoreSlash<'de, const Y: usize = 1>:
     /// Retrieve a serialized value by path.
     ///
     /// # Args
-    /// * `path` - The path to the element.
+    /// * `path` - The path to the node.
     /// * `data` - The buffer to serialize the data into.
     ///
     /// # Returns
     /// The number of bytes used in the `data` buffer or an [Error].
     fn get_json(&self, path: &str, data: &mut [u8]) -> Result<usize, Error<ser::Error>>;
 
-    /// Update an element by indices.
+    /// Update a node by key.
     ///
     /// # Args
-    /// * `indices` - The indices to the element. Everything before the first `'/'` is ignored.
+    /// * `keys` - The `Keys` to the node.
     /// * `data` - The serialized data making up the content.
     ///
     /// # Returns
     /// The number of bytes consumed from `data` or an [Error].
-    fn set_json_by_index(
+    fn set_json_by_key<K: IntoKeys>(
         &mut self,
-        indices: &[usize],
+        keys: K,
         data: &'de [u8],
     ) -> Result<usize, Error<de::Error>>;
 
-    /// Retrieve a serialized value by indices.
+    /// Retrieve a serialized value by key.
     ///
     /// # Args
-    /// * `indices` - The indices to the element.
+    /// * `keys` - The `Keys` to the node.
     /// * `data` - The buffer to serialize the data into.
     ///
     /// # Returns
     /// The number of bytes used in the `data` buffer or an [Error].
-    fn get_json_by_index(
+    fn get_json_by_key<K: IntoKeys>(
         &self,
-        indices: &[usize],
+        keys: K,
         data: &mut [u8],
     ) -> Result<usize, Error<ser::Error>>;
 }
@@ -60,35 +60,35 @@ pub trait JsonCoreSlash<'de, const Y: usize = 1>:
 impl<'de, T: TreeSerialize<Y> + TreeDeserialize<'de, Y>, const Y: usize> JsonCoreSlash<'de, Y>
     for T
 {
+    #[inline]
     fn set_json(&mut self, path: &str, data: &'de [u8]) -> Result<usize, Error<de::Error>> {
-        let mut de = de::Deserializer::new(data);
-        self.deserialize_by_key(path.split('/').skip(1), &mut de)?;
-        de.end().map_err(Error::PostDeserialization)
+        self.set_json_by_key(path.split('/').skip(1), data)
     }
 
+    #[inline]
     fn get_json(&self, path: &str, data: &mut [u8]) -> Result<usize, Error<ser::Error>> {
-        let mut ser = ser::Serializer::new(data);
-        self.serialize_by_key(path.split('/').skip(1), &mut ser)?;
-        Ok(ser.end())
+        self.get_json_by_key(path.split('/').skip(1), data)
     }
 
-    fn set_json_by_index(
+    #[inline]
+    fn set_json_by_key<K: IntoKeys>(
         &mut self,
-        indices: &[usize],
+        keys: K,
         data: &'de [u8],
     ) -> Result<usize, Error<de::Error>> {
         let mut de = de::Deserializer::new(data);
-        self.deserialize_by_key(indices.iter().copied(), &mut de)?;
+        self.deserialize_by_key(keys.into_keys(), &mut de)?;
         de.end().map_err(Error::PostDeserialization)
     }
 
-    fn get_json_by_index(
+    #[inline]
+    fn get_json_by_key<K: IntoKeys>(
         &self,
-        indices: &[usize],
+        keys: K,
         data: &mut [u8],
     ) -> Result<usize, Error<ser::Error>> {
         let mut ser = ser::Serializer::new(data);
-        self.serialize_by_key(indices.iter().copied(), &mut ser)?;
+        self.serialize_by_key(keys.into_keys(), &mut ser)?;
         Ok(ser.end())
     }
 }

--- a/miniconf/src/key.rs
+++ b/miniconf/src/key.rs
@@ -1,0 +1,67 @@
+use crate::TreeKey;
+
+/// Capability to convert a key into a node index for a given `M: TreeKey`
+pub trait Key {
+    /// Convert the key `self` to a `usize` index
+    fn find<const Y: usize, M: TreeKey<Y>>(&self) -> Option<usize>;
+}
+
+// `usize` index as Key
+impl Key for usize {
+    #[inline]
+    fn find<const Y: usize, M>(&self) -> Option<usize> {
+        Some(*self)
+    }
+}
+
+// &str name as Key
+impl Key for &str {
+    #[inline]
+    fn find<const Y: usize, M: TreeKey<Y>>(&self) -> Option<usize> {
+        M::name_to_index(self)
+    }
+}
+
+/// Capability to yield keys given `M: TreeKey`
+pub trait Keys {
+    /// The type of key that we yield.
+    type Item: Key;
+
+    /// Convert the next key `self` to a `usize` index.
+    fn next<const Y: usize, M: TreeKey<Y>>(&mut self) -> Option<Self::Item>;
+}
+
+impl<T> Keys for T
+where
+    T: Iterator,
+    T::Item: Key,
+{
+    type Item = T::Item;
+
+    #[inline]
+    fn next<const Y: usize, M: TreeKey<Y>>(&mut self) -> Option<Self::Item> {
+        Iterator::next(self)
+    }
+}
+
+/// Capability to be converted into a [`Keys`]
+pub trait IntoKeys {
+    /// The specific [`Keys`] implementor.
+    type IntoKeys: Keys;
+
+    /// Convert `self` into a [`Keys`] implementor.
+    fn into_keys(self) -> Self::IntoKeys;
+}
+
+impl<T> IntoKeys for T
+where
+    T: IntoIterator,
+    T::IntoIter: Keys,
+{
+    type IntoKeys = T::IntoIter;
+
+    #[inline]
+    fn into_keys(self) -> Self::IntoKeys {
+        self.into_iter()
+    }
+}

--- a/miniconf/src/key.rs
+++ b/miniconf/src/key.rs
@@ -28,6 +28,10 @@ pub trait Keys {
     type Item: Key;
 
     /// Convert the next key `self` to a `usize` index.
+    ///
+    /// # Args
+    /// * `len` is an upper limit to the number of keys at this level.
+    ///   It is non-zero.
     fn next(&mut self, len: usize) -> Option<Self::Item>;
 }
 

--- a/miniconf/src/key.rs
+++ b/miniconf/src/key.rs
@@ -28,7 +28,7 @@ pub trait Keys {
     type Item: Key;
 
     /// Convert the next key `self` to a `usize` index.
-    fn next<const Y: usize, M: TreeKey<Y>>(&mut self) -> Option<Self::Item>;
+    fn next(&mut self, len: usize) -> Option<Self::Item>;
 }
 
 impl<T> Keys for T
@@ -39,7 +39,7 @@ where
     type Item = T::Item;
 
     #[inline]
-    fn next<const Y: usize, M: TreeKey<Y>>(&mut self) -> Option<Self::Item> {
+    fn next(&mut self, _len: usize) -> Option<Self::Item> {
         Iterator::next(self)
     }
 }

--- a/miniconf/src/key.rs
+++ b/miniconf/src/key.rs
@@ -1,4 +1,4 @@
-use crate::TreeKey;
+use crate::{Error, TreeKey};
 
 /// Capability to convert a key into a node index for a given `M: TreeKey`
 pub trait Key {
@@ -33,6 +33,24 @@ pub trait Keys {
     /// * `len` is an upper limit to the number of keys at this level.
     ///   It is non-zero.
     fn next(&mut self, len: usize) -> Option<Self::Item>;
+
+    /// Look up a key in a [`TreeKey`] and convert to `usize` index.
+    ///
+    /// # Args
+    /// * `len` as for [`Keys::next()`]
+    fn lookup<const Y: usize, S: TreeKey<Y>, E>(&mut self, len: usize) -> Result<usize, Error<E>> {
+        self.next(len)
+            .ok_or(Error::TooShort(0))?
+            .find::<Y, S>()
+            .ok_or(Error::NotFound(1))
+    }
+
+    /// Return whether there are more keys.
+    ///
+    /// This may mutate and consume remaining keys.
+    fn is_empty(&mut self) -> bool {
+        self.next(0).is_none()
+    }
 }
 
 impl<T> Keys for T

--- a/miniconf/src/lib.rs
+++ b/miniconf/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(any(test, doctest, feature = "std")), no_std)]
 #![cfg_attr(all(feature = "json-core", feature = "postcard"), doc = include_str!("../../README.md"))]
-#![cfg_attr(not(feature = "json-core"), doc = "Miniconf")]
+#![cfg_attr(not(all(feature = "json-core", feature = "postcard")), doc = "Miniconf")]
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
 #![warn(missing_docs)]

--- a/miniconf/src/lib.rs
+++ b/miniconf/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(any(test, doctest, feature = "std")), no_std)]
-#![cfg_attr(feature = "json-core", doc = include_str!("../../README.md"))]
+#![cfg_attr(all(feature = "json-core", feature = "postcard"), doc = include_str!("../../README.md"))]
 #![cfg_attr(not(feature = "json-core"), doc = "Miniconf")]
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]

--- a/miniconf/src/lib.rs
+++ b/miniconf/src/lib.rs
@@ -26,7 +26,7 @@ pub use json_core::*;
 #[cfg(feature = "postcard")]
 mod postcard;
 #[cfg(feature = "postcard")]
-pub use postcard::*;
+pub use crate::postcard::*;
 
 // re-export for proc-macro
 #[doc(hidden)]

--- a/miniconf/src/lib.rs
+++ b/miniconf/src/lib.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(not(any(test, doctest, feature = "std")), no_std)]
 #![cfg_attr(all(feature = "json-core", feature = "postcard"), doc = include_str!("../../README.md"))]
-#![cfg_attr(not(all(feature = "json-core", feature = "postcard")), doc = "Miniconf")]
+#![cfg_attr(
+    not(all(feature = "json-core", feature = "postcard")),
+    doc = "Miniconf"
+)]
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
 #![warn(missing_docs)]

--- a/miniconf/src/lib.rs
+++ b/miniconf/src/lib.rs
@@ -13,6 +13,10 @@ mod array;
 mod iter;
 pub use iter::*;
 mod option;
+mod packed;
+pub use packed::*;
+mod key;
+pub use key::*;
 
 #[cfg(feature = "json-core")]
 mod json_core;

--- a/miniconf/src/lib.rs
+++ b/miniconf/src/lib.rs
@@ -23,6 +23,11 @@ mod json_core;
 #[cfg(feature = "json-core")]
 pub use json_core::*;
 
+#[cfg(feature = "postcard")]
+mod postcard;
+#[cfg(feature = "postcard")]
+pub use postcard::*;
+
 // re-export for proc-macro
 #[doc(hidden)]
 pub use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};

--- a/miniconf/src/option.rs
+++ b/miniconf/src/option.rs
@@ -84,7 +84,7 @@ impl<T: Serialize> TreeSerialize for Option<T> {
         K: Keys,
         S: Serializer,
     {
-        if keys.next(0).is_some() {
+        if !keys.is_empty() {
             Err(Error::TooLong(0))
         } else if let Some(inner) = self {
             inner.serialize(ser)?;
@@ -101,7 +101,7 @@ impl<'de, T: Deserialize<'de>> TreeDeserialize<'de> for Option<T> {
         K: Keys,
         D: Deserializer<'de>,
     {
-        if keys.next(0).is_some() {
+        if !keys.is_empty() {
             Err(Error::TooLong(0))
         } else if let Some(inner) = self {
             *inner = T::deserialize(de)?;

--- a/miniconf/src/option.rs
+++ b/miniconf/src/option.rs
@@ -13,10 +13,6 @@ macro_rules! depth {
                 None
             }
 
-            fn len() -> usize {
-                0
-            }
-
             fn traverse_by_key<K, F, E>(keys: K, func: F) -> Result<usize, Error<E>>
             where
                 K: Keys,
@@ -65,10 +61,6 @@ depth!(2 3 4 5 6 7 8);
 impl<T> TreeKey for Option<T> {
     fn name_to_index(_value: &str) -> Option<usize> {
         None
-    }
-
-    fn len() -> usize {
-        0
     }
 
     fn traverse_by_key<K, F, E>(_keys: K, _func: F) -> Result<usize, Error<E>>

--- a/miniconf/src/option.rs
+++ b/miniconf/src/option.rs
@@ -92,7 +92,7 @@ impl<T: Serialize> TreeSerialize for Option<T> {
         K: Keys,
         S: Serializer,
     {
-        if keys.next::<1, Self>().is_some() {
+        if keys.next(0).is_some() {
             Err(Error::TooLong(0))
         } else if let Some(inner) = self {
             inner.serialize(ser)?;
@@ -109,7 +109,7 @@ impl<'de, T: Deserialize<'de>> TreeDeserialize<'de> for Option<T> {
         K: Keys,
         D: Deserializer<'de>,
     {
-        if keys.next::<1, Self>().is_some() {
+        if keys.next(0).is_some() {
             Err(Error::TooLong(0))
         } else if let Some(inner) = self {
             *inner = T::deserialize(de)?;

--- a/miniconf/src/packed.rs
+++ b/miniconf/src/packed.rs
@@ -91,8 +91,8 @@ impl Packed {
 impl Keys for Packed {
     type Item = usize;
     #[inline]
-    fn next<const Y: usize, M: TreeKey<Y>>(&mut self) -> Option<Self::Item> {
-        self.pop_msb(usize::BITS - (M::len() - 1).leading_zeros())
+    fn next(&mut self, len: usize) -> Option<Self::Item> {
+        self.pop_msb(usize::BITS - (len - 1).leading_zeros())
     }
 }
 

--- a/miniconf/src/packed.rs
+++ b/miniconf/src/packed.rs
@@ -147,13 +147,13 @@ impl Packed {
     /// it is left unchanged and `None` is returned.
     ///
     /// # Args
-    /// * `bits`: Number of bits to pop. `1 <= bits <= Self::BITS`
+    /// * `bits`: Number of bits to pop. `bits <= Self::CAPACITY`
     #[inline]
     pub fn pop_msb(&mut self, bits: u32) -> Option<usize> {
         let s = self.get();
         if let Some(new) = Self::new(s << bits) {
             self.0 = new.0;
-            Some(s >> (Self::BITS - bits))
+            Some((s >> (Self::CAPACITY - bits)) >> 1)
         } else {
             None
         }
@@ -164,7 +164,7 @@ impl Packed {
     /// Returns the remaining number of unused bits on success.
     ///
     /// # Args
-    /// * `bits`: Number of bits to push. `1 <= bits <= Self::BITS`
+    /// * `bits`: Number of bits to push. `bits <= Self::CAPACITY`
     /// * `value`: Value to push. `value >> bits == 0`
     #[inline]
     pub fn push_lsb(&mut self, bits: u32, value: usize) -> Option<u32> {

--- a/miniconf/src/packed.rs
+++ b/miniconf/src/packed.rs
@@ -45,7 +45,7 @@ impl Packed {
 
     /// Get the contained bit-packed indices representation as a `usize`.
     #[inline]
-    pub fn get(&self) -> usize {
+    pub const fn get(&self) -> usize {
         self.0.get()
     }
 
@@ -63,7 +63,7 @@ impl Packed {
 
     /// Number of bits set (previously pushed and now available for `pop()`).
     #[inline]
-    pub fn len(&self) -> u32 {
+    pub const fn len(&self) -> u32 {
         Self::CAPACITY - self.0.trailing_zeros()
     }
 

--- a/miniconf/src/packed.rs
+++ b/miniconf/src/packed.rs
@@ -41,8 +41,8 @@ use core::{
 /// # use miniconf::Packed;
 ///
 /// let mut p = Packed::EMPTY;
-/// let mut p_lsb = 1; // marker
-/// for (bits, value) in [(2, 3), (1, 0), (0, 0), (3, 5)] {
+/// let mut p_lsb = 0b1; // marker
+/// for (bits, value) in [(2, 0b11), (1, 0b0), (0, 0b0), (3, 0b101)] {
 ///     p.push_lsb(bits, value).unwrap();
 ///     p_lsb <<= bits;
 ///     p_lsb |= value;

--- a/miniconf/src/packed.rs
+++ b/miniconf/src/packed.rs
@@ -235,8 +235,9 @@ mod test {
 
     #[test]
     fn test() {
+        // Check path encoding round trip.
         let t = [1usize, 3, 4, 0, 1];
-        let mut p = Packed::default();
+        let mut p = Packed::EMPTY;
         for t in t {
             let bits = Packed::bits_for(t);
             p.push_lsb(bits, t).unwrap();

--- a/miniconf/src/packed.rs
+++ b/miniconf/src/packed.rs
@@ -1,0 +1,105 @@
+use crate::{IntoKeys, Keys, TreeKey};
+use core::num::NonZeroUsize;
+
+/// A bit-packed representation of `TreeKey` indices.
+///
+/// The value consists of a number of (from MSB to LSB):
+///
+/// * Zero or more groups of variable bit length, concatenated, each containing
+///   the index at the given `TreeKey` level. The deepest level is last.
+/// * A set marker bit
+/// * Zero or more cleared bits corresponding to unused index space.
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[repr(transparent)]
+pub struct Packed(NonZeroUsize);
+
+impl Default for Packed {
+    #[inline]
+    fn default() -> Self {
+        Self::new(1 << (usize::BITS - 1)).unwrap()
+    }
+}
+
+impl Packed {
+    /// Create a new `Packed` from a `usize`.
+    ///
+    /// The value must not be zero.
+    #[inline]
+    pub fn new(v: usize) -> Option<Self> {
+        NonZeroUsize::new(v).map(Self)
+    }
+
+    /// Get the contained bit-packed indices representation as a `usize`.
+    #[inline]
+    pub fn get(&self) -> usize {
+        self.0.get()
+    }
+
+    /// The value is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// Clear and discard all bits pushed.
+    #[inline]
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Number of bits set (previously pushed and now available for `pop()`).
+    #[inline]
+    pub fn len(&self) -> u32 {
+        usize::BITS - 1 - self.0.get().trailing_zeros()
+    }
+
+    /// Remove the given number of MSBs and return them.
+    ///
+    /// If the value does not contain sufficient bits, it is cleared and `None` is returned.
+    #[inline]
+    pub fn pop_msb(&mut self, bits: u32) -> Option<usize> {
+        let s = self.0.get();
+        if let Some(v) = NonZeroUsize::new(s << bits) {
+            self.0 = v;
+            Some(s >> (usize::BITS - bits))
+        } else {
+            self.clear();
+            None
+        }
+    }
+
+    /// Push the given number `bits` of `value` as new LSBs.
+    ///
+    /// Returns the remaining unused number of bits on success.
+    #[inline]
+    pub fn push_lsb(&mut self, bits: u32, value: usize) -> Option<u32> {
+        debug_assert_eq!(value >> bits, 0);
+        let mut s = self.0.get();
+        let mut n = s.trailing_zeros();
+        if bits <= n {
+            s &= !(1 << n);
+            n -= bits;
+            s |= ((value << 1) | 1) << n;
+            self.0 = NonZeroUsize::new(s).unwrap();
+            Some(n)
+        } else {
+            None
+        }
+    }
+}
+
+impl Keys for Packed {
+    type Item = usize;
+    #[inline]
+    fn next<const Y: usize, M: TreeKey<Y>>(&mut self) -> Option<Self::Item> {
+        self.pop_msb(usize::BITS - (M::len() - 1).leading_zeros())
+    }
+}
+
+impl IntoKeys for Packed {
+    type IntoKeys = Self;
+    #[inline]
+    fn into_keys(self) -> Self::IntoKeys {
+        self
+    }
+}

--- a/miniconf/src/packed.rs
+++ b/miniconf/src/packed.rs
@@ -218,6 +218,11 @@ impl Keys for Packed {
     fn next(&mut self, len: usize) -> Option<Self::Item> {
         self.pop_msb(Self::bits_for(len.saturating_sub(1)))
     }
+
+    #[inline]
+    fn is_empty(&mut self) -> bool {
+        Packed::is_empty(self)
+    }
 }
 
 impl IntoKeys for Packed {

--- a/miniconf/src/packed.rs
+++ b/miniconf/src/packed.rs
@@ -53,6 +53,13 @@ impl Packed {
         usize::BITS - 1 - self.0.get().trailing_zeros()
     }
 
+    /// Return the representation LSB aligned with the marker bit stripped.
+    #[inline]
+    pub fn aligned(&self) -> usize {
+        let s = self.0.get();
+        (s >> s.trailing_zeros()) >> 1
+    }
+
     /// Remove the given number of MSBs and return them.
     ///
     /// If the value does not contain sufficient bits

--- a/miniconf/src/postcard.rs
+++ b/miniconf/src/postcard.rs
@@ -1,9 +1,9 @@
 use crate::{Error, IntoKeys, TreeDeserialize, TreeSerialize};
 use postcard::{de_flavors, ser_flavors, Deserializer, Serializer};
 
-/// Miniconf with [`postcard`].
+/// Miniconf with `postcard`.
 pub trait Postcard<'de, const Y: usize = 1>: TreeSerialize<Y> + TreeDeserialize<'de, Y> {
-    /// Deserialize and set a node value from a [`postcard`] flavor.
+    /// Deserialize and set a node value from a `postcard` flavor.
     ///
     /// ```
     /// # use miniconf::{Tree, TreeKey, Postcard, Packed};
@@ -26,7 +26,7 @@ pub trait Postcard<'de, const Y: usize = 1>: TreeSerialize<Y> + TreeDeserialize<
         flavor: F,
     ) -> Result<F::Remainder, Error<postcard::Error>>;
 
-    /// Get and serialize a node value into a [`postcard`] flavor.
+    /// Get and serialize a node value into a `postcard` flavor.
     ///
     /// ```
     /// # use miniconf::{Tree, TreeKey, Postcard, Packed};

--- a/miniconf/src/postcard.rs
+++ b/miniconf/src/postcard.rs
@@ -1,0 +1,76 @@
+use crate::{Error, IntoKeys, TreeDeserialize, TreeSerialize};
+use postcard::{de_flavors, ser_flavors, Deserializer, Serializer};
+
+/// Miniconf with [`postcard`].
+pub trait Postcard<'de, const Y: usize = 1>: TreeSerialize<Y> + TreeDeserialize<'de, Y> {
+    /// Deserialize and set a node value from a [`postcard`] flavor.
+    ///
+    /// ```
+    /// # use miniconf::{Tree, TreeKey, Postcard, Packed};
+    /// # use postcard::de_flavors::Slice;
+    /// #[derive(Tree, Default)]
+    /// struct S {
+    ///     foo: u32,
+    ///     #[tree(depth=1)]
+    ///     bar: [u16; 3],
+    /// };
+    /// let mut s = S::default();
+    /// let p = Packed::from_lsb(0b1110.try_into().unwrap());
+    /// let r = s.set_postcard_by_key(p, Slice::new(&[7])).unwrap();
+    /// assert_eq!(s.bar[2], 7);
+    /// assert!(r.is_empty());
+    /// ```
+    fn set_postcard_by_key<K: IntoKeys, F: de_flavors::Flavor<'de>>(
+        &mut self,
+        keys: K,
+        flavor: F,
+    ) -> Result<F::Remainder, Error<postcard::Error>>;
+
+    /// Get and serialize a node value into a [`postcard`] flavor.
+    ///
+    /// ```
+    /// # use miniconf::{Tree, TreeKey, Postcard, Packed};
+    /// # use postcard::ser_flavors::Slice;
+    /// #[derive(Tree, Default)]
+    /// struct S {
+    ///     foo: u32,
+    ///     #[tree(depth=1)]
+    ///     bar: [u16; 3],
+    /// };
+    /// let mut s = S::default();
+    /// s.bar[2] = 7;
+    /// let p = Packed::from_lsb(0b1110.try_into().unwrap());
+    /// let mut buf = [0; 1];
+    /// let o = s.get_postcard_by_key(p, Slice::new(&mut buf[..])).unwrap();
+    /// assert_eq!(o, [7]);
+    /// ```
+    fn get_postcard_by_key<K: IntoKeys, F: ser_flavors::Flavor>(
+        &mut self,
+        keys: K,
+        flavor: F,
+    ) -> Result<F::Output, Error<postcard::Error>>;
+}
+
+impl<'de, T: TreeSerialize<Y> + TreeDeserialize<'de, Y>, const Y: usize> Postcard<'de, Y> for T {
+    #[inline]
+    fn set_postcard_by_key<K: IntoKeys, F: de_flavors::Flavor<'de>>(
+        &mut self,
+        keys: K,
+        flavor: F,
+    ) -> Result<F::Remainder, Error<postcard::Error>> {
+        let mut de = Deserializer::from_flavor(flavor);
+        self.deserialize_by_key(keys.into_keys(), &mut de)?;
+        de.finalize().map_err(Error::Finalization)
+    }
+
+    #[inline]
+    fn get_postcard_by_key<K: IntoKeys, F: ser_flavors::Flavor>(
+        &mut self,
+        keys: K,
+        flavor: F,
+    ) -> Result<F::Output, Error<postcard::Error>> {
+        let mut ser = Serializer { output: flavor };
+        self.serialize_by_key(keys.into_keys(), &mut ser)?;
+        ser.output.finalize().map_err(Error::Finalization)
+    }
+}

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -331,15 +331,6 @@ pub trait TreeKey<const Y: usize = 1> {
     /// ```
     fn name_to_index(name: &str) -> Option<usize>;
 
-    /// The number of paths at this level.
-    ///
-    /// ```
-    /// # use miniconf::TreeKey;
-    /// assert_eq!(<[f32; 5] as TreeKey>::len(), 5);
-    /// assert_eq!(<Option<f32> as TreeKey>::len(), 0);
-    /// ```
-    fn len() -> usize;
-
     /// Call a function for each node on the path described by keys.
     ///
     /// Traversal is aborted once `func` returns an `Err(E)`.
@@ -603,7 +594,7 @@ pub trait TreeKey<const Y: usize = 1> {
     ///     foo: u32,
     ///     bar: [u16; 2],
     /// };
-    /// let packed: Vec<_> = S::iter_packed().map(|p| p.unwrap().0.aligned()).collect();
+    /// let packed: Vec<_> = S::iter_packed().map(|p| p.unwrap().aligned()).collect();
     /// assert_eq!(packed, [0, 1]);
     /// ```
     ///

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -412,17 +412,17 @@ pub trait TreeKey<const Y: usize = 1> {
     /// * `keys`: An `Iterator` of `Key`s identifying the node.
     /// * `path`: A string to write the separators and node names into.
     ///   See also [TreeKey::metadata()] for upper bounds on path length.
-    /// * `sep`: The path hierarchy separator to be inserted before each name.
+    /// * `separator`: The path hierarchy separator to be inserted before each name.
     ///
     /// # Returns
     /// Final node depth on success
-    fn path<K, P>(keys: K, mut path: P, sep: &str) -> Result<usize, Error<core::fmt::Error>>
+    fn path<K, P>(keys: K, mut path: P, separator: &str) -> Result<usize, Error<core::fmt::Error>>
     where
         K: IntoKeys,
         P: Write,
     {
         Self::traverse_by_key(keys.into_keys(), |_index, name, _len| {
-            path.write_str(sep).and_then(|_| path.write_str(name))
+            path.write_str(separator).and_then(|_| path.write_str(name))
         })
     }
 
@@ -529,13 +529,13 @@ pub trait TreeKey<const Y: usize = 1> {
     /// * `P`  - The type to hold the path. Needs to be `core::fmt::Write + Default`
     ///
     /// # Args
-    /// * `sep` - The path hierarchy separator
+    /// * `separator` - The path hierarchy separator
     ///
     /// # Returns
     /// An iterator of paths with a trusted and exact [`Iterator::size_hint()`].
     #[inline]
-    fn iter_paths<P: Write>(sep: &str) -> PathIter<'_, Self, Y, P> {
-        PathIter::new(sep, Some(Self::metadata().count))
+    fn iter_paths<P: Write>(separator: &str) -> PathIter<'_, Self, Y, P> {
+        PathIter::new(separator, Some(Self::metadata().count))
     }
 
     /// Create an unchecked iterator of all possible paths.
@@ -546,13 +546,13 @@ pub trait TreeKey<const Y: usize = 1> {
     /// * `P`  - The type to hold the path. Needs to be `core::fmt::Write + Default`.
     ///
     /// # Args
-    /// * `sep` - The path hierarchy separator
+    /// * `separator` - The path hierarchy separator
     ///
     /// # Returns
     /// A iterator of paths.
     #[inline]
-    fn iter_paths_unchecked<P: Write>(sep: &str) -> PathIter<'_, Self, Y, P> {
-        PathIter::new(sep, None)
+    fn iter_paths_unchecked<P: Write>(separator: &str) -> PathIter<'_, Self, Y, P> {
+        PathIter::new(separator, None)
     }
 
     /// Create an iterator of all possible indices.

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -80,7 +80,7 @@ impl<E: core::fmt::Display> Display for Error<E> {
                 error.fmt(f)
             }
             Error::Finalization(error) => {
-                write!(f, "Deserializer error after deserialization: ")?;
+                write!(f, "(De)serializer finalization error: ")?;
                 error.fmt(f)
             }
             Error::InvalidLeaf(depth, msg) => {

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -506,10 +506,9 @@ pub trait TreeKey<const Y: usize = 1> {
     {
         let mut packed = Packed::default();
         let depth = Self::traverse_by_key(keys.into_keys(), |index, _name, len| {
-            packed
-                .push_lsb(usize::BITS - (len - 1).leading_zeros(), index)
-                .ok_or(())
-                .and(Ok(()))
+            // ensure at least one bit
+            let bits = (usize::BITS - (len - 1).leading_zeros()).max(1);
+            packed.push_lsb(bits, index).ok_or(()).and(Ok(()))
         })?;
         Ok((packed, depth))
     }

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -480,7 +480,7 @@ pub trait TreeKey<const Y: usize = 1> {
     ///     bar: [u16; 5],
     /// };
     /// let (p, _) = S::packed(["bar", "4"]).unwrap();
-    /// assert_eq!(p.as_lsb().get(), 0b11100);
+    /// assert_eq!(p.into_lsb().get(), 0b11100);
     /// let mut s = String::new();
     /// S::path(p, &mut s, "/").unwrap();
     /// assert_eq!(s, "/bar/4");
@@ -595,7 +595,7 @@ pub trait TreeKey<const Y: usize = 1> {
     ///     foo: u32,
     ///     bar: [u16; 2],
     /// };
-    /// let packed: Vec<_> = S::iter_packed().map(|p| p.unwrap().as_lsb().get()).collect();
+    /// let packed: Vec<_> = S::iter_packed().map(|p| p.unwrap().into_lsb().get()).collect();
     /// assert_eq!(packed, [0b10, 0b11]);
     /// ```
     ///

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -452,7 +452,7 @@ pub trait TreeKey<const Y: usize = 1> {
     /// # Args
     /// * `keys`: An `Iterator` of `Key`s identifying the node.
     /// * `indices`: An iterator of `&mut usize` to write the node indices into.
-    ///   If `indices` is shorter than the node depth, [`Error<()>`] is returned
+    ///   If `indices` is shorter than the node depth, [`Error::Inner`] is returned
     ///   See also [TreeKey::metadata()] for upper bounds on depth.
     ///
     /// # Returns

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -488,7 +488,7 @@ pub trait TreeKey<const Y: usize = 1> {
     ///     #[tree(depth=1)]
     ///     bar: [u16; 5],
     /// };
-    /// let p = S::packed(["bar", "4"]).unwrap();
+    /// let (p, _) = S::packed(["bar", "4"]).unwrap();
     /// assert_eq!(p.get(), 0b11001 << (usize::BITS - 5));
     /// let mut s = String::new();
     /// S::path(p, &mut s, "/").unwrap();
@@ -499,19 +499,19 @@ pub trait TreeKey<const Y: usize = 1> {
     /// * `keys`: An `Iterator` of `Key`s identifying the node.
     ///
     /// # Returns
-    /// The packed indices representation on success
-    fn packed<K>(keys: K) -> Result<Packed, Error<()>>
+    /// The packed indices representation on success and the leaf depth.
+    fn packed<K>(keys: K) -> Result<(Packed, usize), Error<()>>
     where
         K: IntoKeys,
     {
         let mut packed = Packed::default();
-        Self::traverse_by_key(keys.into_keys(), |index, _name, len| {
+        let depth = Self::traverse_by_key(keys.into_keys(), |index, _name, len| {
             packed
                 .push_lsb(usize::BITS - (len - 1).leading_zeros(), index)
                 .ok_or(())
                 .and(Ok(()))
         })?;
-        Ok(packed)
+        Ok((packed, depth))
     }
 
     /// Create an iterator of all possible paths.

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -572,7 +572,8 @@ pub trait TreeKey<const Y: usize = 1> {
     ///     foo: u32,
     ///     bar: u16,
     /// };
-    /// assert_eq!(S::iter_indices().next().unwrap(), ([0], 1));
+    /// let indices: Vec<_> = S::iter_indices().collect();
+    /// assert_eq!(indices, [([0], 1), ([1], 1)]);
     /// ```
     ///
     /// # Returns
@@ -594,6 +595,17 @@ pub trait TreeKey<const Y: usize = 1> {
     }
 
     /// Create an iterator of all packed indices.
+    ///
+    /// ```
+    /// # use miniconf::TreeKey;
+    /// #[derive(TreeKey)]
+    /// struct S {
+    ///     foo: u32,
+    ///     bar: [u16; 2],
+    /// };
+    /// let packed: Vec<_> = S::iter_packed().map(|p| p.unwrap().0.aligned()).collect();
+    /// assert_eq!(packed, [0, 1]);
+    /// ```
     ///
     /// # Returns
     /// An iterator of packed indices.

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -1,4 +1,4 @@
-use crate::{IndexIter, IntoKeys, Keys, Packed, PathIter};
+use crate::{IndexIter, IntoKeys, Keys, Packed, PackedIter, PathIter};
 use core::fmt::{Display, Formatter, Write};
 use serde::{Deserializer, Serializer};
 
@@ -518,8 +518,8 @@ pub trait TreeKey<const Y: usize = 1> {
     ///
     /// This is a depth-first walk.
     /// The iterator will walk all paths, including those that may be absent at
-    /// run-time (see [Option]).
-    /// The iterator has an exact and trusted [Iterator::size_hint].
+    /// run-time (see [`TreeKey#option`]).
+    /// The iterator has an exact and trusted [`Iterator::size_hint()`].
     ///
     /// ```
     /// # #[cfg(feature = "std")] {
@@ -544,25 +544,12 @@ pub trait TreeKey<const Y: usize = 1> {
     /// An iterator of paths with a trusted and exact [`Iterator::size_hint()`].
     #[inline]
     fn iter_paths<P: Write>(sep: &str) -> PathIter<'_, Self, Y, P> {
-        PathIter::new(sep)
+        PathIter::new(sep, Some(Self::metadata().count))
     }
 
     /// Create an unchecked iterator of all possible paths.
     ///
-    /// See also [TreeKey::iter_paths].
-    ///
-    /// ```
-    /// # #[cfg(feature = "std")] {
-    /// # use miniconf::TreeKey;
-    /// #[derive(TreeKey)]
-    /// struct S {
-    ///     foo: u32,
-    ///     bar: u16,
-    /// };
-    /// let paths: Vec<String> = S::iter_paths_unchecked("/").map(|p| p.unwrap()).collect();
-    /// assert_eq!(paths, ["/foo", "/bar"]);
-    /// # }
-    /// ```
+    /// See also [`TreeKey::iter_paths`].
     ///
     /// # Generics
     /// * `P`  - The type to hold the path. Needs to be `core::fmt::Write + Default`.
@@ -574,12 +561,10 @@ pub trait TreeKey<const Y: usize = 1> {
     /// A iterator of paths.
     #[inline]
     fn iter_paths_unchecked<P: Write>(sep: &str) -> PathIter<'_, Self, Y, P> {
-        PathIter::new_unchecked(sep)
+        PathIter::new(sep, None)
     }
 
     /// Create an iterator of all possible indices.
-    ///
-    /// See also [TreeKey::iter_paths].
     ///
     /// ```
     /// # use miniconf::TreeKey;
@@ -595,28 +580,38 @@ pub trait TreeKey<const Y: usize = 1> {
     /// An iterator of indices with a trusted and exact [`Iterator::size_hint()`].
     #[inline]
     fn iter_indices() -> IndexIter<Self, Y> {
-        IndexIter::new()
+        IndexIter::new(Some(Self::metadata().count))
     }
 
     /// Create an unchecked iterator of all possible indices.
     ///
-    /// See also [TreeKey::iter_indices].
-    ///
-    /// ```
-    /// # use miniconf::TreeKey;
-    /// #[derive(TreeKey)]
-    /// struct S {
-    ///     foo: u32,
-    ///     bar: u16,
-    /// };
-    /// assert_eq!(S::iter_indices_unchecked().next().unwrap(), ([0], 1));
-    /// ```
+    /// See also [`TreeKey::iter_indices()`].
     ///
     /// # Returns
     /// An iterator of indices.
     #[inline]
     fn iter_indices_unchecked() -> IndexIter<Self, Y> {
-        IndexIter::new_unchecked()
+        IndexIter::new(None)
+    }
+
+    /// Create an iterator of all packed indices.
+    ///
+    /// # Returns
+    /// An iterator of packed indices.
+    #[inline]
+    fn iter_packed() -> PackedIter<Self, Y> {
+        PackedIter::new(Some(Self::metadata().count))
+    }
+
+    /// Create an iterator of all packed indices.
+    ///
+    /// See also [`TreeKey::iter_packed()`].
+    ///
+    /// # Returns
+    /// An iterator of packed indices.
+    #[inline]
+    fn iter_packed_unchecked() -> PackedIter<Self, Y> {
+        PackedIter::new(None)
     }
 }
 

--- a/miniconf/tests/basic.rs
+++ b/miniconf/tests/basic.rs
@@ -58,7 +58,7 @@ fn indices() {
 fn traverse_empty() {
     #[derive(Tree, Default)]
     struct S {}
-    let f = |_, _: &_| unreachable!();
+    let f = |_, _: &_, _| unreachable!();
     assert_eq!(
         S::traverse_by_key([0].into_iter(), f),
         Err(Error::<()>::NotFound(1))

--- a/miniconf/tests/index.rs
+++ b/miniconf/tests/index.rs
@@ -23,51 +23,48 @@ struct Settings {
 #[test]
 fn atomic() {
     let mut s = Settings::default();
-    s.set_json_by_index(&[0], b"[1,2]").unwrap();
+    s.set_json_by_key([0], b"[1,2]").unwrap();
     assert_eq!(s.a, [1, 2]);
 }
 
 #[test]
 fn defer() {
     let mut s = Settings::default();
-    s.set_json_by_index(&[1, 1], b"99").unwrap();
+    s.set_json_by_key([1, 1], b"99").unwrap();
     assert_eq!(s.d, [0, 99]);
 }
 
 #[test]
 fn defer_miniconf() {
     let mut s = Settings::default();
-    s.set_json_by_index(&[3, 0, 0], b"1").unwrap();
+    s.set_json_by_key([3, 0, 0], b"1").unwrap();
     assert_eq!(s.am[0].c, 1);
-    s.set_json_by_index(&[4, 0, 0, 0], b"3").unwrap();
+    s.set_json_by_key([4, 0, 0, 0], b"3").unwrap();
     assert_eq!(s.aam[0][0].c, 3);
 }
 
 #[test]
 fn too_short() {
     let mut s = Settings::default();
-    assert_eq!(
-        s.set_json_by_index(&[1], b"[1,2,3]"),
-        Err(Error::TooShort(1))
-    );
+    assert_eq!(s.set_json_by_key([1], b"[1,2,3]"), Err(Error::TooShort(1)));
 }
 
 #[test]
 fn too_long() {
     assert_eq!(
-        Settings::default().set_json_by_index(&[0, 1], b"7"),
+        Settings::default().set_json_by_key([0, 1], b"7"),
         Err(Error::TooLong(1))
     );
     assert_eq!(
-        Settings::default().set_json_by_index(&[1, 0, 2], b"7"),
+        Settings::default().set_json_by_key([1, 0, 2], b"7"),
         Err(Error::TooLong(2))
     );
     assert_eq!(
-        Settings::default().set_json_by_index(&[2, 0, 0], b"7"),
+        Settings::default().set_json_by_key([2, 0, 0], b"7"),
         Err(Error::TooLong(2))
     );
     assert_eq!(
-        Settings::default().set_json_by_index(&[2, 0, 1], b"7"),
+        Settings::default().set_json_by_key([2, 0, 1], b"7"),
         Err(Error::TooLong(2))
     );
 }
@@ -75,31 +72,31 @@ fn too_long() {
 #[test]
 fn not_found() {
     assert_eq!(
-        Settings::default().set_json_by_index(&[1, 3], b"7"),
+        Settings::default().set_json_by_key([1, 3], b"7"),
         Err(Error::NotFound(2))
     );
     assert_eq!(
-        Settings::default().set_json_by_index(&[5], b"7"),
+        Settings::default().set_json_by_key([5], b"7"),
         Err(Error::NotFound(1))
     );
     assert_eq!(
-        Settings::default().set_json_by_index(&[4, 0, 0, 1], b"7"),
+        Settings::default().set_json_by_key([4, 0, 0, 1], b"7"),
         Err(Error::NotFound(4))
     );
 }
 
 #[test]
 fn empty() {
-    assert!([0u32; 0].set_json_by_index(&[], b"").is_err());
+    assert!([0u32; 0].set_json_by_key([0usize; 0], b"").is_err());
 
     #[derive(Tree, Serialize, Deserialize, Copy, Clone, Default)]
     struct S {}
 
     let mut s = [S::default(); 0];
-    assert!(JsonCoreSlash::<1>::set_json_by_index(&mut s, &[], b"").is_err());
+    assert!(JsonCoreSlash::<1>::set_json_by_key(&mut s, [0usize; 0], b"1").is_err());
 
     let mut s = [[S::default(); 0]; 0];
-    assert!(JsonCoreSlash::<1>::set_json_by_index(&mut s, &[], b"").is_err());
+    assert!(JsonCoreSlash::<1>::set_json_by_key(&mut s, [0usize; 0], b"1").is_err());
 
     #[derive(Tree, Default)]
     struct Q {
@@ -108,5 +105,5 @@ fn empty() {
         #[tree(depth = 1)]
         b: [S; 0],
     }
-    assert!(Q::default().set_json_by_index(&[], b"").is_err());
+    assert!(Q::default().set_json_by_key([0usize; 0], b"").is_err());
 }

--- a/miniconf/tests/option.rs
+++ b/miniconf/tests/option.rs
@@ -152,7 +152,7 @@ fn option_absent() {
     assert_eq!(s.set_json("/d", b" 7"), Ok(2));
     assert!(matches!(
         s.set_json("/d", b"7i"),
-        Err(Error::PostDeserialization(_))
+        Err(Error::Finalization(_))
     ));
 }
 

--- a/miniconf/tests/packed.rs
+++ b/miniconf/tests/packed.rs
@@ -1,4 +1,6 @@
-use miniconf::{Error, Packed, Tree, TreeKey};
+#![cfg(feature = "json-core")]
+
+use miniconf::{Error, Packed, Tree, TreeKey, TreeSerialize};
 
 #[derive(Tree, Default)]
 struct Settings {
@@ -37,4 +39,33 @@ fn packed() {
     );
     assert_eq!(p, "/a");
     p.clear();
+}
+
+#[test]
+fn zero_key() {
+    let mut a = [[0]];
+    let mut b = [[0, 0], [0, 0]];
+    let mut buf = [0u8; 100];
+    let mut ser = serde_json_core::ser::Serializer::new(&mut buf);
+    for (n, e) in [Err(Error::TooShort(0)), Err(Error::TooShort(1)), Ok(2)]
+        .iter()
+        .enumerate()
+    {
+        assert_eq!(
+            TreeSerialize::<2>::serialize_by_key(
+                &mut a,
+                Packed::new(0b1 << (usize::BITS - 1 - n as u32)).unwrap(),
+                &mut ser
+            ),
+            *e
+        );
+        assert_eq!(
+            TreeSerialize::<2>::serialize_by_key(
+                &mut b,
+                Packed::new(0b1 << (usize::BITS - 1 - n as u32)).unwrap(),
+                &mut ser
+            ),
+            *e
+        );
+    }
 }

--- a/miniconf/tests/packed.rs
+++ b/miniconf/tests/packed.rs
@@ -24,6 +24,12 @@ fn packed() {
         assert_eq!(p, q);
         p.clear();
     }
+    println!(
+        "{:?}",
+        Settings::iter_packed()
+            .map(Result::unwrap)
+            .collect::<Vec<_>>()
+    );
 
     assert_eq!(
         Settings::path(Packed::new(0b01 << 29).unwrap(), &mut p, "/"),

--- a/miniconf/tests/packed.rs
+++ b/miniconf/tests/packed.rs
@@ -13,12 +13,14 @@ struct Settings {
 fn packed() {
     let mut path = String::new();
 
+    // Check empty being too short
     assert_eq!(
-        Settings::path(Packed::default(), &mut path, "/"),
+        Settings::path(Packed::EMPTY, &mut path, "/"),
         Err(Error::TooShort(0))
     );
     path.clear();
 
+    // Check path-packed round trip.
     for iter_path in Settings::iter_paths::<String>("/").map(Result::unwrap) {
         let (packed, _depth) = Settings::packed(iter_path.split("/").skip(1)).unwrap();
         Settings::path(packed, &mut path, "/").unwrap();
@@ -43,6 +45,8 @@ fn packed() {
 
 #[test]
 fn zero_key() {
+    // Check the corner case of a len=1 index where (len - 1) = 0 and zero bits would be required to encode.
+    // Hence the Packed values for len=1 and len=2 are the same.
     let mut a11 = [[0]];
     let mut a22 = [[0, 0], [0, 0]];
     let mut buf = [0u8; 100];

--- a/miniconf/tests/packed.rs
+++ b/miniconf/tests/packed.rs
@@ -1,0 +1,42 @@
+use miniconf::{Error, IntoKeys, Packed, Tree, TreeKey};
+
+#[derive(Tree, Default)]
+struct Settings {
+    a: f32,
+    #[tree(depth = 1)]
+    b: [f32; 2],
+}
+
+#[test]
+fn packed() {
+    let mut p = String::new();
+
+    assert_eq!(
+        Settings::path(Packed::default(), &mut p, "/"),
+        Err(Error::TooShort(0))
+    );
+    p.clear();
+
+    assert_eq!(
+        Settings::path(Packed::new(0b10).unwrap(), &mut p, "/"),
+        Ok(1)
+    );
+    assert_eq!(p, "/a");
+    p.clear();
+
+    assert_eq!(
+        Settings::path(Packed::new(0b111).unwrap(), &mut p, "/"),
+        Ok(2)
+    );
+    assert_eq!(p, "/b/1");
+
+    assert_eq!(Settings::packed(["a"]), Ok(Packed::new(0b10).unwrap()));
+    assert_eq!(
+        Settings::packed(["b", "0"]),
+        Ok(Packed::new(0b110).unwrap())
+    );
+    assert_eq!(
+        Settings::packed(["b", "1"]),
+        Ok(Packed::new(0b111).unwrap())
+    );
+}

--- a/miniconf/tests/packed.rs
+++ b/miniconf/tests/packed.rs
@@ -1,4 +1,4 @@
-use miniconf::{Error, IntoKeys, Packed, Tree, TreeKey};
+use miniconf::{Error, Packed, Tree, TreeKey};
 
 #[derive(Tree, Default)]
 struct Settings {
@@ -17,26 +17,18 @@ fn packed() {
     );
     p.clear();
 
+    for q in Settings::iter_paths::<String>("/") {
+        let q = q.unwrap();
+        let a = Settings::packed(q.split("/").skip(1)).unwrap();
+        Settings::path(a, &mut p, "/").unwrap();
+        assert_eq!(p, q);
+        p.clear();
+    }
+
     assert_eq!(
-        Settings::path(Packed::new(0b10).unwrap(), &mut p, "/"),
+        Settings::path(Packed::new(0b01 << 29).unwrap(), &mut p, "/"),
         Ok(1)
     );
     assert_eq!(p, "/a");
     p.clear();
-
-    assert_eq!(
-        Settings::path(Packed::new(0b111).unwrap(), &mut p, "/"),
-        Ok(2)
-    );
-    assert_eq!(p, "/b/1");
-
-    assert_eq!(Settings::packed(["a"]), Ok(Packed::new(0b10).unwrap()));
-    assert_eq!(
-        Settings::packed(["b", "0"]),
-        Ok(Packed::new(0b110).unwrap())
-    );
-    assert_eq!(
-        Settings::packed(["b", "1"]),
-        Ok(Packed::new(0b111).unwrap())
-    );
 }

--- a/miniconf/tests/packed.rs
+++ b/miniconf/tests/packed.rs
@@ -19,7 +19,7 @@ fn packed() {
 
     for q in Settings::iter_paths::<String>("/") {
         let q = q.unwrap();
-        let a = Settings::packed(q.split("/").skip(1)).unwrap();
+        let (a, _d) = Settings::packed(q.split("/").skip(1)).unwrap();
         Settings::path(a, &mut p, "/").unwrap();
         assert_eq!(p, q);
         p.clear();

--- a/miniconf/tests/packed.rs
+++ b/miniconf/tests/packed.rs
@@ -54,7 +54,7 @@ fn zero_key() {
         assert_eq!(
             TreeSerialize::<2>::serialize_by_key(
                 &mut a,
-                Packed::new(0b1 << (usize::BITS - 1 - n as u32)).unwrap(),
+                Packed::from_lsb((0b1 << n).try_into().unwrap()),
                 &mut ser
             ),
             *e
@@ -62,7 +62,7 @@ fn zero_key() {
         assert_eq!(
             TreeSerialize::<2>::serialize_by_key(
                 &mut b,
-                Packed::new(0b1 << (usize::BITS - 1 - n as u32)).unwrap(),
+                Packed::from_lsb((0b1 << n).try_into().unwrap()),
                 &mut ser
             ),
             *e

--- a/miniconf/tests/validate.rs
+++ b/miniconf/tests/validate.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "json-core")]
 use miniconf::{Error, JsonCoreSlash, Tree};
 
 #[derive(Tree, Default)]

--- a/miniconf_derive/Cargo.toml
+++ b/miniconf_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miniconf_derive"
 version = "0.9.0"
-rust-version = "1.67.0"
+rust-version = "1.70.0"
 authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@vertigo-designs.com", "Robert Jördens <rj@quartiq.de>"]
 edition = "2021"
 license = "MIT"

--- a/miniconf_derive/Cargo.toml
+++ b/miniconf_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miniconf_derive"
 version = "0.9.0"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@vertigo-designs.com", "Robert Jördens <rj@quartiq.de>"]
 edition = "2021"
 license = "MIT"

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -152,8 +152,7 @@ pub fn derive_tree_serialize(input: TokenStream) -> TokenStream {
                     .ok_or(::miniconf::Error::NotFound(1))?;
                 let defer = Self::__MINICONF_DEFERS.get(index)
                     .ok_or(::miniconf::Error::NotFound(1))?;
-                // ensure no non-trivial key is left
-                if !defer && ::miniconf::Keys::next(&mut keys, 1).is_some() {
+                if !defer && ::miniconf::Keys::next(&mut keys, 0).is_some() {
                     return Err(::miniconf::Error::TooLong(1))
                 }
                 // Note(unreachable) empty structs have diverged by now
@@ -224,8 +223,7 @@ pub fn derive_tree_deserialize(input: TokenStream) -> TokenStream {
                     .ok_or(::miniconf::Error::NotFound(1))?;
                 let defer = Self::__MINICONF_DEFERS.get(index)
                     .ok_or(::miniconf::Error::NotFound(1))?;
-                // ensure no non-trivial key is left
-                if !defer && ::miniconf::Keys::next(&mut keys, 1).is_some() {
+                if !defer && ::miniconf::Keys::next(&mut keys, 0).is_some() {
                     return Err(::miniconf::Error::TooLong(1))
                 }
                 // Note(unreachable) empty structs have diverged by now

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -65,7 +65,7 @@ pub fn derive_tree_key(input: TokenStream) -> TokenStream {
                 K: ::miniconf::Keys,
                 F: FnMut(usize, &str, usize) -> Result<(), E>,
             {
-                let index = ::miniconf::Keys::lookup::<#depth, Self, E>(&mut keys, #fields_len)?;
+                let index = ::miniconf::Keys::lookup::<#depth, Self, _>(&mut keys, #fields_len)?;
                 let name = Self::__MINICONF_NAMES.get(index)
                     .ok_or(::miniconf::Error::NotFound(1))?;
                 func(index, name, #fields_len)?;
@@ -143,7 +143,7 @@ pub fn derive_tree_serialize(input: TokenStream) -> TokenStream {
                 K: ::miniconf::Keys,
                 S: ::miniconf::Serializer,
             {
-                let index = ::miniconf::Keys::lookup::<#depth, Self, S::Error>(&mut keys, #fields_len)?;
+                let index = ::miniconf::Keys::lookup::<#depth, Self, _>(&mut keys, #fields_len)?;
                 let defer = Self::__MINICONF_DEFERS.get(index)
                     .ok_or(::miniconf::Error::NotFound(1))?;
                 if !defer && !::miniconf::Keys::is_empty(&mut keys) {
@@ -211,7 +211,7 @@ pub fn derive_tree_deserialize(input: TokenStream) -> TokenStream {
                 K: ::miniconf::Keys,
                 D: ::miniconf::Deserializer<'de>,
             {
-                let index = ::miniconf::Keys::lookup::<#depth, Self, D::Error>(&mut keys, #fields_len)?;
+                let index = ::miniconf::Keys::lookup::<#depth, Self, _>(&mut keys, #fields_len)?;
                 let defer = Self::__MINICONF_DEFERS.get(index)
                     .ok_or(::miniconf::Error::NotFound(1))?;
                 if !defer && !::miniconf::Keys::is_empty(&mut keys) {

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -57,10 +57,6 @@ pub fn derive_tree_key(input: TokenStream) -> TokenStream {
                 Self::__MINICONF_NAMES.iter().position(|&n| n == value)
             }
 
-            fn len() -> usize {
-                #fields_len
-            }
-
             fn traverse_by_key<K, F, E>(
                 mut keys: K,
                 mut func: F,

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -69,7 +69,7 @@ pub fn derive_tree_key(input: TokenStream) -> TokenStream {
                 K: ::miniconf::Keys,
                 F: FnMut(usize, &str, usize) -> Result<(), E>,
             {
-                let key = ::miniconf::Keys::next::<#depth, Self>(&mut keys)
+                let key = ::miniconf::Keys::next(&mut keys, #fields_len)
                     .ok_or(::miniconf::Error::TooShort(0))?;
                 let index = ::miniconf::Key::find::<#depth, Self>(&key)
                     .ok_or(::miniconf::Error::NotFound(1))?;
@@ -139,6 +139,7 @@ pub fn derive_tree_serialize(input: TokenStream) -> TokenStream {
         .map(|(i, field)| field.serialize_by_key(i));
     let depth = tree.depth();
     let ident = input.ident;
+    let fields_len = tree.fields().len();
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
@@ -149,13 +150,13 @@ pub fn derive_tree_serialize(input: TokenStream) -> TokenStream {
                 K: ::miniconf::Keys,
                 S: ::miniconf::Serializer,
             {
-                let key = ::miniconf::Keys::next::<#depth, Self>(&mut keys)
+                let key = ::miniconf::Keys::next(&mut keys, #fields_len)
                     .ok_or(::miniconf::Error::TooShort(0))?;
                 let index = ::miniconf::Key::find::<#depth, Self>(&key)
                     .ok_or(::miniconf::Error::NotFound(1))?;
                 let defer = Self::__MINICONF_DEFERS.get(index)
                     .ok_or(::miniconf::Error::NotFound(1))?;
-                if !defer && ::miniconf::Keys::next::<#depth, Self>(&mut keys).is_some() {
+                if !defer && ::miniconf::Keys::next(&mut keys, #fields_len).is_some() {
                     return Err(::miniconf::Error::TooLong(1))
                 }
                 // Note(unreachable) empty structs have diverged by now
@@ -198,6 +199,7 @@ pub fn derive_tree_deserialize(input: TokenStream) -> TokenStream {
         .map(|(i, field)| field.deserialize_by_key(i));
     let depth = tree.depth();
     let ident = input.ident;
+    let fields_len = tree.fields().len();
 
     let orig_generics = input.generics.clone();
     let (_, ty_generics, where_clause) = orig_generics.split_for_impl();
@@ -219,13 +221,13 @@ pub fn derive_tree_deserialize(input: TokenStream) -> TokenStream {
                 K: ::miniconf::Keys,
                 D: ::miniconf::Deserializer<'de>,
             {
-                let key = ::miniconf::Keys::next::<#depth, Self>(&mut keys)
+                let key = ::miniconf::Keys::next(&mut keys, #fields_len)
                     .ok_or(::miniconf::Error::TooShort(0))?;
                 let index = ::miniconf::Key::find::<#depth, Self>(&key)
                     .ok_or(::miniconf::Error::NotFound(1))?;
                 let defer = Self::__MINICONF_DEFERS.get(index)
                     .ok_or(::miniconf::Error::NotFound(1))?;
-                if !defer && ::miniconf::Keys::next::<#depth, Self>(&mut keys).is_some() {
+                if !defer && ::miniconf::Keys::next(&mut keys, #fields_len).is_some() {
                     return Err(::miniconf::Error::TooLong(1))
                 }
                 // Note(unreachable) empty structs have diverged by now

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -65,10 +65,7 @@ pub fn derive_tree_key(input: TokenStream) -> TokenStream {
                 K: ::miniconf::Keys,
                 F: FnMut(usize, &str, usize) -> Result<(), E>,
             {
-                let key = ::miniconf::Keys::next(&mut keys, #fields_len)
-                    .ok_or(::miniconf::Error::TooShort(0))?;
-                let index = ::miniconf::Key::find::<#depth, Self>(&key)
-                    .ok_or(::miniconf::Error::NotFound(1))?;
+                let index = ::miniconf::Keys::lookup::<#depth, Self, E>(&mut keys, #fields_len)?;
                 let name = Self::__MINICONF_NAMES.get(index)
                     .ok_or(::miniconf::Error::NotFound(1))?;
                 func(index, name, #fields_len)?;
@@ -146,13 +143,10 @@ pub fn derive_tree_serialize(input: TokenStream) -> TokenStream {
                 K: ::miniconf::Keys,
                 S: ::miniconf::Serializer,
             {
-                let key = ::miniconf::Keys::next(&mut keys, #fields_len)
-                    .ok_or(::miniconf::Error::TooShort(0))?;
-                let index = ::miniconf::Key::find::<#depth, Self>(&key)
-                    .ok_or(::miniconf::Error::NotFound(1))?;
+                let index = ::miniconf::Keys::lookup::<#depth, Self, S::Error>(&mut keys, #fields_len)?;
                 let defer = Self::__MINICONF_DEFERS.get(index)
                     .ok_or(::miniconf::Error::NotFound(1))?;
-                if !defer && ::miniconf::Keys::next(&mut keys, 0).is_some() {
+                if !defer && !::miniconf::Keys::is_empty(&mut keys) {
                     return Err(::miniconf::Error::TooLong(1))
                 }
                 // Note(unreachable) empty structs have diverged by now
@@ -217,13 +211,10 @@ pub fn derive_tree_deserialize(input: TokenStream) -> TokenStream {
                 K: ::miniconf::Keys,
                 D: ::miniconf::Deserializer<'de>,
             {
-                let key = ::miniconf::Keys::next(&mut keys, #fields_len)
-                    .ok_or(::miniconf::Error::TooShort(0))?;
-                let index = ::miniconf::Key::find::<#depth, Self>(&key)
-                    .ok_or(::miniconf::Error::NotFound(1))?;
+                let index = ::miniconf::Keys::lookup::<#depth, Self, D::Error>(&mut keys, #fields_len)?;
                 let defer = Self::__MINICONF_DEFERS.get(index)
                     .ok_or(::miniconf::Error::NotFound(1))?;
-                if !defer && ::miniconf::Keys::next(&mut keys, 0).is_some() {
+                if !defer && !::miniconf::Keys::is_empty(&mut keys) {
                     return Err(::miniconf::Error::TooLong(1))
                 }
                 // Note(unreachable) empty structs have diverged by now

--- a/miniconf_derive/src/lib.rs
+++ b/miniconf_derive/src/lib.rs
@@ -156,7 +156,8 @@ pub fn derive_tree_serialize(input: TokenStream) -> TokenStream {
                     .ok_or(::miniconf::Error::NotFound(1))?;
                 let defer = Self::__MINICONF_DEFERS.get(index)
                     .ok_or(::miniconf::Error::NotFound(1))?;
-                if !defer && ::miniconf::Keys::next(&mut keys, #fields_len).is_some() {
+                // ensure no non-trivial key is left
+                if !defer && ::miniconf::Keys::next(&mut keys, 1).is_some() {
                     return Err(::miniconf::Error::TooLong(1))
                 }
                 // Note(unreachable) empty structs have diverged by now
@@ -227,7 +228,8 @@ pub fn derive_tree_deserialize(input: TokenStream) -> TokenStream {
                     .ok_or(::miniconf::Error::NotFound(1))?;
                 let defer = Self::__MINICONF_DEFERS.get(index)
                     .ok_or(::miniconf::Error::NotFound(1))?;
-                if !defer && ::miniconf::Keys::next(&mut keys, #fields_len).is_some() {
+                // ensure no non-trivial key is left
+                if !defer && ::miniconf::Keys::next(&mut keys, 1).is_some() {
                     return Err(::miniconf::Error::TooLong(1))
                 }
                 // Note(unreachable) empty structs have diverged by now

--- a/miniconf_mqtt/Cargo.toml
+++ b/miniconf_mqtt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miniconf_mqtt"
 version = "0.9.0"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@vertigo-designs.com", "Robert Jördens <rj@quartiq.de>"]
 edition = "2021"
 license = "MIT"

--- a/miniconf_mqtt/Cargo.toml
+++ b/miniconf_mqtt/Cargo.toml
@@ -17,7 +17,7 @@ std = []
 [lib]
 
 [dependencies]
-miniconf = { version = "0.9", path = "../miniconf" }
+miniconf = { version = "0.9", features = ["json-core"], path = "../miniconf" }
 minimq = "0.8.0"
 smlang = "0.6"
 embedded-io = "0.6"

--- a/miniconf_mqtt/Cargo.toml
+++ b/miniconf_mqtt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miniconf_mqtt"
 version = "0.9.0"
-rust-version = "1.67.0"
+rust-version = "1.70.0"
 authors = ["James Irwin <irwineffect@gmail.com>", "Ryan Summers <ryan.summers@vertigo-designs.com", "Robert Jördens <rj@quartiq.de>"]
 edition = "2021"
 license = "MIT"

--- a/miniconf_mqtt/tests/integration_test.rs
+++ b/miniconf_mqtt/tests/integration_test.rs
@@ -102,7 +102,7 @@ fn main() -> std::io::Result<()> {
 
     // We will wait 100ms in between each state to allow the MQTT broker to catch up
     let mut state = TestState::started();
-    let mut timer = Timer::new(std::time::Duration::from_millis(1000));
+    let mut timer = Timer::new(std::time::Duration::from_millis(100));
 
     let mut settings = Settings::default();
 

--- a/miniconf_mqtt/tests/integration_test.rs
+++ b/miniconf_mqtt/tests/integration_test.rs
@@ -102,7 +102,7 @@ fn main() -> std::io::Result<()> {
 
     // We will wait 100ms in between each state to allow the MQTT broker to catch up
     let mut state = TestState::started();
-    let mut timer = Timer::new(std::time::Duration::from_millis(200));
+    let mut timer = Timer::new(std::time::Duration::from_millis(1000));
 
     let mut settings = Settings::default();
 

--- a/miniconf_mqtt/tests/republish.rs
+++ b/miniconf_mqtt/tests/republish.rs
@@ -46,7 +46,8 @@ async fn verify_settings() {
         ("republish/device/settings/more/inner".to_string(), 0),
     ]);
 
-    for _ in 0..300 { // 3 seconds
+    for _ in 0..300 {
+        // 3 seconds
         mqtt.poll(|_, topic, value, _properties| {
             log::info!("{}: {:?}", &topic, value);
             let element = received_settings.get_mut(&topic.to_string()).unwrap();

--- a/miniconf_mqtt/tests/validation_failure.rs
+++ b/miniconf_mqtt/tests/validation_failure.rs
@@ -42,7 +42,7 @@ async fn client_task() {
     while !mqtt.client().is_connected() {
         mqtt.poll(|_client, _topic, _message, _properties| {})
             .unwrap();
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
     }
 
     let topic_filter = minimq::types::TopicFilter::new(RESPONSE_TOPIC);


### PR DESCRIPTION
Four big things and some smaller tweaks in one PR (sorry @ryan-summers)

* The `Packed` keys implementation for very compact node keys
* Revamped the `Keys`/`Iterator<Item=Key>` stuff
* Added `postcard` support, which leads to very small key-value access with `Packed` keys
* Revamped the `Iterator` architecture a bit to reduce code duplication, especially in the high-complexity area

Changes:

- add packed keys
- packed tweaks
- rewrite packed
- split key, packed, rework packed
- introduce generic iterator
- port PathIter
- port IndexIter to generic iter
- add PackedIter
- make generic iter non-generic over treekey
- simplify iter creation
- Keys::next: don't be generic
- packed corner cases
- packed: aligned, docs
- rm len(), simplify iter, docs/changelog
- expand packed
- tweaks
- deref for Packed
- tweak packed
- changelog
- refactor JsonCoreSlash impl
- fix miniconf_mqtt dependency
- postcard: add blanket implementation
- add comment about ExactSizeIterator
