### PR TITLE
`KeyLookup` trait -> struct, `metadata()` -> `traverse_all::<W: Walk>()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/quartiq/miniconf/compare/v0.15.0...HEAD) - DATE
+
+### Changed
+
+* `KeyLookup::name_to_index()` has been removed in favor of exposing the names as `NAMES: Option<&[&str]>`.
+
 ## [0.15.0](https://github.com/quartiq/miniconf/compare/v0.14.1...v0.15.0) - 2024-10-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * `KeyLookup::name_to_index()` has been removed in favor of exposing the names as `NAMES: Option<&[&str]>`.
+* `TreeKey::metadata() -> Metadata` has been changed to `walk<W: Walk>() -> W` with `impl Walk for Metadata`.
 
 ## [0.15.0](https://github.com/quartiq/miniconf/compare/v0.14.1...v0.15.0) - 2024-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* `KeyLookup::name_to_index()` has been removed in favor of exposing the names as `NAMES: Option<&[&str]>`.
+* `KeyLookup` has been changed from a trait to a struct.
 * `TreeKey::metadata() -> Metadata` has been changed to `walk<W: Walk>() -> W` with `impl Walk for Metadata`.
 
 ## [0.15.0](https://github.com/quartiq/miniconf/compare/v0.14.1...v0.15.0) - 2024-10-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * `KeyLookup` has been changed from a trait to a struct.
-* `TreeKey::metadata() -> Metadata` has been changed to `walk<W: Walk>() -> W` with `impl Walk for Metadata`.
+* `TreeKey::metadata() -> Metadata` has been changed to `traverse_all<W: Walk>() -> W` with `impl Walk for Metadata`.
 
 ## [0.15.0](https://github.com/quartiq/miniconf/compare/v0.14.1...v0.15.0) - 2024-10-01
 

--- a/miniconf/Cargo.toml
+++ b/miniconf/Cargo.toml
@@ -93,3 +93,7 @@ required-features = ["json-core", "derive"]
 [[example]]
 name = "menu"
 required-features = ["json-core", "derive", "postcard"]
+
+[[example]]
+name = "scpi"
+required-features = ["json-core", "derive"]

--- a/miniconf/README.md
+++ b/miniconf/README.md
@@ -80,9 +80,9 @@ json::set(&mut settings, "/array_tree/0", b"7")?;
 // ... or by index and then struct field name
 json::set(&mut settings, "/array_tree2/0/a", b"11")?;
 // ... or by hierarchical index
-json::set_by_key(&mut settings, [7, 0, 1], b"8")?;
+json::set_by_key(&mut settings, [7usize, 0, 1], b"8")?;
 // ... or by packed index
-let (packed, node) = Settings::transcode::<Packed, _>([7, 1, 0]).unwrap();
+let (packed, node) = Settings::transcode::<Packed, _>([7usize, 1, 0]).unwrap();
 assert_eq!(packed.into_lsb().get(), 0b1_0111_1_0);
 assert_eq!(node, Node::leaf(3));
 json::set_by_key(&mut settings, packed, b"9")?;

--- a/miniconf/examples/scpi.rs
+++ b/miniconf/examples/scpi.rs
@@ -1,12 +1,21 @@
 use core::str;
 
 use miniconf::{
-    json, IntoKeys, Key, KeyLookup, KeysIter, PathIter, TreeDeserializeOwned, TreeSerialize,
+    json, IntoKeys, Key, KeyLookup, Keys, PathIter, TreeDeserializeOwned, TreeSerialize,
 };
 
 mod common;
 use common::Settings;
 
+/// This show-cases the implementation of a custom [`miniconf::Key`]
+/// alogn the lines of SCPI style hierarchies.
+/// It then proceeds to implement a SCPI command parser that supports
+/// setting and getting, case-insensitive, and distinguishes relative/absolute
+/// paths.
+///
+/// This is just a sketch. There is no error handling.
+
+#[derive(Copy, Clone)]
 struct ScpiKey<T: ?Sized>(T);
 
 impl<T: AsRef<str> + ?Sized> Key for ScpiKey<T> {
@@ -14,7 +23,8 @@ impl<T: AsRef<str> + ?Sized> Key for ScpiKey<T> {
         let s = self.0.as_ref();
         match lookup.names {
             Some(names) => {
-                let mut idx = [None; 2];
+                let mut truncated = None;
+                let mut ambiguous = false;
                 for (i, name) in names.iter().enumerate() {
                     if name.len() < s.len() {
                         continue;
@@ -25,20 +35,22 @@ impl<T: AsRef<str> + ?Sized> Key for ScpiKey<T> {
                         .all(|(n, s)| n.to_ascii_lowercase() == s.to_ascii_lowercase())
                     {
                         if name.len() == s.len() {
+                            // Exact match: return immediately
                             return Some(i);
                         }
-                        if idx[1].is_some() {
-                        } else if idx[0].is_some() {
-                            idx[1] = Some(i);
+                        if truncated.is_some() {
+                            // Multiple truncated matches: ambiguous if there isn't an additional exact match
+                            ambiguous = true;
                         } else {
-                            idx[0] = Some(i);
+                            // First truncated match: fine if there is only one.
+                            truncated = Some(i);
                         }
                     }
                 }
-                if idx[1].is_some() {
+                if ambiguous {
                     None
                 } else {
-                    idx[0]
+                    truncated
                 }
             }
             None => s.parse().ok(),
@@ -46,6 +58,7 @@ impl<T: AsRef<str> + ?Sized> Key for ScpiKey<T> {
     }
 }
 
+#[derive(Clone)]
 struct ScpiPathIter<'a>(PathIter<'a, ':'>);
 
 impl<'a> Iterator for ScpiPathIter<'a> {
@@ -55,12 +68,14 @@ impl<'a> Iterator for ScpiPathIter<'a> {
     }
 }
 
-struct ScpiPath<T: ?Sized>(T);
+#[derive(Copy, Clone)]
+struct ScpiPath<'a>(Option<&'a str>);
 
-impl<'a, T: AsRef<str> + ?Sized> IntoKeys for &'a ScpiPath<T> {
-    type IntoKeys = KeysIter<ScpiPathIter<'a>>;
-    fn into_keys(self) -> Self::IntoKeys {
-        ScpiPathIter(PathIter::new(self.0.as_ref())).into_keys()
+impl<'a> IntoIterator for &'a ScpiPath<'a> {
+    type IntoIter = ScpiPathIter<'a>;
+    type Item = ScpiKey<&'a str>;
+    fn into_iter(self) -> Self::IntoIter {
+        ScpiPathIter(PathIter::new(self.0))
     }
 }
 
@@ -77,15 +92,48 @@ impl<M: TreeSerialize<Y> + TreeDeserializeOwned<Y>, const Y: usize> ScpiCtrl<M, 
         }
     }
 
-    fn get(&mut self, path: &str) -> &str {
-        let path = ScpiPath(path);
-        let len = json::get_by_key(&self.settings, &path, &mut self.buf[..]).unwrap();
+    fn get(&mut self, path: impl IntoKeys) -> &str {
+        let len = json::get_by_key(&self.settings, path, &mut self.buf[..]).unwrap();
         str::from_utf8(&self.buf[..len]).unwrap()
     }
 
-    fn set(&mut self, path: &str, value: &str) {
-        let path = ScpiPath(path);
-        json::set_by_key(&mut self.settings, &path, value.as_bytes()).unwrap();
+    fn set(&mut self, path: impl IntoKeys, value: &str) {
+        json::set_by_key(&mut self.settings, path, value.as_bytes()).unwrap();
+    }
+
+    fn cmd(&mut self, cmd: &str) {
+        let root = ScpiPath(None);
+        let mut abs = root;
+        let mut rel;
+        for mut cmd in cmd.split_terminator(';') {
+            cmd = cmd.trim();
+            let (path, value) = if let Some(path) = cmd.strip_suffix('?') {
+                (path, None)
+            } else if let Some((path, value)) = cmd.split_once(' ') {
+                (path, Some(value))
+            } else {
+                println!("Could not parse: {}", cmd);
+                continue;
+            };
+            if let Some(path) = path.strip_prefix(':') {
+                if let Some((abs_path, rel_path)) = path.rsplit_once(':') {
+                    abs = ScpiPath(Some(abs_path));
+                    rel = ScpiPath(Some(rel_path));
+                } else {
+                    abs = root;
+                    rel = ScpiPath(Some(path));
+                }
+            } else {
+                rel = ScpiPath(Some(path));
+            };
+            let path = Keys::chain(abs.into_keys(), &rel);
+            if let Some(value) = value {
+                self.set(path, value);
+                println!("OK");
+            } else {
+                println!("{}", self.get(path));
+            }
+        }
     }
 }
 
@@ -94,8 +142,11 @@ fn main() -> anyhow::Result<()> {
     settings.enable();
     let mut ctrl = ScpiCtrl::new(settings);
 
-    ctrl.set(":ARRAY_OPT:1:A", "99");
-    println!("{}", ctrl.get(":ArrAY_opTION_TRE:1:A"));
+    ctrl.set(&ScpiPath(Some("ARRAY_OPT:1:A")), "99");
+    println!("{}", ctrl.get(&ScpiPath(Some("ArrAY_opTION_TRE:1:A"))));
+
+    ctrl.cmd("FOO?; :ARRAY_OPT:1:A?; A?; A?; A 1; A?; :FOO?");
+    ctrl.cmd("FO?; STRUCT_TREE:B 3; STRUCT_TREE:B?");
 
     Ok(())
 }

--- a/miniconf/examples/scpi.rs
+++ b/miniconf/examples/scpi.rs
@@ -10,9 +10,9 @@ use common::Settings;
 struct ScpiKey<T: ?Sized>(T);
 
 impl<T: AsRef<str> + ?Sized> Key for ScpiKey<T> {
-    fn find<M: KeyLookup + ?Sized>(&self) -> Option<usize> {
+    fn find(&self, lookup: &KeyLookup) -> Option<usize> {
         let s = self.0.as_ref();
-        match M::NAMES {
+        match lookup.names {
             Some(names) => {
                 let mut idx = [None; 2];
                 for (i, name) in names.iter().enumerate() {

--- a/miniconf/examples/scpi.rs
+++ b/miniconf/examples/scpi.rs
@@ -1,0 +1,101 @@
+use core::str;
+
+use miniconf::{
+    json, IntoKeys, Key, KeyLookup, KeysIter, PathIter, TreeDeserializeOwned, TreeSerialize,
+};
+
+mod common;
+use common::Settings;
+
+struct ScpiKey<T: ?Sized>(T);
+
+impl<T: AsRef<str> + ?Sized> Key for ScpiKey<T> {
+    fn find<M: KeyLookup + ?Sized>(&self) -> Option<usize> {
+        let s = self.0.as_ref();
+        match M::NAMES {
+            Some(names) => {
+                let mut idx = [None; 2];
+                for (i, name) in names.iter().enumerate() {
+                    if name.len() < s.len() {
+                        continue;
+                    }
+                    if name
+                        .chars()
+                        .zip(s.chars())
+                        .all(|(n, s)| n.to_ascii_lowercase() == s.to_ascii_lowercase())
+                    {
+                        if name.len() == s.len() {
+                            return Some(i);
+                        }
+                        if idx[1].is_some() {
+                        } else if idx[0].is_some() {
+                            idx[1] = Some(i);
+                        } else {
+                            idx[0] = Some(i);
+                        }
+                    }
+                }
+                if idx[1].is_some() {
+                    None
+                } else {
+                    idx[0]
+                }
+            }
+            None => s.parse().ok(),
+        }
+    }
+}
+
+struct ScpiPathIter<'a>(PathIter<'a, ':'>);
+
+impl<'a> Iterator for ScpiPathIter<'a> {
+    type Item = ScpiKey<&'a str>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(ScpiKey)
+    }
+}
+
+struct ScpiPath<T: ?Sized>(T);
+
+impl<'a, T: AsRef<str> + ?Sized> IntoKeys for &'a ScpiPath<T> {
+    type IntoKeys = KeysIter<ScpiPathIter<'a>>;
+    fn into_keys(self) -> Self::IntoKeys {
+        ScpiPathIter(PathIter::new(self.0.as_ref())).into_keys()
+    }
+}
+
+struct ScpiCtrl<M, const Y: usize> {
+    settings: M,
+    buf: [u8; 1024],
+}
+
+impl<M: TreeSerialize<Y> + TreeDeserializeOwned<Y>, const Y: usize> ScpiCtrl<M, Y> {
+    fn new(settings: M) -> Self {
+        Self {
+            settings,
+            buf: [0; 1024],
+        }
+    }
+
+    fn get(&mut self, path: &str) -> &str {
+        let path = ScpiPath(path);
+        let len = json::get_by_key(&self.settings, &path, &mut self.buf[..]).unwrap();
+        str::from_utf8(&self.buf[..len]).unwrap()
+    }
+
+    fn set(&mut self, path: &str, value: &str) {
+        let path = ScpiPath(path);
+        json::set_by_key(&mut self.settings, &path, value.as_bytes()).unwrap();
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let mut settings = Settings::default();
+    settings.enable();
+    let mut ctrl = ScpiCtrl::new(settings);
+
+    ctrl.set(":ARRAY_OPT:1:A", "99");
+    println!("{}", ctrl.get(":ArrAY_opTION_TRE:1:A"));
+
+    Ok(())
+}

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -44,9 +44,9 @@ fn get_mut<'a, const N: usize, K: Keys, T>(
 macro_rules! depth {
     ($($y:literal)+) => {$(
         impl<T: TreeKey<{$y - 1}>, const N: usize> TreeKey<$y> for [T; N] {
-            fn walk<W: Walk>() -> Result<W, W::Error> {
+            fn traverse_all<W: Walk>() -> Result<W, W::Error> {
                 W::internal().merge(
-                    &T::walk::<W>()?,
+                    &T::traverse_all::<W>()?,
                     None,
                     &KeyLookup {
                         len: N,
@@ -117,7 +117,7 @@ depth!(2 3 4 5 6 7 8 9 10 11 12 13 14 15 16);
 
 // Y == 1
 impl<T, const N: usize> TreeKey for [T; N] {
-    fn walk<W: Walk>() -> Result<W, W::Error> {
+    fn traverse_all<W: Walk>() -> Result<W, W::Error> {
         W::internal().merge(
             &W::leaf(),
             None,

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -3,8 +3,7 @@ use core::any::Any;
 use serde::{de::Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
-    Error, KeyLookup, Keys, Meta, Metadata, Traversal, TreeAny, TreeDeserialize, TreeKey,
-    TreeSerialize,
+    Error, KeyLookup, Keys, Meta, Traversal, TreeAny, TreeDeserialize, TreeKey, TreeSerialize,
 };
 
 fn get<'a, const N: usize, K, T>(
@@ -47,16 +46,6 @@ where
 macro_rules! depth {
     ($($y:literal)+) => {$(
         impl<T: TreeKey<{$y - 1}>, const N: usize> TreeKey<$y> for [T; N] {
-            fn metadata() -> Metadata {
-                let mut meta = T::metadata();
-
-                meta.max_length += N.checked_ilog10().unwrap_or_default() as usize + 1;
-                meta.max_depth += 1;
-                meta.count *= N;
-
-                meta
-            }
-
             fn walk<M: Meta>() -> M {
                 let mut meta = M::default();
                 meta.merge::<Self>(None, &T::walk::<M>());
@@ -126,17 +115,9 @@ impl<const N: usize, T> KeyLookup for [T; N] {
 
 // Y == 1
 impl<T, const N: usize> TreeKey for [T; N] {
-    fn metadata() -> Metadata {
-        Metadata {
-            max_length: N.checked_ilog10().unwrap_or_default() as usize + 1,
-            max_depth: 1,
-            count: N,
-        }
-    }
-
     fn walk<M: Meta>() -> M {
         let mut meta = M::default();
-        meta.merge::<Self>(None, &M::one());
+        meta.merge::<Self>(None, &M::leaf());
         meta
     }
 

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -62,10 +62,10 @@ macro_rules! depth {
                 F: FnMut(usize, Option<&'static str>, usize) -> Result<(), E>,
             {
                 let index = keys.next::<Self>()?;
-                if index >= N {
+                if index >= Self::LEN {
                     return Err(Traversal::NotFound(1).into());
                 }
-                func(index, None, N).map_err(|err| Error::Inner(1, err))?;
+                func(index, None, Self::LEN).map_err(|err| Error::Inner(1, err))?;
                 Error::increment_result(T::traverse_by_key(keys, func))
             }
         }
@@ -115,10 +115,6 @@ depth!(2 3 4 5 6 7 8 9 10 11 12 13 14 15 16);
 
 impl<const N: usize, T> KeyLookup for [T; N] {
     const LEN: usize = N;
-
-    fn name_to_index(value: &str) -> Option<usize> {
-        value.parse().ok()
-    }
 }
 
 // Y == 1
@@ -137,10 +133,10 @@ impl<T, const N: usize> TreeKey for [T; N] {
         F: FnMut(usize, Option<&'static str>, usize) -> Result<(), E>,
     {
         let index = keys.next::<Self>()?;
-        if index >= N {
+        if index >= Self::LEN {
             return Err(Traversal::NotFound(1).into());
         }
-        func(index, None, N).map_err(|err| Error::Inner(1, err))?;
+        func(index, None, Self::LEN).map_err(|err| Error::Inner(1, err))?;
         if !keys.finalize() {
             Err(Traversal::TooLong(1).into())
         } else {

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -46,7 +46,14 @@ macro_rules! depth {
         impl<T: TreeKey<{$y - 1}>, const N: usize> TreeKey<$y> for [T; N] {
             fn walk<W: Walk>() -> W {
                 let mut walk = W::inner();
-                walk.merge(None, &T::walk::<W>(), &KeyLookup{len: N, names: None});
+                walk.merge(
+                    &T::walk::<W>(),
+                    None,
+                    &KeyLookup {
+                        len: N,
+                        names: None
+                    }
+                );
                 walk
             }
 
@@ -115,8 +122,8 @@ impl<T, const N: usize> TreeKey for [T; N] {
     fn walk<W: Walk>() -> W {
         let mut walk = W::inner();
         walk.merge(
-            None,
             &W::leaf(),
+            None,
             &KeyLookup {
                 len: N,
                 names: None,

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -3,7 +3,8 @@ use core::any::Any;
 use serde::{de::Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
-    Error, KeyLookup, Keys, Metadata, Traversal, TreeAny, TreeDeserialize, TreeKey, TreeSerialize,
+    Error, KeyLookup, Keys, Meta, Metadata, Traversal, TreeAny, TreeDeserialize, TreeKey,
+    TreeSerialize,
 };
 
 fn get<'a, const N: usize, K, T>(
@@ -53,6 +54,12 @@ macro_rules! depth {
                 meta.max_depth += 1;
                 meta.count *= N;
 
+                meta
+            }
+
+            fn walk<M: Meta>() -> M {
+                let mut meta = M::default();
+                meta.merge::<Self>(None, &T::walk::<M>());
                 meta
             }
 
@@ -125,6 +132,12 @@ impl<T, const N: usize> TreeKey for [T; N] {
             max_depth: 1,
             count: N,
         }
+    }
+
+    fn walk<M: Meta>() -> M {
+        let mut meta = M::default();
+        meta.merge::<Self>(None, &M::one());
+        meta
     }
 
     fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -3,7 +3,7 @@ use core::any::Any;
 use serde::{de::Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
-    Error, KeyLookup, Keys, Meta, Traversal, TreeAny, TreeDeserialize, TreeKey, TreeSerialize,
+    Error, KeyLookup, Keys, Traversal, TreeAny, TreeDeserialize, TreeKey, TreeSerialize, Walk,
 };
 
 fn get<'a, const N: usize, K, T>(
@@ -46,10 +46,10 @@ where
 macro_rules! depth {
     ($($y:literal)+) => {$(
         impl<T: TreeKey<{$y - 1}>, const N: usize> TreeKey<$y> for [T; N] {
-            fn walk<M: Meta>() -> M {
-                let mut meta = M::default();
-                meta.merge::<Self>(None, &T::walk::<M>());
-                meta
+            fn walk<W: Walk>() -> W {
+                let mut walk = W::default();
+                walk.merge::<Self>(None, &T::walk::<W>());
+                walk
             }
 
             fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>
@@ -115,10 +115,10 @@ impl<const N: usize, T> KeyLookup for [T; N] {
 
 // Y == 1
 impl<T, const N: usize> TreeKey for [T; N] {
-    fn walk<M: Meta>() -> M {
-        let mut meta = M::default();
-        meta.merge::<Self>(None, &M::leaf());
-        meta
+    fn walk<W: Walk>() -> W {
+        let mut walk = W::default();
+        walk.merge::<Self>(None, &W::leaf());
+        walk
     }
 
     fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -44,17 +44,15 @@ fn get_mut<'a, const N: usize, K: Keys, T>(
 macro_rules! depth {
     ($($y:literal)+) => {$(
         impl<T: TreeKey<{$y - 1}>, const N: usize> TreeKey<$y> for [T; N] {
-            fn walk<W: Walk>() -> W {
-                let mut walk = W::inner();
-                walk.merge(
-                    &T::walk::<W>(),
+            fn walk<W: Walk>() -> Result<W, W::Error> {
+                W::inner().merge(
+                    &T::walk::<W>()?,
                     None,
                     &KeyLookup {
                         len: N,
                         names: None
                     }
-                );
-                walk
+                )
             }
 
             fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>
@@ -119,17 +117,15 @@ depth!(2 3 4 5 6 7 8 9 10 11 12 13 14 15 16);
 
 // Y == 1
 impl<T, const N: usize> TreeKey for [T; N] {
-    fn walk<W: Walk>() -> W {
-        let mut walk = W::inner();
-        walk.merge(
+    fn walk<W: Walk>() -> Result<W, W::Error> {
+        W::inner().merge(
             &W::leaf(),
             None,
             &KeyLookup {
                 len: N,
                 names: None,
             },
-        );
-        walk
+        )
     }
 
     fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -45,7 +45,7 @@ macro_rules! depth {
     ($($y:literal)+) => {$(
         impl<T: TreeKey<{$y - 1}>, const N: usize> TreeKey<$y> for [T; N] {
             fn walk<W: Walk>() -> Result<W, W::Error> {
-                W::inner().merge(
+                W::internal().merge(
                     &T::walk::<W>()?,
                     None,
                     &KeyLookup {
@@ -118,7 +118,7 @@ depth!(2 3 4 5 6 7 8 9 10 11 12 13 14 15 16);
 // Y == 1
 impl<T, const N: usize> TreeKey for [T; N] {
     fn walk<W: Walk>() -> Result<W, W::Error> {
-        W::inner().merge(
+        W::internal().merge(
             &W::leaf(),
             None,
             &KeyLookup {

--- a/miniconf/src/array.rs
+++ b/miniconf/src/array.rs
@@ -11,10 +11,7 @@ fn get<'a, const N: usize, K: Keys, T>(
     keys: &mut K,
     drain: bool,
 ) -> Result<&'a T, Traversal> {
-    let index = keys.next(&KeyLookup {
-        len: N,
-        names: None,
-    })?;
+    let index = keys.next(&KeyLookup::homogeneous(N))?;
     let item = arr.get(index).ok_or(Traversal::NotFound(1))?;
     if drain && !keys.finalize() {
         Err(Traversal::TooLong(1))
@@ -28,10 +25,7 @@ fn get_mut<'a, const N: usize, K: Keys, T>(
     keys: &mut K,
     drain: bool,
 ) -> Result<&'a mut T, Traversal> {
-    let index = keys.next(&KeyLookup {
-        len: N,
-        names: None,
-    })?;
+    let index = keys.next(&KeyLookup::homogeneous(N))?;
     let item = arr.get_mut(index).ok_or(Traversal::NotFound(1))?;
     if drain && !keys.finalize() {
         Err(Traversal::TooLong(1))
@@ -48,10 +42,7 @@ macro_rules! depth {
                 W::internal().merge(
                     &T::traverse_all::<W>()?,
                     None,
-                    &KeyLookup {
-                        len: N,
-                        names: None
-                    }
+                    &KeyLookup::homogeneous(N)
                 )
             }
 
@@ -60,10 +51,7 @@ macro_rules! depth {
                 K: Keys,
                 F: FnMut(usize, Option<&'static str>, usize) -> Result<(), E>,
             {
-                let index = keys.next(&KeyLookup {
-                    len: N,
-                    names: None,
-                })?;
+                let index = keys.next(&KeyLookup::homogeneous(N))?;
                 if index >= N {
                     return Err(Traversal::NotFound(1).into());
                 }
@@ -118,14 +106,7 @@ depth!(2 3 4 5 6 7 8 9 10 11 12 13 14 15 16);
 // Y == 1
 impl<T, const N: usize> TreeKey for [T; N] {
     fn traverse_all<W: Walk>() -> Result<W, W::Error> {
-        W::internal().merge(
-            &W::leaf(),
-            None,
-            &KeyLookup {
-                len: N,
-                names: None,
-            },
-        )
+        W::internal().merge(&W::leaf(), None, &KeyLookup::homogeneous(N))
     }
 
     fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>
@@ -133,10 +114,7 @@ impl<T, const N: usize> TreeKey for [T; N] {
         K: Keys,
         F: FnMut(usize, Option<&'static str>, usize) -> Result<(), E>,
     {
-        let index = keys.next(&KeyLookup {
-            len: N,
-            names: None,
-        })?;
+        let index = keys.next(&KeyLookup::homogeneous(N))?;
         if index >= N {
             return Err(Traversal::NotFound(1).into());
         }

--- a/miniconf/src/iter.rs
+++ b/miniconf/src/iter.rs
@@ -47,8 +47,8 @@ impl<T: Iterator> core::iter::FusedIterator for ExactSize<T> {}
 /// A Keys wrapper that can always finalize()
 struct Consume<T>(T);
 impl<T: Keys> Keys for Consume<T> {
-    fn next<M: KeyLookup + ?Sized>(&mut self) -> Result<usize, Traversal> {
-        self.0.next::<M>()
+    fn next(&mut self, lookup: &KeyLookup) -> Result<usize, Traversal> {
+        self.0.next(lookup)
     }
 
     fn finalize(&mut self) -> bool {

--- a/miniconf/src/iter.rs
+++ b/miniconf/src/iter.rs
@@ -118,7 +118,7 @@ impl<M: TreeKey<Y> + ?Sized, const Y: usize, N, const D: usize> NodeIter<M, Y, N
         assert!(self.root == 0);
         debug_assert_eq!(&self.state, &Indices::default()); // ensured by depth = D + 1 marker
         assert!(D >= Y);
-        ExactSize::new(self, M::metadata().count)
+        ExactSize::new(self, M::path_metadata().count)
     }
 }
 

--- a/miniconf/src/iter.rs
+++ b/miniconf/src/iter.rs
@@ -118,7 +118,7 @@ impl<M: TreeKey<Y> + ?Sized, const Y: usize, N, const D: usize> NodeIter<M, Y, N
         assert!(self.root == 0);
         debug_assert_eq!(&self.state, &Indices::default()); // ensured by depth = D + 1 marker
         assert!(D >= Y);
-        ExactSize::new(self, M::walk::<Metadata>().unwrap().count)
+        ExactSize::new(self, M::traverse_all::<Metadata>().unwrap().count)
     }
 }
 

--- a/miniconf/src/iter.rs
+++ b/miniconf/src/iter.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::{Indices, IntoKeys, KeyLookup, Keys, Node, Transcode, Traversal, TreeKey};
+use crate::{Indices, IntoKeys, KeyLookup, Keys, Metadata, Node, Transcode, Traversal, TreeKey};
 
 /// Counting wrapper for iterators with known exact size
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -118,7 +118,7 @@ impl<M: TreeKey<Y> + ?Sized, const Y: usize, N, const D: usize> NodeIter<M, Y, N
         assert!(self.root == 0);
         debug_assert_eq!(&self.state, &Indices::default()); // ensured by depth = D + 1 marker
         assert!(D >= Y);
-        ExactSize::new(self, M::path_metadata().count)
+        ExactSize::new(self, M::walk::<Metadata>().count)
     }
 }
 

--- a/miniconf/src/iter.rs
+++ b/miniconf/src/iter.rs
@@ -118,7 +118,7 @@ impl<M: TreeKey<Y> + ?Sized, const Y: usize, N, const D: usize> NodeIter<M, Y, N
         assert!(self.root == 0);
         debug_assert_eq!(&self.state, &Indices::default()); // ensured by depth = D + 1 marker
         assert!(D >= Y);
-        ExactSize::new(self, M::walk::<Metadata>().count)
+        ExactSize::new(self, M::walk::<Metadata>().unwrap().count)
     }
 }
 

--- a/miniconf/src/json.rs
+++ b/miniconf/src/json.rs
@@ -40,7 +40,7 @@ pub fn set<'de, T: TreeDeserialize<'de, Y> + ?Sized, const Y: usize>(
     path: &str,
     data: &'de [u8],
 ) -> Result<usize, Error<de::Error>> {
-    set_by_key::<_, Y, _>(tree, &Path::<_, '/'>::from(path), data)
+    set_by_key(tree, &Path::<_, '/'>::from(path), data)
 }
 
 /// Retrieve a serialized value by path.
@@ -57,7 +57,7 @@ pub fn get<T: TreeSerialize<Y> + ?Sized, const Y: usize>(
     path: &str,
     data: &mut [u8],
 ) -> Result<usize, Error<ser::Error>> {
-    get_by_key::<_, Y, _>(tree, &Path::<_, '/'>::from(path), data)
+    get_by_key(tree, &Path::<_, '/'>::from(path), data)
 }
 
 /// Update a node by key.

--- a/miniconf/src/jsonpath.rs
+++ b/miniconf/src/jsonpath.rs
@@ -77,6 +77,8 @@ impl<'a> Iterator for JsonPathIter<'a> {
     }
 }
 
+impl<'a> core::iter::FusedIterator for JsonPathIter<'a> {}
+
 /// JSON style path notation
 ///
 /// `T` can be `Write` for `Transcode` with the following behavior:

--- a/miniconf/src/jsonpath.rs
+++ b/miniconf/src/jsonpath.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{IntoKeys, KeysIter, Node, Transcode, Traversal, TreeKey};
 
-/// JSON style path notation
+/// JSON style path notation iterator
 ///
 /// This is only styled after JSON notation, it does not adhere to it.
 /// Supported are both dot and key notation with and without

--- a/miniconf/src/key.rs
+++ b/miniconf/src/key.rs
@@ -14,7 +14,7 @@ use crate::Traversal;
 ///     bar: [u16; 2],
 /// }
 /// assert_eq!(S::LEN, 2);
-/// assert_eq!(S::name_to_index("bar").unwrap(), 1);
+/// assert_eq!(S::NAMES.unwrap()[1], "bar");
 /// ```
 pub trait KeyLookup {
     /// The number of top-level nodes.
@@ -22,12 +22,11 @@ pub trait KeyLookup {
     /// This is used by `impl Keys for Packed`.
     const LEN: usize;
 
-    /// Convert a top level node name to a node index.
+    /// Node names, if any.
     ///
-    /// The details of the mapping and the `usize` index values
-    /// are an implementation detail and only need to be stable at runtime.
-    /// This is used by `impl Key for &str`.
-    fn name_to_index(value: &str) -> Option<usize>;
+    /// If nodes have names, this is a slice of them.
+    /// If it is `Some`, it's `.len()` is guaranteed to be `LEN`.
+    const NAMES: Option<&'static [&'static str]> = None;
 }
 
 /// Convert a `&str` key into a node index on a `KeyLookup`
@@ -46,7 +45,10 @@ impl Key for usize {
 // name
 impl Key for &str {
     fn find<M: KeyLookup + ?Sized>(&self) -> Option<usize> {
-        M::name_to_index(self)
+        match M::NAMES {
+            Some(names) => names.iter().position(|n| n == self),
+            None => self.parse().ok(),
+        }
     }
 }
 

--- a/miniconf/src/key.rs
+++ b/miniconf/src/key.rs
@@ -20,6 +20,7 @@ pub struct KeyLookup {
 
 impl KeyLookup {
     /// Return a homogenenous unnamed KeyLookup
+    #[inline]
     pub const fn homogeneous(len: usize) -> Self {
         Self { len, names: None }
     }

--- a/miniconf/src/key.rs
+++ b/miniconf/src/key.rs
@@ -23,6 +23,24 @@ impl KeyLookup {
     pub const fn homogeneous(len: usize) -> Self {
         Self { len, names: None }
     }
+
+    /// Perform a index-to-name lookup
+    #[inline]
+    pub fn lookup(&self, index: usize) -> Result<Option<&'static str>, Traversal> {
+        match self.names {
+            Some(names) => match names.get(index) {
+                Some(name) => Ok(Some(name)),
+                None => Err(Traversal::NotFound(1)),
+            },
+            None => {
+                if index >= self.len {
+                    Err(Traversal::NotFound(1))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
 }
 
 /// Convert a `&str` key into a node index on a `KeyLookup`

--- a/miniconf/src/key.rs
+++ b/miniconf/src/key.rs
@@ -18,6 +18,13 @@ pub struct KeyLookup {
     pub names: Option<&'static [&'static str]>,
 }
 
+impl KeyLookup {
+    /// Return a homogenenous unnamed KeyLookup
+    pub const fn homogeneous(len: usize) -> Self {
+        Self { len, names: None }
+    }
+}
+
 /// Convert a `&str` key into a node index on a `KeyLookup`
 pub trait Key {
     /// Convert the key `self` to a `usize` index
@@ -25,11 +32,16 @@ pub trait Key {
 }
 
 // index
-impl Key for usize {
-    fn find(&self, _lookup: &KeyLookup) -> Option<usize> {
-        Some(*self)
-    }
+macro_rules! impl_key {
+    ($($t:ty)+) => {$(
+        impl Key for $t {
+            fn find(&self, _lookup: &KeyLookup) -> Option<usize> {
+                Some(*self as _)
+            }
+        })+
+    };
 }
+impl_key!(usize u8 u16 u32);
 
 // name
 impl Key for &str {

--- a/miniconf/src/lib.rs
+++ b/miniconf/src/lib.rs
@@ -21,6 +21,8 @@ mod array;
 mod iter;
 mod option;
 pub use iter::*;
+mod walk;
+pub use walk::*;
 
 #[cfg(feature = "derive")]
 pub use miniconf_derive::*;

--- a/miniconf/src/node.rs
+++ b/miniconf/src/node.rs
@@ -179,8 +179,6 @@ pub struct PathIter<'a, const S: char>(Option<&'a str>);
 
 impl<'a, const S: char> PathIter<'a, S> {
     /// Create a new `PathIter`
-    ///
-    /// This calls `next()` once to pop everything up to and including the first separator.
     #[inline]
     pub fn new(s: Option<&'a str>) -> Self {
         Self(s)
@@ -188,7 +186,7 @@ impl<'a, const S: char> PathIter<'a, S> {
 
     /// Create a new `PathIter` starting at the root.
     ///
-    /// This discards everything up to and including the first separator.
+    /// This calls `next()` once to pop everything up to and including the first separator.
     #[inline]
     pub fn root(s: &'a str) -> Self {
         let mut s = Self::new(Some(s));

--- a/miniconf/src/node.rs
+++ b/miniconf/src/node.rs
@@ -225,15 +225,11 @@ impl<T: Write + ?Sized, const S: char> Transcode for Path<T, S> {
         K: IntoKeys,
     {
         M::traverse_by_key(keys.into_keys(), |index, name, _len| {
-            self.0
-                .write_char(S)
-                .and_then(|()| {
-                    let mut buf = itoa::Buffer::new();
-                    let name = name.unwrap_or_else(|| buf.format(index));
-                    debug_assert!(!name.contains(S));
-                    self.0.write_str(name)
-                })
-                .or(Err(()))
+            self.0.write_char(S).or(Err(()))?;
+            let mut buf = itoa::Buffer::new();
+            let name = name.unwrap_or_else(|| buf.format(index));
+            debug_assert!(!name.contains(S));
+            self.0.write_str(name).or(Err(()))
         })
         .try_into()
     }

--- a/miniconf/src/node.rs
+++ b/miniconf/src/node.rs
@@ -1,6 +1,5 @@
 use core::{
     fmt::Write,
-    iter::Copied,
     ops::{Deref, DerefMut},
     slice::Iter,
 };
@@ -210,6 +209,8 @@ impl<'a, const S: char> Iterator for PathIter<'a, S> {
     }
 }
 
+impl<'a, const S: char> core::iter::FusedIterator for PathIter<'a, S> {}
+
 impl<'a, T: AsRef<str> + ?Sized, const S: char> IntoKeys for &'a Path<T, S> {
     type IntoKeys = KeysIter<PathIter<'a, S>>;
     fn into_keys(self) -> Self::IntoKeys {
@@ -285,7 +286,7 @@ impl<T> From<T> for Indices<T> {
 }
 
 impl<'a, T: AsRef<[usize]> + ?Sized> IntoKeys for &'a Indices<T> {
-    type IntoKeys = KeysIter<Copied<Iter<'a, usize>>>;
+    type IntoKeys = KeysIter<core::iter::Copied<Iter<'a, usize>>>;
     fn into_keys(self) -> Self::IntoKeys {
         self.0.as_ref().iter().copied().into_keys()
     }

--- a/miniconf/src/node.rs
+++ b/miniconf/src/node.rs
@@ -130,7 +130,7 @@ impl Transcode for () {
 /// The path will either be empty or start with the separator.
 ///
 /// * `path: T`: A `Write` to write the separators and node names into during `Transcode`.
-///   See also [TreeKey::metadata()] and `Metadata::max_length()` for upper bounds
+///   See also [TreeKey::walk()] and `Metadata::max_length()` for upper bounds
 ///   on path length. Can also be a `AsRef<str>` to implement `IntoKeys` (see [`KeysIter`]).
 /// * `const S: char`: The path hierarchy separator to be inserted before each name,
 ///   e.g. `'/'`.

--- a/miniconf/src/node.rs
+++ b/miniconf/src/node.rs
@@ -130,7 +130,7 @@ impl Transcode for () {
 /// The path will either be empty or start with the separator.
 ///
 /// * `path: T`: A `Write` to write the separators and node names into during `Transcode`.
-///   See also [TreeKey::walk()] and `Metadata::max_length()` for upper bounds
+///   See also [TreeKey::traverse_all()] and `Metadata::max_length()` for upper bounds
 ///   on path length. Can also be a `AsRef<str>` to implement `IntoKeys` (see [`KeysIter`]).
 /// * `const S: char`: The path hierarchy separator to be inserted before each name,
 ///   e.g. `'/'`.

--- a/miniconf/src/node.rs
+++ b/miniconf/src/node.rs
@@ -182,8 +182,16 @@ impl<'a, const S: char> PathIter<'a, S> {
     ///
     /// This calls `next()` once to pop everything up to and including the first separator.
     #[inline]
-    pub fn new(s: &'a str) -> Self {
-        let mut s = Self(Some(s));
+    pub fn new(s: Option<&'a str>) -> Self {
+        Self(s)
+    }
+
+    /// Create a new `PathIter` starting at the root.
+    ///
+    /// This discards everything up to and including the first separator.
+    #[inline]
+    pub fn root(s: &'a str) -> Self {
+        let mut s = Self::new(Some(s));
         // Skip the first part to disambiguate between
         // the one-Key Keys `[""]` and the zero-Key Keys `[]`.
         // This is relevant in the case of e.g. `Option` and newtypes.
@@ -217,7 +225,7 @@ impl<'a, const S: char> core::iter::FusedIterator for PathIter<'a, S> {}
 impl<'a, T: AsRef<str> + ?Sized, const S: char> IntoKeys for &'a Path<T, S> {
     type IntoKeys = KeysIter<PathIter<'a, S>>;
     fn into_keys(self) -> Self::IntoKeys {
-        PathIter::<'a, S>::new(self.0.as_ref()).into_keys()
+        PathIter::<'a, S>::root(self.0.as_ref()).into_keys()
     }
 }
 
@@ -315,7 +323,7 @@ mod test {
     fn strsplit() {
         use heapless::Vec;
         for p in ["/d/1", "/a/bccc//d/e/", "", "/", "a/b", "a"] {
-            let a: Vec<_, 10> = PathIter::<'_, '/'>::new(p).collect();
+            let a: Vec<_, 10> = PathIter::<'_, '/'>::root(p).collect();
             let b: Vec<_, 10> = p.split('/').skip(1).collect();
             assert_eq!(a, b);
         }

--- a/miniconf/src/node.rs
+++ b/miniconf/src/node.rs
@@ -178,8 +178,11 @@ impl<T, const S: char> From<T> for Path<T, S> {
 pub struct PathIter<'a, const S: char>(Option<&'a str>);
 
 impl<'a, const S: char> PathIter<'a, S> {
+    /// Create a new `PathIter`
+    ///
+    /// This calls `next()` once to pop everything up to and including the first separator.
     #[inline]
-    fn new(s: &'a str) -> Self {
+    pub fn new(s: &'a str) -> Self {
         let mut s = Self(Some(s));
         // Skip the first part to disambiguate between
         // the one-Key Keys `[""]` and the zero-Key Keys `[]`.

--- a/miniconf/src/node.rs
+++ b/miniconf/src/node.rs
@@ -80,6 +80,7 @@ impl Node {
 }
 
 impl From<Node> for usize {
+    #[inline]
     fn from(value: Node) -> Self {
         value.depth
     }
@@ -88,6 +89,8 @@ impl From<Node> for usize {
 /// Map a `TreeKey::traverse_by_key()` `Result` to a `Transcode::transcode()` `Result`.
 impl TryFrom<Result<usize, Error<()>>> for Node {
     type Error = Traversal;
+
+    #[inline]
     fn try_from(value: Result<usize, Error<()>>) -> Result<Self, Traversal> {
         match value {
             Ok(depth) => Ok(Node::leaf(depth)),

--- a/miniconf/src/option.rs
+++ b/miniconf/src/option.rs
@@ -37,8 +37,8 @@ fn get_mut<'a, T, K: Keys>(
 macro_rules! depth {
     ($($y:literal)+) => {$(
         impl<T: TreeKey<{$y - 1}>> TreeKey<$y> for Option<T> {
-            fn walk<W: Walk>() -> Result<W, W::Error> {
-                T::walk()
+            fn traverse_all<W: Walk>() -> Result<W, W::Error> {
+                T::traverse_all()
             }
 
             fn traverse_by_key<K, F, E>(keys: K, func: F) -> Result<usize, Error<E>>
@@ -95,7 +95,7 @@ depth!(2 3 4 5 6 7 8 9 10 11 12 13 14 15 16);
 
 // Y == 1
 impl<T> TreeKey for Option<T> {
-    fn walk<W: Walk>() -> Result<W, W::Error> {
+    fn traverse_all<W: Walk>() -> Result<W, W::Error> {
         Ok(W::leaf())
     }
 

--- a/miniconf/src/option.rs
+++ b/miniconf/src/option.rs
@@ -2,7 +2,9 @@ use core::any::Any;
 
 use serde::{de::Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::{Error, Keys, Metadata, Traversal, TreeAny, TreeDeserialize, TreeKey, TreeSerialize};
+use crate::{
+    Error, Keys, Meta, Metadata, Traversal, TreeAny, TreeDeserialize, TreeKey, TreeSerialize,
+};
 
 // `Option` does not add to the path hierarchy (does not consume from `keys` or call `func`).
 // But it does add one Tree API layer between its `Tree<Y>` level
@@ -39,6 +41,10 @@ macro_rules! depth {
         impl<T: TreeKey<{$y - 1}>> TreeKey<$y> for Option<T> {
             fn metadata() -> Metadata {
                 T::metadata()
+            }
+
+            fn walk<M: Meta>() -> M {
+                T::walk()
             }
 
             fn traverse_by_key<K, F, E>(keys: K, func: F) -> Result<usize, Error<E>>
@@ -100,6 +106,10 @@ impl<T> TreeKey for Option<T> {
             count: 1,
             ..Default::default()
         }
+    }
+
+    fn walk<M: Meta>() -> M {
+        M::one()
     }
 
     fn traverse_by_key<K, F, E>(mut keys: K, _func: F) -> Result<usize, Error<E>>

--- a/miniconf/src/option.rs
+++ b/miniconf/src/option.rs
@@ -2,9 +2,7 @@ use core::any::Any;
 
 use serde::{de::Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::{
-    Error, Keys, Meta, Metadata, Traversal, TreeAny, TreeDeserialize, TreeKey, TreeSerialize,
-};
+use crate::{Error, Keys, Meta, Traversal, TreeAny, TreeDeserialize, TreeKey, TreeSerialize};
 
 // `Option` does not add to the path hierarchy (does not consume from `keys` or call `func`).
 // But it does add one Tree API layer between its `Tree<Y>` level
@@ -39,10 +37,6 @@ fn get_mut<'a, T, K: Keys>(
 macro_rules! depth {
     ($($y:literal)+) => {$(
         impl<T: TreeKey<{$y - 1}>> TreeKey<$y> for Option<T> {
-            fn metadata() -> Metadata {
-                T::metadata()
-            }
-
             fn walk<M: Meta>() -> M {
                 T::walk()
             }
@@ -101,15 +95,8 @@ depth!(2 3 4 5 6 7 8 9 10 11 12 13 14 15 16);
 
 // Y == 1
 impl<T> TreeKey for Option<T> {
-    fn metadata() -> Metadata {
-        Metadata {
-            count: 1,
-            ..Default::default()
-        }
-    }
-
     fn walk<M: Meta>() -> M {
-        M::one()
+        M::leaf()
     }
 
     fn traverse_by_key<K, F, E>(mut keys: K, _func: F) -> Result<usize, Error<E>>

--- a/miniconf/src/option.rs
+++ b/miniconf/src/option.rs
@@ -2,7 +2,7 @@ use core::any::Any;
 
 use serde::{de::Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::{Error, Keys, Meta, Traversal, TreeAny, TreeDeserialize, TreeKey, TreeSerialize};
+use crate::{Error, Keys, Traversal, TreeAny, TreeDeserialize, TreeKey, TreeSerialize, Walk};
 
 // `Option` does not add to the path hierarchy (does not consume from `keys` or call `func`).
 // But it does add one Tree API layer between its `Tree<Y>` level
@@ -37,7 +37,7 @@ fn get_mut<'a, T, K: Keys>(
 macro_rules! depth {
     ($($y:literal)+) => {$(
         impl<T: TreeKey<{$y - 1}>> TreeKey<$y> for Option<T> {
-            fn walk<M: Meta>() -> M {
+            fn walk<W: Walk>() -> W {
                 T::walk()
             }
 
@@ -95,8 +95,8 @@ depth!(2 3 4 5 6 7 8 9 10 11 12 13 14 15 16);
 
 // Y == 1
 impl<T> TreeKey for Option<T> {
-    fn walk<M: Meta>() -> M {
-        M::leaf()
+    fn walk<W: Walk>() -> W {
+        W::leaf()
     }
 
     fn traverse_by_key<K, F, E>(mut keys: K, _func: F) -> Result<usize, Error<E>>

--- a/miniconf/src/option.rs
+++ b/miniconf/src/option.rs
@@ -37,7 +37,7 @@ fn get_mut<'a, T, K: Keys>(
 macro_rules! depth {
     ($($y:literal)+) => {$(
         impl<T: TreeKey<{$y - 1}>> TreeKey<$y> for Option<T> {
-            fn walk<W: Walk>() -> W {
+            fn walk<W: Walk>() -> Result<W, W::Error> {
                 T::walk()
             }
 
@@ -95,8 +95,8 @@ depth!(2 3 4 5 6 7 8 9 10 11 12 13 14 15 16);
 
 // Y == 1
 impl<T> TreeKey for Option<T> {
-    fn walk<W: Walk>() -> W {
-        W::leaf()
+    fn walk<W: Walk>() -> Result<W, W::Error> {
+        Ok(W::leaf())
     }
 
     fn traverse_by_key<K, F, E>(mut keys: K, _func: F) -> Result<usize, Error<E>>

--- a/miniconf/src/packed.rs
+++ b/miniconf/src/packed.rs
@@ -240,10 +240,10 @@ impl Packed {
 }
 
 impl Keys for Packed {
-    fn next<M: KeyLookup + ?Sized>(&mut self) -> Result<usize, Traversal> {
-        let bits = Self::bits_for(M::LEN.saturating_sub(1));
+    fn next(&mut self, lookup: &KeyLookup) -> Result<usize, Traversal> {
+        let bits = Self::bits_for(lookup.len.saturating_sub(1));
         let index = self.pop_msb(bits).ok_or(Traversal::TooShort(0))?;
-        index.find::<M>().ok_or(Traversal::NotFound(1))
+        index.find(lookup).ok_or(Traversal::NotFound(1))
     }
 
     #[inline]

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -81,7 +81,6 @@ impl Walk for Metadata {
         }
     }
 
-    #[inline]
     fn merge(
         mut self,
         meta: &Self,
@@ -244,6 +243,25 @@ impl Walk for Metadata {
 /// Note: In both cases `get_mut` receives `&mut self` as an argument and may
 /// mutate the struct.
 ///
+/// ### `validate`
+///
+/// For leaf fields the `validate` callback is called during `deserialize_by_key()`
+/// after successful deserialization of the leaf value but before `get_mut()` and
+/// before storing the value.
+/// The leaf `validate` signature is `fn(&mut self, value: T) ->
+/// Result<T, &'static str>`. It may mutate the value before it is being stored.
+/// If a leaf validate callback returns `Err(&str)`, the leaf value is not updated
+/// and [`Traversal::Invalid`] is returned from `deserialize_by_key()`.
+/// For internal fields `validate` is called after the successful update of the leaf field
+/// during upward traversal.
+/// The internal `validate` signature is `fn(&mut self, depth: usize) ->
+/// Result<usize, &'static str>`
+/// If an internal node validate callback returns `Err()`, the leaf value **has been**
+/// updated and [`Traversal::Invalid`] is returned from `deserialize_by_key()`.
+///
+/// Note: In both cases `validate` receives `&mut self` as an argument and may
+/// mutate the struct.
+///
 /// ```
 /// use miniconf::{Error, Tree};
 /// #[derive(Tree, Default)]
@@ -260,25 +278,6 @@ impl Walk for Metadata {
 ///     Err("fail")
 /// }
 /// ```
-///
-/// ### `validate`
-///
-/// For leaf fields the `validate` callback is called during `deserialize_by_key()`
-/// after successful deserialization of the leaf value but before `get_mut()` and
-/// before storing the value.
-/// The leaf `validate` signature is `fn(&mut self, value: T) ->
-/// Result<T, &'static str>`. It may mutate the value before it is being stored.
-/// If a leaf validate callback returns `Err(&str)`, the leaf value is not updated
-/// and [`Traversal::Invalid`] is returned from `deserialize_by_key()`.
-/// For internal fields `validate` is called after the successful update of the leaf field
-/// during upward traversal.
-/// The internal `validate` signature is `fn(&mut self, depth: usize) ->
-/// Result<usize, &'static str>`
-/// If an internal validate callback returns `Err()`, the leaf value **has been**
-/// updated and [`Traversal::Invalid`] is returned from `deserialize_by_key()`.
-///
-/// Note: In both cases `validate` receives `&mut self` as an argument and may
-/// mutate the struct.
 ///
 /// ## Bounds
 ///

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -44,8 +44,8 @@ pub trait Walk: Sized {
     /// Error type for `merge()`
     type Error;
 
-    /// Return the walk starting point for an an empty inner node
-    fn inner() -> Self;
+    /// Return the walk starting point for an an empty internal node
+    fn internal() -> Self;
 
     /// Return the walk starting point for a single leaf node
     fn leaf() -> Self;
@@ -69,7 +69,7 @@ impl Walk for Metadata {
     type Error = Infallible;
 
     #[inline]
-    fn inner() -> Self {
+    fn internal() -> Self {
         Default::default()
     }
 

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -50,10 +50,11 @@ pub trait Walk {
     /// Merge node metadata into self.
     ///
     /// # Args
-    /// * `index`: Either the node index in case of a single node or `None`, if
-    ///   there are `lookup.len` nodes of homogeneous type.
     /// * `walk`: The walk of the node to merge.
-    fn merge(&mut self, index: Option<usize>, walk: &Self, lookup: &KeyLookup);
+    /// * `index`: Either the node index in case of a single node
+    ///   or `None`, in case of `lookup.len` nodes of homogeneous type.
+    /// * `lookup`: The namespace the node(s) are in.
+    fn merge(&mut self, walk: &Self, index: Option<usize>, lookup: &KeyLookup);
 }
 
 impl Walk for Metadata {
@@ -71,15 +72,15 @@ impl Walk for Metadata {
     }
 
     #[inline]
-    fn merge(&mut self, index: Option<usize>, meta: &Self, lookup: &KeyLookup) {
+    fn merge(&mut self, meta: &Self, index: Option<usize>, lookup: &KeyLookup) {
         let (ident_len, count) = match index {
-            None => {
-                debug_assert!(lookup.names.is_none());
-                (
-                    lookup.len.checked_ilog10().unwrap_or_default() as usize + 1,
-                    lookup.len,
-                )
-            }
+            None => (
+                match lookup.names {
+                    Some(names) => names.iter().map(|n| n.len()).max().unwrap_or_default(),
+                    None => lookup.len.checked_ilog10().unwrap_or_default() as usize + 1,
+                },
+                lookup.len,
+            ),
             Some(index) => (
                 match lookup.names {
                     Some(names) => names[index].len(),

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -39,7 +39,7 @@ impl Metadata {
     }
 }
 
-/// Capability to be walked through a `TreeKey` using `walk()`.
+/// Capability to be walked through a `TreeKey` using `traverse_all()`.
 pub trait Walk: Sized {
     /// Error type for `merge()`
     type Error;
@@ -141,7 +141,7 @@ impl Walk for Metadata {
 /// (even if no keys are consumed directly) to satisfy the bound
 /// heuristics in the derive macro.
 ///
-/// The exact maximum key depth can be obtained through [`TreeKey::walk()`].
+/// The exact maximum key depth can be obtained through [`TreeKey::traverse_all()`].
 ///
 /// # Keys
 ///
@@ -309,9 +309,9 @@ impl Walk for Metadata {
 ///     a: [Option<T>; 2],
 /// };
 /// // This works as [u32; N] implements TreeKey<1>:
-/// S::<[u32; 5]>::walk::<Metadata>();
+/// S::<[u32; 5]>::traverse_all::<Metadata>();
 /// // This does not compile as u32 does not implement TreeKey<1>:
-/// // S::<u32>::walk::<Metadata>();
+/// // S::<u32>::traverse_all::<Metadata>();
 /// ```
 ///
 /// This behavior is upheld by and compatible with all implementations in this crate. It is only violated
@@ -372,10 +372,10 @@ pub trait TreeKey<const Y: usize = 1> {
     ///     #[tree(depth = 1)]
     ///     bar: [u16; 2],
     /// };
-    /// let m = S::walk::<Metadata>().unwrap();
+    /// let m = S::traverse_all::<Metadata>().unwrap();
     /// assert_eq!((m.max_depth, m.max_length, m.count), (2, 4, 3));
     /// ```
-    fn walk<W: Walk>() -> Result<W, W::Error>;
+    fn traverse_all<W: Walk>() -> Result<W, W::Error>;
 
     /// Traverse from the root to a leaf and call a function for each node.
     ///

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -338,24 +338,20 @@ pub trait TreeKey<const Y: usize = 1> {
     ///     bar: [u16; 5],
     /// };
     ///
-    /// let (path, node) = S::transcode::<Path<String, '/'>, _>([1usize, 1]).unwrap();
-    /// assert_eq!(path.as_str(), "/bar/1");
-    ///
     /// let idx = [1usize, 1];
+    ///
+    /// let (path, node) = S::transcode::<Path<String, '/'>, _>(idx).unwrap();
+    /// assert_eq!(path.as_str(), "/bar/1");
     /// let (path, node) = S::transcode::<JsonPath<String>, _>(idx).unwrap();
     /// assert_eq!(path.as_str(), ".bar[1]");
-    ///
     /// let (indices, node) = S::transcode::<Indices<[_; 2]>, _>(&path).unwrap();
     /// assert_eq!(&indices[..node.depth()], idx);
-    ///
     /// let (indices, node) = S::transcode::<Indices<[_; 2]>, _>(["bar", "1"]).unwrap();
     /// assert_eq!(&indices[..node.depth()], [1, 1]);
-    ///
     /// let (packed, node) = S::transcode::<Packed, _>(["bar", "4"]).unwrap();
     /// assert_eq!(packed.into_lsb().get(), 0b1_1_100);
     /// let (path, node) = S::transcode::<Path<String, '/'>, _>(packed).unwrap();
     /// assert_eq!(path.as_str(), "/bar/4");
-    ///
     /// let ((), node) = S::transcode(&path).unwrap();
     /// assert_eq!(node, Node::leaf(2));
     /// ```

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -73,10 +73,13 @@ impl Walk for Metadata {
     #[inline]
     fn merge(&mut self, index: Option<usize>, meta: &Self, lookup: &KeyLookup) {
         let (ident_len, count) = match index {
-            None => (
-                lookup.len.checked_ilog10().unwrap_or_default() as usize + 1,
-                lookup.len,
-            ),
+            None => {
+                debug_assert!(lookup.names.is_none());
+                (
+                    lookup.len.checked_ilog10().unwrap_or_default() as usize + 1,
+                    lookup.len,
+                )
+            }
             Some(index) => (
                 match lookup.names {
                     Some(names) => names[index].len(),
@@ -85,7 +88,7 @@ impl Walk for Metadata {
                 1,
             ),
         };
-        self.max_depth = self.max_depth.max(meta.max_depth + 1);
+        self.max_depth = self.max_depth.max(1 + meta.max_depth);
         self.max_length = self.max_length.max(ident_len + meta.max_length);
         self.count += count * meta.count;
     }

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -2,7 +2,7 @@ use core::any::Any;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::{Error, IntoKeys, Keys, Node, NodeIter, Transcode, Traversal};
+use crate::{Error, IntoKeys, KeyLookup, Keys, Node, NodeIter, Transcode, Traversal};
 
 /// Metadata about a `TreeKey` namespace.
 ///
@@ -37,6 +37,11 @@ impl Metadata {
     pub fn max_length(&self, separator: &str) -> usize {
         self.max_length + self.max_depth * separator.len()
     }
+}
+
+pub trait Meta: Default {
+    fn one() -> Self;
+    fn merge<K: KeyLookup>(&mut self, index: Option<usize>, meta: &Self);
 }
 
 /// Traversal, iteration of keys in a tree.
@@ -304,6 +309,8 @@ pub trait TreeKey<const Y: usize = 1> {
     /// assert_eq!((m.max_depth, m.max_length, m.count), (2, 4, 3));
     /// ```
     fn metadata() -> Metadata;
+
+    fn walk<M: Meta>() -> M;
 
     /// Traverse from the root to a leaf and call a function for each node.
     ///

--- a/miniconf/src/walk.rs
+++ b/miniconf/src/walk.rs
@@ -1,0 +1,111 @@
+use core::convert::Infallible;
+
+use serde::{Deserialize, Serialize};
+
+use crate::KeyLookup;
+
+/// Metadata about a `TreeKey` namespace.
+///
+/// Metadata includes paths that may be [`crate::Traversal::Absent`] at runtime.
+#[non_exhaustive]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Metadata {
+    /// The maximum length of a path in bytes.
+    ///
+    /// This is the exact maximum of the length of the concatenation of the node names
+    /// in a [`crate::Path`] excluding the separators. See [`Self::max_length()`] for
+    /// the maximum length including separators.
+    pub max_length: usize,
+
+    /// The maximum key depth.
+    ///
+    /// This is equal to the exact maximum number of path hierarchy separators.
+    /// It's the exact maximum number of key indices.
+    /// It may be smaller than the [`TreeKey<Y>` recursion depth](crate::TreeKey#recursion-depth).
+    pub max_depth: usize,
+
+    /// The exact total number of keys.
+    pub count: usize,
+}
+
+impl Metadata {
+    /// Add separator length to the maximum path length.
+    ///
+    /// To obtain an upper bound on the maximum length of all paths
+    /// including separators, this adds `max_depth*separator_length`.
+    #[inline]
+    pub fn max_length(&self, separator: &str) -> usize {
+        self.max_length + self.max_depth * separator.len()
+    }
+}
+
+/// Capability to be walked through a `TreeKey` using `traverse_all()`.
+pub trait Walk: Sized {
+    /// Error type for `merge()`
+    type Error;
+
+    /// Return the walk starting point for an an empty internal node
+    fn internal() -> Self;
+
+    /// Return the walk starting point for a single leaf node
+    fn leaf() -> Self;
+
+    /// Merge node metadata into self.
+    ///
+    /// # Args
+    /// * `walk`: The walk of the node to merge.
+    /// * `index`: Either the node index in case of a single node
+    ///   or `None`, in case of `lookup.len` nodes of homogeneous type.
+    /// * `lookup`: The namespace the node(s) are in.
+    fn merge(
+        self,
+        walk: &Self,
+        index: Option<usize>,
+        lookup: &KeyLookup,
+    ) -> Result<Self, Self::Error>;
+}
+
+impl Walk for Metadata {
+    type Error = Infallible;
+
+    #[inline]
+    fn internal() -> Self {
+        Default::default()
+    }
+
+    #[inline]
+    fn leaf() -> Self {
+        Self {
+            count: 1,
+            ..Default::default()
+        }
+    }
+
+    fn merge(
+        mut self,
+        meta: &Self,
+        index: Option<usize>,
+        lookup: &KeyLookup,
+    ) -> Result<Self, Self::Error> {
+        let (ident_len, count) = match index {
+            None => (
+                match lookup.names {
+                    Some(names) => names.iter().map(|n| n.len()).max().unwrap_or_default(),
+                    None => lookup.len.checked_ilog10().unwrap_or_default() as usize + 1,
+                },
+                lookup.len,
+            ),
+            Some(index) => (
+                match lookup.names {
+                    Some(names) => names[index].len(),
+                    None => index.checked_ilog10().unwrap_or_default() as usize + 1,
+                },
+                1,
+            ),
+        };
+        self.max_depth = self.max_depth.max(1 + meta.max_depth);
+        self.max_length = self.max_length.max(ident_len + meta.max_length);
+        self.count += count * meta.count;
+        Ok(self)
+    }
+}

--- a/miniconf/tests/arrays.rs
+++ b/miniconf/tests/arrays.rs
@@ -128,7 +128,7 @@ fn not_found() {
 
 #[test]
 fn metadata() {
-    let metadata = Settings::walk::<Metadata>();
+    let metadata = Settings::walk::<Metadata>().unwrap();
     assert_eq!(metadata.max_depth, 4);
     assert_eq!(metadata.max_length("/"), "/aam/0/0/c".len());
     assert_eq!(metadata.count, 11);

--- a/miniconf/tests/arrays.rs
+++ b/miniconf/tests/arrays.rs
@@ -128,7 +128,7 @@ fn not_found() {
 
 #[test]
 fn metadata() {
-    let metadata = Settings::metadata();
+    let metadata = Settings::path_metadata();
     assert_eq!(metadata.max_depth, 4);
     assert_eq!(metadata.max_length("/"), "/aam/0/0/c".len());
     assert_eq!(metadata.count, 11);

--- a/miniconf/tests/arrays.rs
+++ b/miniconf/tests/arrays.rs
@@ -128,7 +128,7 @@ fn not_found() {
 
 #[test]
 fn metadata() {
-    let metadata = Settings::walk::<Metadata>().unwrap();
+    let metadata = Settings::traverse_all::<Metadata>().unwrap();
     assert_eq!(metadata.max_depth, 4);
     assert_eq!(metadata.max_length("/"), "/aam/0/0/c".len());
     assert_eq!(metadata.count, 11);

--- a/miniconf/tests/arrays.rs
+++ b/miniconf/tests/arrays.rs
@@ -1,5 +1,5 @@
 use miniconf::{
-    json, Deserialize, Error, Indices, Packed, Path, Serialize, Traversal, Tree, TreeKey,
+    json, Deserialize, Error, Indices, Metadata, Packed, Path, Serialize, Traversal, Tree, TreeKey,
 };
 
 mod common;
@@ -128,7 +128,7 @@ fn not_found() {
 
 #[test]
 fn metadata() {
-    let metadata = Settings::path_metadata();
+    let metadata = Settings::walk::<Metadata>();
     assert_eq!(metadata.max_depth, 4);
     assert_eq!(metadata.max_length("/"), "/aam/0/0/c".len());
     assert_eq!(metadata.count, 11);

--- a/miniconf/tests/basic.rs
+++ b/miniconf/tests/basic.rs
@@ -15,7 +15,7 @@ struct Settings {
 
 #[test]
 fn meta() {
-    let meta = Settings::walk::<Metadata>();
+    let meta = Settings::walk::<Metadata>().unwrap();
     assert_eq!(meta.max_depth, 2);
     assert_eq!(meta.max_length("/"), "/c/inner".len());
     assert_eq!(meta.count, 3);

--- a/miniconf/tests/basic.rs
+++ b/miniconf/tests/basic.rs
@@ -15,7 +15,7 @@ struct Settings {
 
 #[test]
 fn meta() {
-    let meta = Settings::metadata();
+    let meta = Settings::path_metadata();
     assert_eq!(meta.max_depth, 2);
     assert_eq!(meta.max_length("/"), "/c/inner".len());
     assert_eq!(meta.count, 3);

--- a/miniconf/tests/basic.rs
+++ b/miniconf/tests/basic.rs
@@ -1,4 +1,4 @@
-use miniconf::{Indices, IntoKeys, Node, Path, Traversal, Tree, TreeKey};
+use miniconf::{Indices, IntoKeys, Metadata, Node, Path, Traversal, Tree, TreeKey};
 
 #[derive(Tree, Default)]
 struct Inner {
@@ -15,7 +15,7 @@ struct Settings {
 
 #[test]
 fn meta() {
-    let meta = Settings::path_metadata();
+    let meta = Settings::walk::<Metadata>();
     assert_eq!(meta.max_depth, 2);
     assert_eq!(meta.max_length("/"), "/c/inner".len());
     assert_eq!(meta.count, 3);

--- a/miniconf/tests/basic.rs
+++ b/miniconf/tests/basic.rs
@@ -15,7 +15,7 @@ struct Settings {
 
 #[test]
 fn meta() {
-    let meta = Settings::walk::<Metadata>().unwrap();
+    let meta = Settings::traverse_all::<Metadata>().unwrap();
     assert_eq!(meta.max_depth, 2);
     assert_eq!(meta.max_length("/"), "/c/inner".len());
     assert_eq!(meta.count, 3);

--- a/miniconf/tests/basic.rs
+++ b/miniconf/tests/basic.rs
@@ -24,7 +24,7 @@ fn meta() {
 #[test]
 fn path() {
     for (keys, path, depth) in [
-        (&[1][..], "/b", Node::leaf(1)),
+        (&[1usize][..], "/b", Node::leaf(1)),
         (&[2, 0][..], "/c/inner", Node::leaf(2)),
         (&[2][..], "/c", Node::internal(1)),
         (&[][..], "", Node::internal(0)),
@@ -48,11 +48,11 @@ fn indices() {
         assert_eq!(node, depth);
         assert_eq!(indices.0, idx);
     }
-    let (indices, node) = Option::<i8>::transcode::<Indices<_>, _>([0; 0]).unwrap();
+    let (indices, node) = Option::<i8>::transcode::<Indices<_>, _>([0usize; 0]).unwrap();
     assert_eq!(indices.0, [0]);
     assert_eq!(node, Node::leaf(0));
 
-    let mut it = [0; 4].into_iter();
+    let mut it = [0usize; 4].into_iter();
     assert_eq!(
         Settings::transcode::<Indices<[_; 2]>, _>(&mut it),
         Err(Traversal::TooLong(1).into())
@@ -66,24 +66,27 @@ fn traverse_empty() {
     struct S {}
     let f = |_, _, _| -> Result<(), ()> { unreachable!() };
     assert_eq!(
-        S::traverse_by_key([0].into_keys(), f),
+        S::traverse_by_key([0usize].into_keys(), f),
         Err(Traversal::NotFound(1).into())
     );
     assert_eq!(
-        S::traverse_by_key([0; 0].into_keys(), f),
+        S::traverse_by_key([0usize; 0].into_keys(), f),
         Err(Traversal::TooShort(0).into())
     );
     assert_eq!(
-        Option::<i32>::traverse_by_key([0].into_keys(), f),
+        Option::<i32>::traverse_by_key([0usize].into_keys(), f),
         Err(Traversal::TooLong(0).into())
     );
-    assert_eq!(Option::<i32>::traverse_by_key([0; 0].into_keys(), f), Ok(0));
     assert_eq!(
-        <Option::<S> as TreeKey<2>>::traverse_by_key([0].into_keys(), f),
+        Option::<i32>::traverse_by_key([0usize; 0].into_keys(), f),
+        Ok(0)
+    );
+    assert_eq!(
+        <Option::<S> as TreeKey<2>>::traverse_by_key([0usize].into_keys(), f),
         Err(Traversal::NotFound(1).into())
     );
     assert_eq!(
-        <Option::<S> as TreeKey<2>>::traverse_by_key([0; 0].into_keys(), f),
+        <Option::<S> as TreeKey<2>>::traverse_by_key([0usize; 0].into_keys(), f),
         Err(Traversal::TooShort(0).into())
     );
 }

--- a/miniconf/tests/generics.rs
+++ b/miniconf/tests/generics.rs
@@ -15,7 +15,7 @@ fn generic_type() {
     assert_eq!(settings.data, 3.0);
 
     // Test metadata
-    let metadata = Settings::<f32>::walk::<Metadata>().unwrap();
+    let metadata = Settings::<f32>::traverse_all::<Metadata>().unwrap();
     assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "data".len());
     assert_eq!(metadata.count, 1);
@@ -35,7 +35,7 @@ fn generic_array() {
     assert_eq!(settings.data[0], 3.0);
 
     // Test metadata
-    let metadata = Settings::<f32>::walk::<Metadata>().unwrap();
+    let metadata = Settings::<f32>::traverse_all::<Metadata>().unwrap();
     assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_length("/"), "/data/0".len());
     assert_eq!(metadata.count, 2);
@@ -59,7 +59,7 @@ fn generic_struct() {
     assert_eq!(settings.inner.data, 3.0);
 
     // Test metadata
-    let metadata = Settings::<Inner>::walk::<Metadata>().unwrap();
+    let metadata = Settings::<Inner>::traverse_all::<Metadata>().unwrap();
     assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length("/"), "/inner".len());
     assert_eq!(metadata.count, 1);
@@ -87,7 +87,7 @@ fn generic_atomic() {
     assert_eq!(settings.atomic.inner[0], 3.0);
 
     // Test metadata
-    let metadata = Settings::<f32>::walk::<Metadata>().unwrap();
+    let metadata = Settings::<f32>::traverse_all::<Metadata>().unwrap();
     assert_eq!(metadata.max_depth, 3);
     assert_eq!(metadata.max_length("/"), "/opt1/0/0".len());
 }
@@ -116,7 +116,7 @@ fn test_depth() {
     #[derive(Tree)]
     struct S<T>(#[tree(depth = 3)] Option<Option<T>>);
     // works as array implements Tree<1>
-    S::<[u32; 1]>::walk::<Metadata>().unwrap();
+    S::<[u32; 1]>::traverse_all::<Metadata>().unwrap();
     // does not compile as u32 does not implement Tree<1>
-    // S::<u32>::walk::<Metadata>();
+    // S::<u32>::traverse_all::<Metadata>();
 }

--- a/miniconf/tests/generics.rs
+++ b/miniconf/tests/generics.rs
@@ -15,7 +15,7 @@ fn generic_type() {
     assert_eq!(settings.data, 3.0);
 
     // Test metadata
-    let metadata = Settings::<f32>::metadata();
+    let metadata = Settings::<f32>::path_metadata();
     assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "data".len());
     assert_eq!(metadata.count, 1);
@@ -35,7 +35,7 @@ fn generic_array() {
     assert_eq!(settings.data[0], 3.0);
 
     // Test metadata
-    let metadata = Settings::<f32>::metadata();
+    let metadata = Settings::<f32>::path_metadata();
     assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_length("/"), "/data/0".len());
     assert_eq!(metadata.count, 2);
@@ -59,7 +59,7 @@ fn generic_struct() {
     assert_eq!(settings.inner.data, 3.0);
 
     // Test metadata
-    let metadata = Settings::<Inner>::metadata();
+    let metadata = Settings::<Inner>::path_metadata();
     assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length("/"), "/inner".len());
     assert_eq!(metadata.count, 1);
@@ -87,7 +87,7 @@ fn generic_atomic() {
     assert_eq!(settings.atomic.inner[0], 3.0);
 
     // Test metadata
-    let metadata = Settings::<f32>::metadata();
+    let metadata = Settings::<f32>::path_metadata();
     assert_eq!(metadata.max_depth, 3);
     assert_eq!(metadata.max_length("/"), "/opt1/0/0".len());
 }
@@ -116,7 +116,7 @@ fn test_depth() {
     #[derive(Tree)]
     struct S<T>(#[tree(depth = 3)] Option<Option<T>>);
     // works as array implements Tree<1>
-    S::<[u32; 1]>::metadata();
+    S::<[u32; 1]>::path_metadata();
     // does not compile as u32 does not implement Tree<1>
     // S::<u32>::metadata();
 }

--- a/miniconf/tests/generics.rs
+++ b/miniconf/tests/generics.rs
@@ -15,7 +15,7 @@ fn generic_type() {
     assert_eq!(settings.data, 3.0);
 
     // Test metadata
-    let metadata = Settings::<f32>::walk::<Metadata>();
+    let metadata = Settings::<f32>::walk::<Metadata>().unwrap();
     assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "data".len());
     assert_eq!(metadata.count, 1);
@@ -35,7 +35,7 @@ fn generic_array() {
     assert_eq!(settings.data[0], 3.0);
 
     // Test metadata
-    let metadata = Settings::<f32>::walk::<Metadata>();
+    let metadata = Settings::<f32>::walk::<Metadata>().unwrap();
     assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_length("/"), "/data/0".len());
     assert_eq!(metadata.count, 2);
@@ -59,7 +59,7 @@ fn generic_struct() {
     assert_eq!(settings.inner.data, 3.0);
 
     // Test metadata
-    let metadata = Settings::<Inner>::walk::<Metadata>();
+    let metadata = Settings::<Inner>::walk::<Metadata>().unwrap();
     assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length("/"), "/inner".len());
     assert_eq!(metadata.count, 1);
@@ -87,7 +87,7 @@ fn generic_atomic() {
     assert_eq!(settings.atomic.inner[0], 3.0);
 
     // Test metadata
-    let metadata = Settings::<f32>::walk::<Metadata>();
+    let metadata = Settings::<f32>::walk::<Metadata>().unwrap();
     assert_eq!(metadata.max_depth, 3);
     assert_eq!(metadata.max_length("/"), "/opt1/0/0".len());
 }
@@ -97,8 +97,8 @@ fn test_derive_macro_bound_failure() {
     // The derive macro uses a simplistic approach to adding bounds
     // for generic types.
     // This is analogous to other standard derive macros.
-    // See also the documentation for the [Tree] trait
-    // and the code comments in the derive macro ([StructField::walk_type]
+    // See also the documentation for the Tree traits
+    // and the code comments in the derive macro
     // on adding bounds to generics.
     // This test below shows the issue and tests whether the workaround of
     // adding the required traits by hand works.
@@ -116,7 +116,7 @@ fn test_depth() {
     #[derive(Tree)]
     struct S<T>(#[tree(depth = 3)] Option<Option<T>>);
     // works as array implements Tree<1>
-    S::<[u32; 1]>::walk::<Metadata>();
+    S::<[u32; 1]>::walk::<Metadata>().unwrap();
     // does not compile as u32 does not implement Tree<1>
     // S::<u32>::walk::<Metadata>();
 }

--- a/miniconf/tests/generics.rs
+++ b/miniconf/tests/generics.rs
@@ -1,6 +1,6 @@
 use core::any::Any;
 
-use miniconf::{json, Deserialize, Serialize, Tree, TreeKey};
+use miniconf::{json, Deserialize, Metadata, Serialize, Tree, TreeKey};
 use serde::de::DeserializeOwned;
 
 #[test]
@@ -15,7 +15,7 @@ fn generic_type() {
     assert_eq!(settings.data, 3.0);
 
     // Test metadata
-    let metadata = Settings::<f32>::path_metadata();
+    let metadata = Settings::<f32>::walk::<Metadata>();
     assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length, "data".len());
     assert_eq!(metadata.count, 1);
@@ -35,7 +35,7 @@ fn generic_array() {
     assert_eq!(settings.data[0], 3.0);
 
     // Test metadata
-    let metadata = Settings::<f32>::path_metadata();
+    let metadata = Settings::<f32>::walk::<Metadata>();
     assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_length("/"), "/data/0".len());
     assert_eq!(metadata.count, 2);
@@ -59,7 +59,7 @@ fn generic_struct() {
     assert_eq!(settings.inner.data, 3.0);
 
     // Test metadata
-    let metadata = Settings::<Inner>::path_metadata();
+    let metadata = Settings::<Inner>::walk::<Metadata>();
     assert_eq!(metadata.max_depth, 1);
     assert_eq!(metadata.max_length("/"), "/inner".len());
     assert_eq!(metadata.count, 1);
@@ -87,7 +87,7 @@ fn generic_atomic() {
     assert_eq!(settings.atomic.inner[0], 3.0);
 
     // Test metadata
-    let metadata = Settings::<f32>::path_metadata();
+    let metadata = Settings::<f32>::walk::<Metadata>();
     assert_eq!(metadata.max_depth, 3);
     assert_eq!(metadata.max_length("/"), "/opt1/0/0".len());
 }
@@ -116,7 +116,7 @@ fn test_depth() {
     #[derive(Tree)]
     struct S<T>(#[tree(depth = 3)] Option<Option<T>>);
     // works as array implements Tree<1>
-    S::<[u32; 1]>::path_metadata();
+    S::<[u32; 1]>::walk::<Metadata>();
     // does not compile as u32 does not implement Tree<1>
-    // S::<u32>::metadata();
+    // S::<u32>::walk::<Metadata>();
 }

--- a/miniconf/tests/packed.rs
+++ b/miniconf/tests/packed.rs
@@ -63,7 +63,7 @@ fn top() {
             .collect::<Vec<_>>(),
         [(Indices([1, 0]), Node::leaf(1))]
     );
-    let (p, node) = S::transcode::<Packed, _>([1]).unwrap();
+    let (p, node) = S::transcode::<Packed, _>([1usize]).unwrap();
     assert_eq!((p.into_lsb().get(), node), (0b11, Node::leaf(1)));
     assert_eq!(
         S::nodes::<Packed>()

--- a/miniconf/tests/skipped.rs
+++ b/miniconf/tests/skipped.rs
@@ -22,11 +22,11 @@ fn meta() {
 #[test]
 fn path() {
     assert_eq!(
-        Settings::transcode::<Path<String, '/'>, _>([0]),
+        Settings::transcode::<Path<String, '/'>, _>([0usize]),
         Ok((Path("/value".to_owned()), Node::leaf(1)))
     );
     assert_eq!(
-        Settings::transcode::<Path<String, '/'>, _>([1]),
+        Settings::transcode::<Path<String, '/'>, _>([1usize]),
         Err(Traversal::NotFound(1))
     );
 }

--- a/miniconf/tests/skipped.rs
+++ b/miniconf/tests/skipped.rs
@@ -13,7 +13,7 @@ struct Settings {
 
 #[test]
 fn meta() {
-    let meta = Settings::walk::<Metadata>().unwrap();
+    let meta = Settings::traverse_all::<Metadata>().unwrap();
     assert_eq!(meta.max_depth, 1);
     assert_eq!(meta.max_length("/"), "/value".len());
     assert_eq!(meta.count, 1);

--- a/miniconf/tests/skipped.rs
+++ b/miniconf/tests/skipped.rs
@@ -13,7 +13,7 @@ struct Settings {
 
 #[test]
 fn meta() {
-    let meta = Settings::metadata();
+    let meta = Settings::path_metadata();
     assert_eq!(meta.max_depth, 1);
     assert_eq!(meta.max_length("/"), "/value".len());
     assert_eq!(meta.count, 1);

--- a/miniconf/tests/skipped.rs
+++ b/miniconf/tests/skipped.rs
@@ -13,7 +13,7 @@ struct Settings {
 
 #[test]
 fn meta() {
-    let meta = Settings::walk::<Metadata>();
+    let meta = Settings::walk::<Metadata>().unwrap();
     assert_eq!(meta.max_depth, 1);
     assert_eq!(meta.max_length("/"), "/value".len());
     assert_eq!(meta.count, 1);

--- a/miniconf/tests/skipped.rs
+++ b/miniconf/tests/skipped.rs
@@ -1,4 +1,4 @@
-use miniconf::{Node, Path, Traversal, Tree, TreeKey};
+use miniconf::{Metadata, Node, Path, Traversal, Tree, TreeKey};
 
 #[derive(Default)]
 pub struct SkippedType;
@@ -13,7 +13,7 @@ struct Settings {
 
 #[test]
 fn meta() {
-    let meta = Settings::path_metadata();
+    let meta = Settings::walk::<Metadata>();
     assert_eq!(meta.max_depth, 1);
     assert_eq!(meta.max_length("/"), "/value".len());
     assert_eq!(meta.count, 1);

--- a/miniconf/tests/structs.rs
+++ b/miniconf/tests/structs.rs
@@ -37,7 +37,7 @@ fn structs() {
     assert_eq!(settings.d, Inner { a: 3 });
 
     // Check that metadata is correct.
-    let metadata = Settings::metadata();
+    let metadata = Settings::path_metadata();
     assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_length("/"), "/d/a".len());
     assert_eq!(metadata.count, 4);

--- a/miniconf/tests/structs.rs
+++ b/miniconf/tests/structs.rs
@@ -39,7 +39,7 @@ fn structs() {
     assert_eq!(settings.d, Inner { a: 3 });
 
     // Check that metadata is correct.
-    let metadata = Settings::walk::<Metadata>().unwrap();
+    let metadata = Settings::traverse_all::<Metadata>().unwrap();
     assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_length("/"), "/d/a".len());
     assert_eq!(metadata.count, 4);

--- a/miniconf/tests/structs.rs
+++ b/miniconf/tests/structs.rs
@@ -39,7 +39,7 @@ fn structs() {
     assert_eq!(settings.d, Inner { a: 3 });
 
     // Check that metadata is correct.
-    let metadata = Settings::walk::<Metadata>();
+    let metadata = Settings::walk::<Metadata>().unwrap();
     assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_length("/"), "/d/a".len());
     assert_eq!(metadata.count, 4);

--- a/miniconf/tests/structs.rs
+++ b/miniconf/tests/structs.rs
@@ -1,4 +1,6 @@
-use miniconf::{json, Deserialize, Serialize, Tree, TreeDeserialize, TreeKey, TreeSerialize};
+use miniconf::{
+    json, Deserialize, Metadata, Serialize, Tree, TreeDeserialize, TreeKey, TreeSerialize,
+};
 
 mod common;
 use common::*;
@@ -37,7 +39,7 @@ fn structs() {
     assert_eq!(settings.d, Inner { a: 3 });
 
     // Check that metadata is correct.
-    let metadata = Settings::path_metadata();
+    let metadata = Settings::walk::<Metadata>();
     assert_eq!(metadata.max_depth, 2);
     assert_eq!(metadata.max_length("/"), "/d/a".len());
     assert_eq!(metadata.count, 4);

--- a/miniconf_derive/src/field.rs
+++ b/miniconf_derive/src/field.rs
@@ -62,7 +62,7 @@ impl TreeField {
         if depth > 0 {
             let typ = self.typ();
             quote_spanned! { self.span()=>
-                <#typ as ::miniconf::TreeKey<#depth>>::walk()
+                <#typ as ::miniconf::TreeKey<#depth>>::walk()?
             }
         } else {
             quote_spanned! { self.span()=>

--- a/miniconf_derive/src/field.rs
+++ b/miniconf_derive/src/field.rs
@@ -57,6 +57,20 @@ impl TreeField {
         }
     }
 
+    pub fn walk(&self) -> TokenStream {
+        let depth = self.depth;
+        if depth > 0 {
+            let typ = self.typ();
+            quote_spanned! { self.span()=>
+                <#typ as ::miniconf::TreeKey<#depth>>::walk()
+            }
+        } else {
+            quote_spanned! { self.span()=>
+                M::one()
+            }
+        }
+    }
+
     pub fn metadata(&self, i: usize) -> TokenStream {
         // Quote context is a match of the field index with `metadata()` args available.
         let depth = self.depth;

--- a/miniconf_derive/src/field.rs
+++ b/miniconf_derive/src/field.rs
@@ -66,26 +66,7 @@ impl TreeField {
             }
         } else {
             quote_spanned! { self.span()=>
-                M::one()
-            }
-        }
-    }
-
-    pub fn metadata(&self, i: usize) -> TokenStream {
-        // Quote context is a match of the field index with `metadata()` args available.
-        let depth = self.depth;
-        if depth > 0 {
-            let typ = self.typ();
-            quote_spanned! { self.span()=>
-                let m = <#typ as ::miniconf::TreeKey<#depth>>::metadata();
-                meta.max_length = meta.max_length.max(ident_len(#i) + m.max_length);
-                meta.max_depth = meta.max_depth.max(m.max_depth);
-                meta.count += m.count;
-            }
-        } else {
-            quote_spanned! { self.span()=>
-                meta.max_length = meta.max_length.max(ident_len(#i));
-                meta.count += 1;
+                M::leaf()
             }
         }
     }

--- a/miniconf_derive/src/field.rs
+++ b/miniconf_derive/src/field.rs
@@ -66,7 +66,7 @@ impl TreeField {
             }
         } else {
             quote_spanned! { self.span()=>
-                M::leaf()
+                W::leaf()
             }
         }
     }

--- a/miniconf_derive/src/field.rs
+++ b/miniconf_derive/src/field.rs
@@ -57,12 +57,12 @@ impl TreeField {
         }
     }
 
-    pub fn walk(&self) -> TokenStream {
+    pub fn traverse_all(&self) -> TokenStream {
         let depth = self.depth;
         if depth > 0 {
             let typ = self.typ();
             quote_spanned! { self.span()=>
-                <#typ as ::miniconf::TreeKey<#depth>>::walk()?
+                <#typ as ::miniconf::TreeKey<#depth>>::traverse_all()?
             }
         } else {
             quote_spanned! { self.span()=>

--- a/miniconf_derive/src/tree.rs
+++ b/miniconf_derive/src/tree.rs
@@ -145,8 +145,8 @@ impl Tree {
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
         let fields = self.fields();
         let fields_len = fields.len();
-        let walk_arms = fields.iter().enumerate().map(|(i, f)| {
-            let w = f.walk();
+        let traverse_all_arms = fields.iter().enumerate().map(|(i, f)| {
+            let w = f.traverse_all();
             if self.flatten.is_present() {
                 quote!(walk = #w;)
             } else {
@@ -237,10 +237,10 @@ impl Tree {
 
             #[automatically_derived]
             impl #impl_generics ::miniconf::TreeKey<#depth> for #ident #ty_generics #where_clause {
-                fn walk<W: ::miniconf::Walk>() -> ::core::result::Result<W, W::Error> {
+                fn traverse_all<W: ::miniconf::Walk>() -> ::core::result::Result<W, W::Error> {
                     #[allow(unused_mut)]
                     let mut walk = W::internal();
-                    #(#walk_arms)*
+                    #(#traverse_all_arms)*
                     Ok(walk)
                 }
 

--- a/miniconf_derive/src/tree.rs
+++ b/miniconf_derive/src/tree.rs
@@ -150,7 +150,7 @@ impl Tree {
             if self.flatten.is_present() {
                 quote!(walk = #w;)
             } else {
-                quote!(walk.merge(Some(#i), &#w, &Self::__MINICONF_LOOKUP);)
+                quote!(walk.merge(&#w, Some(#i), &Self::__MINICONF_LOOKUP);)
             }
         });
         let traverse_arms = fields

--- a/miniconf_derive/src/tree.rs
+++ b/miniconf_derive/src/tree.rs
@@ -238,7 +238,8 @@ impl Tree {
             #[automatically_derived]
             impl #impl_generics ::miniconf::TreeKey<#depth> for #ident #ty_generics #where_clause {
                 fn walk<W: ::miniconf::Walk>() -> ::core::result::Result<W, W::Error> {
-                    let mut walk = W::inner();
+                    #[allow(unused_mut)]
+                    let mut walk = W::internal();
                     #(#walk_arms)*
                     Ok(walk)
                 }

--- a/miniconf_derive/src/tree.rs
+++ b/miniconf_derive/src/tree.rs
@@ -146,11 +146,11 @@ impl Tree {
         let fields = self.fields();
         let fields_len = fields.len();
         let walk_arms = fields.iter().enumerate().map(|(i, f)| {
-            let m = f.walk();
+            let w = f.walk();
             if self.flatten.is_present() {
-                quote!(meta = #m;)
+                quote!(walk = #w;)
             } else {
-                quote!(meta.merge::<Self>(Some(#i), &#m);)
+                quote!(walk.merge::<Self>(Some(#i), &#w);)
             }
         });
         let traverse_arms = fields
@@ -244,10 +244,10 @@ impl Tree {
 
             #[automatically_derived]
             impl #impl_generics ::miniconf::TreeKey<#depth> for #ident #ty_generics #where_clause {
-                fn walk<M: ::miniconf::Meta>() -> M {
-                    let mut meta = M::default();
+                fn walk<W: ::miniconf::Walk>() -> W {
+                    let mut walk = W::default();
                     #(#walk_arms)*
-                    meta
+                    walk
                 }
 
                 fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> ::core::result::Result<usize, ::miniconf::Error<E>>

--- a/miniconf_derive/src/tree.rs
+++ b/miniconf_derive/src/tree.rs
@@ -191,21 +191,7 @@ impl Tree {
             (
                 quote!(::miniconf::Keys::next(&mut keys, &Self::__MINICONF_LOOKUP)?),
                 Some(quote! {
-                    let name = match Self::__MINICONF_LOOKUP.names {
-                        ::core::option::Option::Some(names) => {
-                            Some(
-                                *names
-                                    .get(index)
-                                    .ok_or(::miniconf::Traversal::NotFound(1))?
-                            )
-                        }
-                        ::core::option::Option::None => {
-                            if index >= Self::__MINICONF_LOOKUP.len {
-                                ::core::result::Result::Err(::miniconf::Traversal::NotFound(1))?
-                            }
-                            ::core::option::Option::None
-                        }
-                    };
+                    let name = Self::__MINICONF_LOOKUP.lookup(index)?;
                     func(index, name, Self::__MINICONF_LOOKUP.len)
                     .map_err(|err| ::miniconf::Error::Inner(1, err))?;
                 }),

--- a/miniconf_derive/src/tree.rs
+++ b/miniconf_derive/src/tree.rs
@@ -150,7 +150,7 @@ impl Tree {
             if self.flatten.is_present() {
                 quote!(walk = #w;)
             } else {
-                quote!(walk.merge(&#w, Some(#i), &Self::__MINICONF_LOOKUP);)
+                quote!(walk = walk.merge(&#w, Some(#i), &Self::__MINICONF_LOOKUP)?;)
             }
         });
         let traverse_arms = fields
@@ -237,10 +237,10 @@ impl Tree {
 
             #[automatically_derived]
             impl #impl_generics ::miniconf::TreeKey<#depth> for #ident #ty_generics #where_clause {
-                fn walk<W: ::miniconf::Walk>() -> W {
+                fn walk<W: ::miniconf::Walk>() -> ::core::result::Result<W, W::Error> {
                     let mut walk = W::inner();
                     #(#walk_arms)*
-                    walk
+                    Ok(walk)
                 }
 
                 fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> ::core::result::Result<usize, ::miniconf::Error<E>>

--- a/miniconf_derive/src/tree.rs
+++ b/miniconf_derive/src/tree.rs
@@ -147,6 +147,14 @@ impl Tree {
         let fields = self.fields();
         let fields_len = fields.len();
         let metadata_arms = fields.iter().enumerate().map(|(i, f)| f.metadata(i));
+        let walk_arms = fields.iter().enumerate().map(|(i, f)| {
+            let m = f.walk();
+            if self.flatten.is_present() {
+                quote!(meta = #m;)
+            } else {
+                quote!(meta.merge::<Self>(Some(#i), &#m);)
+            }
+        });
         let traverse_arms = fields
             .iter()
             .enumerate()
@@ -246,6 +254,12 @@ impl Tree {
                     let ident_len = |index: usize| { #ident_len };
                     #(#metadata_arms)*
                     meta.max_depth += #level;
+                    meta
+                }
+
+                fn walk<M: ::miniconf::Meta>() -> M {
+                    let mut meta = M::default();
+                    #(#walk_arms)*
                     meta
                 }
 

--- a/miniconf_mqtt/src/lib.rs
+++ b/miniconf_mqtt/src/lib.rs
@@ -251,7 +251,7 @@ where
     ) -> Result<Self, ProtocolError> {
         assert_eq!("/".len(), SEPARATOR.len_utf8());
         assert!(
-            prefix.len() + "/settings".len() + Settings::metadata().max_length("/")
+            prefix.len() + "/settings".len() + Settings::path_metadata().max_length("/")
                 <= MAX_TOPIC_LENGTH
         );
 

--- a/miniconf_mqtt/src/lib.rs
+++ b/miniconf_mqtt/src/lib.rs
@@ -252,7 +252,9 @@ where
     ) -> Result<Self, ProtocolError> {
         assert_eq!("/".len(), SEPARATOR.len_utf8());
         assert!(
-            prefix.len() + "/settings".len() + Settings::walk::<Metadata>().max_length("/")
+            prefix.len()
+                + "/settings".len()
+                + Settings::walk::<Metadata>().unwrap().max_length("/")
                 <= MAX_TOPIC_LENGTH
         );
 

--- a/miniconf_mqtt/src/lib.rs
+++ b/miniconf_mqtt/src/lib.rs
@@ -10,7 +10,8 @@ use core::fmt::Display;
 use heapless::{String, Vec};
 use log::{error, info, warn};
 use miniconf::{
-    json, IntoKeys, NodeIter, Path, Traversal, TreeDeserializeOwned, TreeKey, TreeSerialize,
+    json, IntoKeys, Metadata, NodeIter, Path, Traversal, TreeDeserializeOwned, TreeKey,
+    TreeSerialize,
 };
 pub use minimq;
 use minimq::{
@@ -251,7 +252,7 @@ where
     ) -> Result<Self, ProtocolError> {
         assert_eq!("/".len(), SEPARATOR.len_utf8());
         assert!(
-            prefix.len() + "/settings".len() + Settings::path_metadata().max_length("/")
+            prefix.len() + "/settings".len() + Settings::walk::<Metadata>().max_length("/")
                 <= MAX_TOPIC_LENGTH
         );
 

--- a/miniconf_mqtt/src/lib.rs
+++ b/miniconf_mqtt/src/lib.rs
@@ -254,7 +254,9 @@ where
         assert!(
             prefix.len()
                 + "/settings".len()
-                + Settings::walk::<Metadata>().unwrap().max_length("/")
+                + Settings::traverse_all::<Metadata>()
+                    .unwrap()
+                    .max_length("/")
                 <= MAX_TOPIC_LENGTH
         );
 


### PR DESCRIPTION
- **force and use FusedIterator for KeysIter**
- **name_to_index -> NAMES**
- **[wip] add walk**
- **[wip] remove old metadata impls**
- **[wip] rename metadata -> path_metadata**
- **port to walk and remove path_metadata**
- **basic SCPI example**
- **change KeyLookup from trait to struct**
- **style, add a debug check**
- **change Walk::merge() args order**
- **example/scpi: expand**
- **walk: make fallible, use builder pattern**
- **Walk: inner -> internal**
- **walk() -> traverse_all()**
