### PR TITLE
trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * py: a synchronous client version in `miniconf.sync`
 * py: support for response-less (fire and forget) requests in both the synchronous and the asyncio client
 * py: cli support for simple relative paths
+* examples/trace: Tracing reflection with serde-reflection
 
 ### Changed
 
 * py: `await discover_one(...)` -> `one(await discover(...))`
+* serialize_by_key: returns serializer Ok instead of depth
+* deserialize_by_key: returns () instead of depth
+* TreeDeserialize: add probe_by_key() for tracing without sample
+* Walk::internal() takes slice of children by value
+* derive: deserialize validate doesn't receive or return depth
 
 ## [0.18.0](https://github.com/quartiq/miniconf/compare/v0.17.2...v0.18.0) - 2024-11-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "miniconf_mqtt",
 ]
 resolver = "2"
+
+[patch.crates-io]
+serde-reflection = { path = "../serde-reflection/serde-reflection" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,3 @@ members = [
     "miniconf_mqtt",
 ]
 resolver = "2"
-
-[patch.crates-io]
-serde-reflection = { path = "../serde-reflection/serde-reflection" }

--- a/miniconf/Cargo.toml
+++ b/miniconf/Cargo.toml
@@ -44,7 +44,9 @@ yafnv = "3.0.0"
 tokio = { version = "1.38.0", features = ["io-std", "rt", "macros"] }
 strum = { version = "0.26.3", features = ["derive"] }
 trybuild = { version = "1.0.99", features = ["diff"] }
-serde_json = { version = "1.0.133" }
+serde_json = "1.0.133"
+serde-reflection = "0.5"
+indexmap = { version = "2.9", features = ["serde"] }
 
 [[test]]
 name = "arrays"
@@ -109,4 +111,8 @@ required-features = ["json-core", "derive", "postcard"]
 
 [[example]]
 name = "scpi"
+required-features = ["json-core", "derive"]
+
+[[example]]
+name = "trace"
 required-features = ["json-core", "derive"]

--- a/miniconf/Cargo.toml
+++ b/miniconf/Cargo.toml
@@ -47,6 +47,7 @@ trybuild = { version = "1.0.99", features = ["diff"] }
 serde_json = "1.0.133"
 serde-reflection = { version = "0.5", path = "../../serde-reflection/serde-reflection" }
 indexmap = { version = "2.9", features = ["serde"] }
+once_cell = "1.21.3"
 
 [[test]]
 name = "arrays"

--- a/miniconf/Cargo.toml
+++ b/miniconf/Cargo.toml
@@ -46,6 +46,7 @@ strum = { version = "0.27.1", features = ["derive"] }
 trybuild = { version = "1.0.99", features = ["diff"] }
 serde_json = "1.0.133"
 serde-reflection = { version = "0.5", path = "../../serde-reflection/serde-reflection" }
+indexmap = { version = "2.9", features = ["serde"] }
 once_cell = "1.21.3"
 
 [[test]]

--- a/miniconf/Cargo.toml
+++ b/miniconf/Cargo.toml
@@ -45,7 +45,7 @@ tokio = { version = "1.38.0", features = ["io-std", "rt", "macros"] }
 strum = { version = "0.27.1", features = ["derive"] }
 trybuild = { version = "1.0.99", features = ["diff"] }
 serde_json = "1.0.133"
-serde-reflection = { version = "0.5", path = "../../serde-reflection/serde-reflection" }
+serde-reflection = { version = "0.5", git = "https://github.com/quartiq/serde-reflection.git", branch = "pub-ser-de" }
 indexmap = { version = "2.9", features = ["serde"] }
 once_cell = "1.21.3"
 

--- a/miniconf/Cargo.toml
+++ b/miniconf/Cargo.toml
@@ -46,7 +46,6 @@ strum = { version = "0.27.1", features = ["derive"] }
 trybuild = { version = "1.0.99", features = ["diff"] }
 serde_json = "1.0.133"
 serde-reflection = { version = "0.5", path = "../../serde-reflection/serde-reflection" }
-indexmap = { version = "2.9", features = ["serde"] }
 once_cell = "1.21.3"
 
 [[test]]

--- a/miniconf/Cargo.toml
+++ b/miniconf/Cargo.toml
@@ -42,10 +42,10 @@ embedded-io-adapters = { version = "0.6.1", features = ["tokio-1"] }
 heapless = "0.8.0"
 yafnv = "3.0.0"
 tokio = { version = "1.38.0", features = ["io-std", "rt", "macros"] }
-strum = { version = "0.26.3", features = ["derive"] }
+strum = { version = "0.27.1", features = ["derive"] }
 trybuild = { version = "1.0.99", features = ["diff"] }
 serde_json = "1.0.133"
-serde-reflection = "0.5"
+serde-reflection = { version = "0.5", path = "../../serde-reflection/serde-reflection" }
 indexmap = { version = "2.9", features = ["serde"] }
 
 [[test]]

--- a/miniconf/examples/cli.rs
+++ b/miniconf/examples/cli.rs
@@ -2,15 +2,13 @@ use anyhow::Context;
 use miniconf::{json, Error, Path, Traversal, TreeKey};
 
 mod common;
-use common::Settings;
 
 // Simple command line interface example for miniconf.
 // This exposes all leaf nodes as long options, parses the command line,
 // and then prints the settings struct as a list of option key-value pairs.
 
 fn main() -> anyhow::Result<()> {
-    let mut settings = Settings::default();
-    settings.enable();
+    let mut settings = common::Settings::new();
 
     // Parse args
     let mut args = std::env::args().skip(1);
@@ -23,7 +21,7 @@ fn main() -> anyhow::Result<()> {
 
     // Dump settings
     let mut buf = vec![0; 1024];
-    for (key, _node) in Settings::nodes::<Path<String, '-'>, 4>().map(Result::unwrap) {
+    for (key, _node) in common::Settings::nodes::<Path<String, '-'>, 4>().map(Result::unwrap) {
         match json::get_by_key(&settings, &key, &mut buf[..]) {
             Ok(len) => {
                 println!(

--- a/miniconf/examples/common.rs
+++ b/miniconf/examples/common.rs
@@ -42,6 +42,13 @@ pub struct Settings {
 }
 
 impl Settings {
+    /// Create a new enabled Settings
+    pub fn new() -> Self {
+        let mut s = Self::default();
+        s.enable();
+        s
+    }
+
     /// Fill some of the Options
     pub fn enable(&mut self) {
         self.option_tree = Some(8.into());

--- a/miniconf/examples/menu.rs
+++ b/miniconf/examples/menu.rs
@@ -274,8 +274,7 @@ where
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     let mut buf = vec![0; 1024];
-    let mut s = common::Settings::default();
-    s.enable();
+    let mut s = common::Settings::new();
 
     let mut stdout = embedded_io_adapters::tokio_1::FromTokio::new(tokio::io::stdout());
     let mut stdin = tokio::io::BufReader::new(tokio::io::stdin()).lines();
@@ -301,8 +300,7 @@ mod test {
     #[tokio::test]
     async fn test() {
         let mut buf = vec![0; 1024];
-        let mut s = common::Settings::default();
-        s.enable();
+        let mut s = common::Settings::new();
 
         let mut stdout = embedded_io_adapters::tokio_1::FromTokio::new(tokio::io::stdout());
         let mut menu = Menu::default();

--- a/miniconf/examples/scpi.rs
+++ b/miniconf/examples/scpi.rs
@@ -5,7 +5,6 @@ use miniconf::{
 };
 
 mod common;
-use common::Settings;
 
 /// This show-cases the implementation of a custom [`miniconf::Key`]
 /// along the lines of SCPI style hierarchies. It is case-insensitive and
@@ -134,8 +133,7 @@ impl<M: TreeSerialize + TreeDeserializeOwned> ScpiCtrl<M> {
 }
 
 fn main() -> anyhow::Result<()> {
-    let mut settings = Settings::default();
-    settings.enable();
+    let settings = common::Settings::new();
     let mut ctrl = ScpiCtrl::new(settings);
 
     ctrl.cmd("fO?; foo?; FOO?; :FOO?; :ARRAY_OPT:1:A?; A?; A?; A 1; A?; :FOO?")?;

--- a/miniconf/examples/trace.rs
+++ b/miniconf/examples/trace.rs
@@ -252,6 +252,10 @@ impl<T> Graph<T> {
                         fmt.reduce();
                         *format = Some(fmt);
                     }
+                    Err(Error::Traversal(Traversal::Invalid(_depth, msg))) => {
+                        Err(serde_reflection::Error::DeserializationError(msg))?
+                    }
+                    Err(Error::Traversal(Traversal::Access(_depth, _msg))) => {}
                     Err(Error::Inner(_depth, e)) => Err(e)?,
                     _ => unreachable!(),
                 }

--- a/miniconf/examples/trace.rs
+++ b/miniconf/examples/trace.rs
@@ -1,0 +1,241 @@
+use core::num::NonZero;
+use indexmap::IndexMap;
+use std::hash::Hash;
+
+use anyhow::Context;
+use serde::Serialize;
+use serde_reflection::{
+    Deserializer, Format, FormatHolder, Registry, Samples, Serializer, TracerConfig, Value,
+};
+
+use miniconf::{
+    Error, IntoKeys, KeyLookup, Path, Traversal, TreeDeserialize, TreeKey, TreeSerialize, Walk,
+};
+
+mod common;
+use common::Settings;
+
+#[derive(Clone, Serialize)]
+#[serde(untagged)]
+enum Node<'a> {
+    Leaf(Option<&'a Format>),
+    Named(IndexMap<&'static str, Node<'a>>),
+    Homogeneous {
+        len: NonZero<usize>,
+        item: Box<Node<'a>>,
+    },
+    Numbered(Vec<Node<'a>>),
+}
+
+impl Walk for Node<'_> {
+    type Error = core::convert::Infallible;
+
+    fn internal(children: &[&Self], lookup: &KeyLookup) -> Result<Self, Self::Error> {
+        Ok(match lookup {
+            KeyLookup::Named(names) => Self::Named(IndexMap::from_iter(
+                names.iter().copied().zip(children.iter().copied().cloned()),
+            )),
+            KeyLookup::Homogeneous(len) => Self::Homogeneous {
+                len: *len,
+                item: Box::new((*children.first().unwrap()).clone()),
+            },
+            KeyLookup::Numbered(_len) => {
+                Self::Numbered(children.iter().copied().cloned().collect())
+            }
+        })
+    }
+
+    fn leaf() -> Self {
+        Self::Leaf(None)
+    }
+}
+
+impl Node<'_> {
+    fn keys(&self, mut root: Vec<usize>) -> Vec<Vec<usize>> {
+        match self {
+            Self::Leaf(_) => vec![root],
+            Self::Homogeneous { item, .. } => {
+                root.push(0);
+                item.keys(root)
+            }
+            Self::Named(map, ..) => map
+                .values()
+                .enumerate()
+                .flat_map(|(i, child)| {
+                    let mut idx = root.clone();
+                    idx.push(i);
+                    child.keys(idx)
+                })
+                .collect(),
+            Self::Numbered(children) => children
+                .iter()
+                .enumerate()
+                .flat_map(|(i, child)| {
+                    let mut idx = root.clone();
+                    idx.push(i);
+                    child.keys(idx)
+                })
+                .collect(),
+        }
+    }
+}
+// fn lookup(&self) -> Option<KeyLookup> {
+//     match self {
+//         Self::Leaf => None,
+//         Self::Homogeneous { len, .. } => Some(KeyLookup::Homogeneous(*len)),
+//         Self::Named(_map, names) => Some(KeyLookup::Named(names)),
+//         Self::Numbered(children) => {
+//             Some(KeyLookup::Numbered(NonZero::new(children.len()).unwrap()))
+//         }
+//     }
+// }
+
+pub struct Tracer {
+    tracer: serde_reflection::Tracer,
+}
+
+impl Tracer {
+    pub fn new(config: TracerConfig) -> Self {
+        Self {
+            tracer: serde_reflection::Tracer::new(config),
+        }
+    }
+
+    pub fn registry(self) -> serde_reflection::Result<Registry> {
+        self.tracer.registry()
+    }
+
+    pub fn trace_value<T: TreeSerialize, K: IntoKeys>(
+        &mut self,
+        samples: &mut Samples,
+        value: &T,
+        keys: K,
+    ) -> Result<(Format, Value), Error<serde_reflection::Error>> {
+        value.serialize_by_key(keys.into_keys(), Serializer::new(&mut self.tracer, samples))
+    }
+
+    pub fn trace_values<T, I, K>(
+        &mut self,
+        samples: &mut Samples,
+        value: &T,
+        keys: I,
+    ) -> Result<IndexMap<K, (Format, Value)>, Error<serde_reflection::Error>>
+    where
+        T: TreeSerialize,
+        I: IntoIterator<Item = K>,
+        K: IntoKeys + Clone + Hash + Eq,
+    {
+        keys.into_iter()
+            .filter_map(
+                |keys| match self.trace_value(samples, value, keys.clone()) {
+                    Ok((mut format, value)) => {
+                        format.reduce();
+                        Some(Ok((keys, (format, value))))
+                    }
+                    Err(Error::Traversal(
+                        Traversal::Absent(_depth) | Traversal::Access(_depth, _),
+                    )) => None,
+                    Err(e) => Some(Err(e)),
+                },
+            )
+            .collect()
+    }
+
+    pub fn trace_type_once<'de, T: TreeDeserialize<'de>, K: IntoKeys>(
+        &mut self,
+        samples: &'de Samples,
+        value: &mut T,
+        keys: K,
+    ) -> Result<Format, Error<serde_reflection::Error>> {
+        let mut format = Format::unknown();
+        value.deserialize_by_key(
+            keys.into_keys(),
+            Deserializer::new(&mut self.tracer, samples, &mut format),
+        )?;
+        format.reduce();
+        Ok(format)
+    }
+
+    pub fn trace_type<'de, T: TreeDeserialize<'de>, K: IntoKeys + Clone>(
+        &mut self,
+        samples: &'de Samples,
+        value: &mut T,
+        keys: K,
+    ) -> Result<Format, Error<serde_reflection::Error>> {
+        loop {
+            let format = self.trace_type_once(samples, value, keys.clone())?;
+            if let Format::TypeName(name) = &format {
+                if self.tracer.incomplete_enums.remove(name).is_some() {
+                    // Restart the analysis to find more variants.
+                    continue;
+                }
+            }
+            return Ok(format);
+        }
+    }
+
+    pub fn trace_types<'de, 'b, T, I, K>(
+        &mut self,
+        samples: &'de Samples,
+        value: &mut T,
+        keys: I,
+    ) -> Result<IndexMap<K, Format>, Error<serde_reflection::Error>>
+    where
+        T: TreeDeserialize<'de>,
+        I: IntoIterator<Item = K>,
+        K: IntoKeys + Clone + Hash + Eq,
+    {
+        keys.into_iter()
+            .filter_map(|keys| match self.trace_type(samples, value, keys.clone()) {
+                Ok(mut format) => {
+                    format.reduce();
+                    Some(Ok((keys, format)))
+                }
+                Err(Error::Traversal(Traversal::Absent(_depth) | Traversal::Access(_depth, _))) => {
+                    None
+                }
+                Err(e) => Some(Err(e)),
+            })
+            .collect()
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let mut settings = Settings::default();
+    settings.enable();
+
+    let graph: Node = Settings::traverse_all()?;
+    println!("{}", serde_json::to_string_pretty(&graph).context("graph")?);
+    let keys = graph.keys(vec![]);
+    let config = TracerConfig::default();
+    let mut tracer = Tracer::new(config);
+    let mut samples = Samples::new();
+    let keys_slice = keys.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let _formats = tracer
+        .trace_values(&mut samples, &settings, keys_slice.iter().copied())
+        .unwrap(); // uncovered variants
+    let formats = tracer
+        .trace_types(&samples, &mut settings, keys_slice)
+        .unwrap();
+    let formats_paths: IndexMap<_, _> = formats
+        .iter()
+        .map(|(key, format)| {
+            (
+                Settings::transcode::<Path<String, '/'>, _>(*key)
+                    .unwrap()
+                    .0
+                    .into_inner(),
+                format,
+            )
+        })
+        .collect();
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&formats_paths).context("formats")?
+    );
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&tracer.registry().unwrap()).context("registry")?
+    );
+    Ok(())
+}

--- a/miniconf/examples/trace.rs
+++ b/miniconf/examples/trace.rs
@@ -30,18 +30,16 @@ enum Node<'a> {
 impl Walk for Node<'_> {
     type Error = core::convert::Infallible;
 
-    fn internal(children: &[&Self], lookup: &KeyLookup) -> Result<Self, Self::Error> {
+    fn internal(children: &[Self], lookup: &KeyLookup) -> Result<Self, Self::Error> {
         Ok(match lookup {
             KeyLookup::Named(names) => Self::Named(IndexMap::from_iter(
-                names.iter().copied().zip(children.iter().copied().cloned()),
+                names.iter().copied().zip(children.iter().cloned()),
             )),
             KeyLookup::Homogeneous(len) => Self::Homogeneous {
                 len: *len,
                 item: Box::new((*children.first().unwrap()).clone()),
             },
-            KeyLookup::Numbered(_len) => {
-                Self::Numbered(children.iter().copied().cloned().collect())
-            }
+            KeyLookup::Numbered(_len) => Self::Numbered(children.iter().cloned().collect()),
         })
     }
 

--- a/miniconf/src/error.rs
+++ b/miniconf/src/error.rs
@@ -117,13 +117,4 @@ impl<E> Error<E> {
             Self::Finalization(e) => Self::Finalization(e),
         }
     }
-
-    /// Pass a `Result<usize, Error<E>>` up one hierarchy depth level, incrementing its usize depth field by one.
-    #[inline]
-    pub fn increment_result(result: Result<usize, Self>) -> Result<usize, Self> {
-        match result {
-            Ok(i) => Ok(i + 1),
-            Err(err) => Err(err.increment()),
-        }
-    }
 }

--- a/miniconf/src/impls.rs
+++ b/miniconf/src/impls.rs
@@ -15,7 +15,7 @@ macro_rules! impl_tuple {
         #[allow(unreachable_code, unused_mut, unused)]
         impl<$($t: TreeKey),+> TreeKey for ($($t,)+) {
             fn traverse_all<W: Walk>() -> Result<W, W::Error> {
-                W::internal(&[$(&$t::traverse_all()?, )+], &KeyLookup::numbered($n))
+                W::internal(&[$($t::traverse_all()?, )+], &KeyLookup::numbered($n))
             }
 
             fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>
@@ -111,7 +111,7 @@ impl<const L: usize, const R: usize> Assert<L, R> {
 impl<T: TreeKey, const N: usize> TreeKey for [T; N] {
     fn traverse_all<W: Walk>() -> Result<W, W::Error> {
         let () = Assert::<N, 0>::GREATER; // internal nodes must have at least one leaf
-        W::internal(&[&T::traverse_all()?], &KeyLookup::homogeneous(N))
+        W::internal(&[T::traverse_all()?], &KeyLookup::homogeneous(N))
     }
 
     fn traverse_by_key<K, F, E>(mut keys: K, mut func: F) -> Result<usize, Error<E>>
@@ -250,7 +250,7 @@ const RESULT_LOOKUP: KeyLookup = KeyLookup::named(&["Ok", "Err"]);
 impl<T: TreeKey, E: TreeKey> TreeKey for Result<T, E> {
     #[inline]
     fn traverse_all<W: Walk>() -> Result<W, W::Error> {
-        W::internal(&[&T::traverse_all()?, &E::traverse_all()?], &RESULT_LOOKUP)
+        W::internal(&[T::traverse_all()?, E::traverse_all()?], &RESULT_LOOKUP)
     }
 
     #[inline]
@@ -336,7 +336,7 @@ const BOUND_LOOKUP: KeyLookup = KeyLookup::named(&["Included", "Excluded"]);
 impl<T: TreeKey> TreeKey for Bound<T> {
     #[inline]
     fn traverse_all<W: Walk>() -> Result<W, W::Error> {
-        W::internal(&[&T::traverse_all()?; 2], &BOUND_LOOKUP)
+        W::internal(&[T::traverse_all()?, T::traverse_all()?], &BOUND_LOOKUP)
     }
 
     #[inline]
@@ -421,7 +421,7 @@ const RANGE_LOOKUP: KeyLookup = KeyLookup::named(&["start", "end"]);
 impl<T: TreeKey> TreeKey for Range<T> {
     #[inline]
     fn traverse_all<W: Walk>() -> Result<W, W::Error> {
-        W::internal(&[&T::traverse_all()?; 2], &RANGE_LOOKUP)
+        W::internal(&[T::traverse_all()?, T::traverse_all()?], &RANGE_LOOKUP)
     }
 
     #[inline]
@@ -504,7 +504,7 @@ impl<T: TreeAny> TreeAny for Range<T> {
 impl<T: TreeKey> TreeKey for RangeInclusive<T> {
     #[inline]
     fn traverse_all<W: Walk>() -> Result<W, W::Error> {
-        W::internal(&[&T::traverse_all()?; 2], &RANGE_LOOKUP)
+        W::internal(&[T::traverse_all()?, T::traverse_all()?], &RANGE_LOOKUP)
     }
 
     #[inline]
@@ -545,7 +545,7 @@ const RANGE_FROM_LOOKUP: KeyLookup = KeyLookup::named(&["start"]);
 impl<T: TreeKey> TreeKey for RangeFrom<T> {
     #[inline]
     fn traverse_all<W: Walk>() -> Result<W, W::Error> {
-        W::internal(&[&T::traverse_all()?], &RANGE_FROM_LOOKUP)
+        W::internal(&[T::traverse_all()?], &RANGE_FROM_LOOKUP)
     }
 
     #[inline]
@@ -626,7 +626,7 @@ const RANGE_TO_LOOKUP: KeyLookup = KeyLookup::named(&["end"]);
 impl<T: TreeKey> TreeKey for RangeTo<T> {
     #[inline]
     fn traverse_all<W: Walk>() -> Result<W, W::Error> {
-        W::internal(&[&T::traverse_all()?], &RANGE_TO_LOOKUP)
+        W::internal(&[T::traverse_all()?], &RANGE_TO_LOOKUP)
     }
 
     #[inline]

--- a/miniconf/src/impls.rs
+++ b/miniconf/src/impls.rs
@@ -64,14 +64,14 @@ macro_rules! impl_tuple {
                 }.map_err(Error::increment)
             }
 
-            fn type_by_key<K, D>(mut keys: K, de: D) -> Result<(), Error<D::Error>>
+            fn probe_by_key<K, D>(mut keys: K, de: D) -> Result<(), Error<D::Error>>
             where
                 K: Keys,
                 D: Deserializer<'de>,
             {
                 let index = keys.next(&KeyLookup::numbered($n))?;
                 match index {
-                    $($i => $t::type_by_key(keys, de),)+
+                    $($i => $t::probe_by_key(keys, de),)+
                     _ => unreachable!()
                 }.map_err(Error::increment)
             }
@@ -166,13 +166,13 @@ impl<'de, T: TreeDeserialize<'de>, const N: usize> TreeDeserialize<'de> for [T; 
             .map_err(Error::increment)
     }
 
-    fn type_by_key<K, D>(mut keys: K, de: D) -> Result<(), Error<D::Error>>
+    fn probe_by_key<K, D>(mut keys: K, de: D) -> Result<(), Error<D::Error>>
     where
         K: Keys,
         D: Deserializer<'de>,
     {
         keys.next(&KeyLookup::homogeneous(N))?;
-        T::type_by_key(keys, de).map_err(Error::increment)
+        T::probe_by_key(keys, de).map_err(Error::increment)
     }
 }
 
@@ -242,12 +242,12 @@ impl<'de, T: TreeDeserialize<'de>> TreeDeserialize<'de> for Option<T> {
     }
 
     #[inline]
-    fn type_by_key<K, D>(keys: K, de: D) -> Result<(), Error<D::Error>>
+    fn probe_by_key<K, D>(keys: K, de: D) -> Result<(), Error<D::Error>>
     where
         K: Keys,
         D: Deserializer<'de>,
     {
-        T::type_by_key(keys, de)
+        T::probe_by_key(keys, de)
     }
 }
 

--- a/miniconf/src/jsonpath.rs
+++ b/miniconf/src/jsonpath.rs
@@ -38,6 +38,13 @@ use crate::{IntoKeys, KeysIter, Node, Transcode, Traversal, TreeKey};
 #[serde(transparent)]
 pub struct JsonPathIter<'a>(&'a str);
 
+impl core::fmt::Display for JsonPathIter<'_> {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl<'a, T> From<&'a T> for JsonPathIter<'a>
 where
     T: AsRef<str> + ?Sized,
@@ -60,10 +67,10 @@ impl<'a> Iterator for JsonPathIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         for (open, close) in [
-            (".'", Continue("'")),         // "'" inclusive
-            (".", Break(&['.', '['][..])), // '.' or '[' exclusive
-            ("['", Continue("']")),        // "']" inclusive
-            ("[", Continue("]")),          // "]" inclusive
+            (".'", Continue("'")),    // "'" inclusive
+            (".", Break(['.', '['])), // '.' or '[' exclusive
+            ("['", Continue("']")),   // "']" inclusive
+            ("[", Continue("]")),     // "]" inclusive
         ] {
             if let Some(rest) = self.0.strip_prefix(open) {
                 let (end, sep) = match close {
@@ -122,6 +129,13 @@ impl<T: ?Sized> DerefMut for JsonPath<T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl<T: core::fmt::Display> core::fmt::Display for JsonPath<T> {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/miniconf/src/leaf.rs
+++ b/miniconf/src/leaf.rs
@@ -105,7 +105,7 @@ impl<'de, T: Deserialize<'de>> TreeDeserialize<'de> for Leaf<T> {
     }
 
     #[inline]
-    fn type_by_key<K, D>(mut keys: K, de: D) -> Result<(), Error<D::Error>>
+    fn probe_by_key<K, D>(mut keys: K, de: D) -> Result<(), Error<D::Error>>
     where
         K: Keys,
         D: Deserializer<'de>,
@@ -247,7 +247,7 @@ impl<'de, T: TryFrom<&'de str>> TreeDeserialize<'de> for StrLeaf<T> {
     }
 
     #[inline]
-    fn type_by_key<K, D>(mut keys: K, de: D) -> Result<(), Error<D::Error>>
+    fn probe_by_key<K, D>(mut keys: K, de: D) -> Result<(), Error<D::Error>>
     where
         K: Keys,
         D: Deserializer<'de>,
@@ -365,7 +365,7 @@ impl<'de, T: ?Sized> TreeDeserialize<'de> for Deny<T> {
     }
 
     #[inline]
-    fn type_by_key<K, D>(mut keys: K, _de: D) -> Result<(), Error<D::Error>>
+    fn probe_by_key<K, D>(mut keys: K, _de: D) -> Result<(), Error<D::Error>>
     where
         K: Keys,
         D: Deserializer<'de>,

--- a/miniconf/src/leaf.rs
+++ b/miniconf/src/leaf.rs
@@ -82,27 +82,26 @@ impl<T: ?Sized> TreeKey for Leaf<T> {
 
 impl<T: Serialize + ?Sized> TreeSerialize for Leaf<T> {
     #[inline]
-    fn serialize_by_key<K, S>(&self, mut keys: K, ser: S) -> Result<usize, Error<S::Error>>
+    fn serialize_by_key<K, S>(&self, mut keys: K, ser: S) -> Result<S::Ok, Error<S::Error>>
     where
         K: Keys,
         S: Serializer,
     {
         keys.finalize()?;
-        self.0.serialize(ser).map_err(|err| Error::Inner(0, err))?;
-        Ok(0)
+        self.0.serialize(ser).map_err(|err| Error::Inner(0, err))
     }
 }
 
 impl<'de, T: Deserialize<'de>> TreeDeserialize<'de> for Leaf<T> {
     #[inline]
-    fn deserialize_by_key<K, D>(&mut self, mut keys: K, de: D) -> Result<usize, Error<D::Error>>
+    fn deserialize_by_key<K, D>(&mut self, mut keys: K, de: D) -> Result<(), Error<D::Error>>
     where
         K: Keys,
         D: Deserializer<'de>,
     {
         keys.finalize()?;
         self.0 = T::deserialize(de).map_err(|err| Error::Inner(0, err))?;
-        Ok(0)
+        Ok(())
     }
 }
 
@@ -212,21 +211,20 @@ impl<T: ?Sized> TreeKey for StrLeaf<T> {
 
 impl<T: AsRef<str> + ?Sized> TreeSerialize for StrLeaf<T> {
     #[inline]
-    fn serialize_by_key<K, S>(&self, mut keys: K, ser: S) -> Result<usize, Error<S::Error>>
+    fn serialize_by_key<K, S>(&self, mut keys: K, ser: S) -> Result<S::Ok, Error<S::Error>>
     where
         K: Keys,
         S: Serializer,
     {
         keys.finalize()?;
         let name = self.0.as_ref();
-        name.serialize(ser).map_err(|err| Error::Inner(0, err))?;
-        Ok(0)
+        name.serialize(ser).map_err(|err| Error::Inner(0, err))
     }
 }
 
 impl<'de, T: TryFrom<&'de str>> TreeDeserialize<'de> for StrLeaf<T> {
     #[inline]
-    fn deserialize_by_key<K, D>(&mut self, mut keys: K, de: D) -> Result<usize, Error<D::Error>>
+    fn deserialize_by_key<K, D>(&mut self, mut keys: K, de: D) -> Result<(), Error<D::Error>>
     where
         K: Keys,
         D: Deserializer<'de>,
@@ -234,7 +232,7 @@ impl<'de, T: TryFrom<&'de str>> TreeDeserialize<'de> for StrLeaf<T> {
         keys.finalize()?;
         let name = Deserialize::deserialize(de).map_err(|err| Error::Inner(0, err))?;
         self.0 = T::try_from(name).or(Err(Traversal::Invalid(0, "Could not convert")))?;
-        Ok(0)
+        Ok(())
     }
 }
 
@@ -322,7 +320,7 @@ impl<T: ?Sized> TreeKey for Deny<T> {
 
 impl<T: ?Sized> TreeSerialize for Deny<T> {
     #[inline]
-    fn serialize_by_key<K, S>(&self, mut keys: K, _ser: S) -> Result<usize, Error<S::Error>>
+    fn serialize_by_key<K, S>(&self, mut keys: K, _ser: S) -> Result<S::Ok, Error<S::Error>>
     where
         K: Keys,
         S: Serializer,
@@ -334,7 +332,7 @@ impl<T: ?Sized> TreeSerialize for Deny<T> {
 
 impl<'de, T: ?Sized> TreeDeserialize<'de> for Deny<T> {
     #[inline]
-    fn deserialize_by_key<K, D>(&mut self, mut keys: K, _de: D) -> Result<usize, Error<D::Error>>
+    fn deserialize_by_key<K, D>(&mut self, mut keys: K, _de: D) -> Result<(), Error<D::Error>>
     where
         K: Keys,
         D: Deserializer<'de>,

--- a/miniconf/src/leaf.rs
+++ b/miniconf/src/leaf.rs
@@ -242,7 +242,7 @@ impl<'de, T: TryFrom<&'de str>> TreeDeserialize<'de> for StrLeaf<T> {
     {
         keys.finalize()?;
         let name = Deserialize::deserialize(de).map_err(|err| Error::Inner(0, err))?;
-        self.0 = T::try_from(name).or(Err(Traversal::Invalid(0, "Could not convert")))?;
+        self.0 = T::try_from(name).or(Err(Traversal::Invalid(0, "Could not convert from str")))?;
         Ok(())
     }
 
@@ -254,7 +254,7 @@ impl<'de, T: TryFrom<&'de str>> TreeDeserialize<'de> for StrLeaf<T> {
     {
         keys.finalize()?;
         let name = Deserialize::deserialize(de).map_err(|err| Error::Inner(0, err))?;
-        T::try_from(name).or(Err(Traversal::Invalid(0, "Could not convert")))?;
+        T::try_from(name).or(Err(Traversal::Invalid(0, "Could not convert from str")))?;
         Ok(())
     }
 }

--- a/miniconf/src/node.rs
+++ b/miniconf/src/node.rs
@@ -190,6 +190,13 @@ impl<T, const S: char> From<T> for Path<T, S> {
     }
 }
 
+impl<T: core::fmt::Display, const S: char> core::fmt::Display for Path<T, S> {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 /// String split/skip wrapper, smaller/simpler than `.split(S).skip(1)`
 #[derive(Copy, Clone, Default, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[repr(transparent)]
@@ -319,6 +326,13 @@ impl<const D: usize, T> From<Indices<[T; D]>> for [T; D] {
     #[inline]
     fn from(value: Indices<[T; D]>) -> Self {
         value.0
+    }
+}
+
+impl<T: core::fmt::Display> core::fmt::Display for Indices<T> {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/miniconf/src/packed.rs
+++ b/miniconf/src/packed.rs
@@ -241,6 +241,13 @@ impl Packed {
     }
 }
 
+impl core::fmt::Display for Packed {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl Keys for Packed {
     #[inline]
     fn next(&mut self, lookup: &KeyLookup) -> Result<usize, Traversal> {

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -475,10 +475,7 @@ pub trait TreeDeserialize<'de> {
     fn probe_by_key<K, D>(keys: K, de: D) -> Result<(), Error<D::Error>>
     where
         K: Keys,
-        D: Deserializer<'de>,
-    {
-        unimplemented!("TODO")
-    }
+        D: Deserializer<'de>;
 }
 
 /// Shorthand for owned deserialization through [`TreeDeserialize`].
@@ -549,6 +546,15 @@ impl<'de, T: TreeDeserialize<'de>> TreeDeserialize<'de> for &mut T {
         D: Deserializer<'de>,
     {
         (**self).deserialize_by_key(keys, de)
+    }
+
+    #[inline]
+    fn probe_by_key<K, D>(keys: K, de: D) -> Result<(), Error<D::Error>>
+    where
+        K: Keys,
+        D: Deserializer<'de>,
+    {
+        T::probe_by_key(keys, de)
     }
 }
 

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -114,7 +114,7 @@ use crate::{Error, IntoKeys, Keys, Node, NodeIter, Transcode, Traversal, Walk};
 ///     b: [Leaf<f32>; 2],
 /// };
 /// impl S {
-///     fn non_leaf(&mut self, depth: usize) -> Result<usize, &'static str> {
+///     fn non_leaf(&mut self) -> Result<(), &'static str> {
 ///         Err("fail")
 ///     }
 /// }
@@ -413,7 +413,7 @@ pub trait TreeSerialize {
     ///
     /// # Returns
     /// Node depth on success.
-    fn serialize_by_key<K, S>(&self, keys: K, ser: S) -> Result<usize, Error<S::Error>>
+    fn serialize_by_key<K, S>(&self, keys: K, ser: S) -> Result<S::Ok, Error<S::Error>>
     where
         K: Keys,
         S: Serializer;
@@ -453,7 +453,7 @@ pub trait TreeDeserialize<'de> {
     ///
     /// # Returns
     /// Node depth on success
-    fn deserialize_by_key<K, D>(&mut self, keys: K, de: D) -> Result<usize, Error<D::Error>>
+    fn deserialize_by_key<K, D>(&mut self, keys: K, de: D) -> Result<(), Error<D::Error>>
     where
         K: Keys,
         D: Deserializer<'de>;
@@ -499,7 +499,7 @@ impl<T: TreeKey> TreeKey for &mut T {
 
 impl<T: TreeSerialize> TreeSerialize for &T {
     #[inline]
-    fn serialize_by_key<K, S>(&self, keys: K, ser: S) -> Result<usize, Error<S::Error>>
+    fn serialize_by_key<K, S>(&self, keys: K, ser: S) -> Result<S::Ok, Error<S::Error>>
     where
         K: Keys,
         S: Serializer,
@@ -510,7 +510,7 @@ impl<T: TreeSerialize> TreeSerialize for &T {
 
 impl<T: TreeSerialize> TreeSerialize for &mut T {
     #[inline]
-    fn serialize_by_key<K, S>(&self, keys: K, ser: S) -> Result<usize, Error<S::Error>>
+    fn serialize_by_key<K, S>(&self, keys: K, ser: S) -> Result<S::Ok, Error<S::Error>>
     where
         K: Keys,
         S: Serializer,
@@ -521,7 +521,7 @@ impl<T: TreeSerialize> TreeSerialize for &mut T {
 
 impl<'de, T: TreeDeserialize<'de>> TreeDeserialize<'de> for &mut T {
     #[inline]
-    fn deserialize_by_key<K, D>(&mut self, keys: K, de: D) -> Result<usize, Error<D::Error>>
+    fn deserialize_by_key<K, D>(&mut self, keys: K, de: D) -> Result<(), Error<D::Error>>
     where
         K: Keys,
         D: Deserializer<'de>,

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -410,9 +410,6 @@ pub trait TreeSerialize {
     /// # Args
     /// * `keys`: A `Keys` identifying the node.
     /// * `ser`: A `Serializer` to to serialize the value.
-    ///
-    /// # Returns
-    /// Node depth on success.
     fn serialize_by_key<K, S>(&self, keys: K, ser: S) -> Result<S::Ok, Error<S::Error>>
     where
         K: Keys,
@@ -450,13 +447,38 @@ pub trait TreeDeserialize<'de> {
     /// # Args
     /// * `keys`: A `Keys` identifying the node.
     /// * `de`: A `Deserializer` to deserialize the value.
-    ///
-    /// # Returns
-    /// Node depth on success
     fn deserialize_by_key<K, D>(&mut self, keys: K, de: D) -> Result<(), Error<D::Error>>
     where
         K: Keys,
         D: Deserializer<'de>;
+
+    /// Blind deserialize a leaf node by its keys.
+    ///
+    /// ```
+    /// # #[cfg(feature = "derive")] {
+    /// use miniconf::{IntoKeys, Leaf, TreeDeserialize, TreeKey};
+    /// #[derive(Default, TreeKey, TreeDeserialize)]
+    /// struct S {
+    ///     foo: Leaf<u32>,
+    ///     bar: [Leaf<u16>; 2],
+    /// };
+    /// let mut de = serde_json::de::Deserializer::from_slice(b"7");
+    /// S::type_by_key(["bar", "0"].into_keys(), &mut de)
+    ///     .unwrap();
+    /// de.end().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// # Args
+    /// * `keys`: A `Keys` identifying the node.
+    /// * `de`: A `Deserializer` to deserialize the value.
+    fn type_by_key<K, D>(keys: K, de: D) -> Result<(), Error<D::Error>>
+    where
+        K: Keys,
+        D: Deserializer<'de>,
+    {
+        unimplemented!("TODO")
+    }
 }
 
 /// Shorthand for owned deserialization through [`TreeDeserialize`].

--- a/miniconf/src/tree.rs
+++ b/miniconf/src/tree.rs
@@ -463,7 +463,7 @@ pub trait TreeDeserialize<'de> {
     ///     bar: [Leaf<u16>; 2],
     /// };
     /// let mut de = serde_json::de::Deserializer::from_slice(b"7");
-    /// S::type_by_key(["bar", "0"].into_keys(), &mut de)
+    /// S::probe_by_key(["bar", "0"].into_keys(), &mut de)
     ///     .unwrap();
     /// de.end().unwrap();
     /// # }
@@ -472,7 +472,7 @@ pub trait TreeDeserialize<'de> {
     /// # Args
     /// * `keys`: A `Keys` identifying the node.
     /// * `de`: A `Deserializer` to deserialize the value.
-    fn type_by_key<K, D>(keys: K, de: D) -> Result<(), Error<D::Error>>
+    fn probe_by_key<K, D>(keys: K, de: D) -> Result<(), Error<D::Error>>
     where
         K: Keys,
         D: Deserializer<'de>,

--- a/miniconf/src/walk.rs
+++ b/miniconf/src/walk.rs
@@ -52,7 +52,7 @@ pub trait Walk: Sized {
     /// # Args
     /// * `children`: The walk of the children to merge.
     /// * `lookup`: The namespace the node(s) are in.
-    fn internal(children: &[&Self], lookup: &KeyLookup) -> Result<Self, Self::Error>;
+    fn internal(children: &[Self], lookup: &KeyLookup) -> Result<Self, Self::Error>;
 }
 
 impl Walk for Metadata {
@@ -69,7 +69,7 @@ impl Walk for Metadata {
     }
 
     #[inline]
-    fn internal(children: &[&Self], lookup: &KeyLookup) -> Result<Self, Self::Error> {
+    fn internal(children: &[Self], lookup: &KeyLookup) -> Result<Self, Self::Error> {
         let mut max_depth = 0;
         let mut max_length = 0;
         let mut count = 0;

--- a/miniconf/tests/enum.rs
+++ b/miniconf/tests/enum.rs
@@ -33,7 +33,7 @@ fn enum_switch() {
     set_get(&mut s, "/tag", b"\"foo\"");
     assert_eq!(
         json::set(&mut s, "/tag", b"\"bar\""),
-        Err(miniconf::Traversal::Invalid(1, "Could not convert").into())
+        Err(miniconf::Traversal::Invalid(1, "Could not convert from str").into())
     );
     assert_eq!(*s.enu, Enum::A(0.into()));
     set_get(&mut s, "/enu/foo", b"99");

--- a/miniconf/tests/packed.rs
+++ b/miniconf/tests/packed.rs
@@ -109,7 +109,7 @@ fn zero_key() {
     for (depth, result) in [
         Err(Traversal::TooShort(0).into()),
         Err(Traversal::TooShort(1).into()),
-        Ok(2),
+        Ok(()),
     ]
     .iter()
     .enumerate()

--- a/miniconf/tests/validate.rs
+++ b/miniconf/tests/validate.rs
@@ -14,17 +14,17 @@ struct Settings {
 }
 
 impl Settings {
-    fn validate_v(&mut self, depth: usize) -> Result<usize, &'static str> {
+    fn validate_v(&mut self) -> Result<(), &'static str> {
         if *self.v >= 0.0 {
-            Ok(depth)
+            Ok(())
         } else {
             Err("")
         }
     }
 
-    fn validate_i(&mut self, depth: usize) -> Result<usize, &'static str> {
+    fn validate_i(&mut self) -> Result<(), &'static str> {
         if *self.i.a >= 0.0 {
-            Ok(depth)
+            Ok(())
         } else {
             Err("")
         }
@@ -108,7 +108,7 @@ fn enable_option() {
     }
 
     impl S {
-        fn validate(&mut self, depth: usize) -> Result<usize, &'static str> {
+        fn validate(&mut self) -> Result<(), &'static str> {
             if *self.enable {
                 if self.opt.is_none() {
                     self.opt = Some(Default::default());
@@ -116,7 +116,7 @@ fn enable_option() {
             } else {
                 self.opt = None;
             }
-            Ok(depth)
+            Ok(())
         }
     }
 

--- a/miniconf_derive/src/field.rs
+++ b/miniconf_derive/src/field.rs
@@ -188,11 +188,11 @@ impl TreeField {
         }
     }
 
-    pub fn type_by_key(&self, i: usize) -> TokenStream {
-        // Quote context is a match of the field index with `type_by_key()` args available.
+    pub fn probe_by_key(&self, i: usize) -> TokenStream {
+        // Quote context is a match of the field index with `probe_by_key()` args available.
         let typ = self.typ();
         quote_spanned! { self.span()=>
-            #i => <#typ as ::miniconf::TreeDeserialize::<'de>>::type_by_key(keys, de)
+            #i => <#typ as ::miniconf::TreeDeserialize::<'de>>::probe_by_key(keys, de)
         }
     }
 

--- a/miniconf_derive/src/field.rs
+++ b/miniconf_derive/src/field.rs
@@ -118,9 +118,11 @@ impl TreeField {
         } else if let Some(defer) = &self.defer {
             quote_spanned!(defer.span()=> ::core::result::Result::Ok(&#defer))
         } else if let Some(i) = i {
+            // named or tuple struct
             let ident = self.ident_or_index(i);
             quote_spanned!(self.span()=> ::core::result::Result::Ok(&self.#ident))
         } else {
+            // enum
             quote_spanned!(self.span()=> ::core::result::Result::Ok(value))
         }
     }
@@ -133,9 +135,11 @@ impl TreeField {
         } else if let Some(defer) = &self.defer {
             quote_spanned!(defer.span()=> ::core::result::Result::Ok(&mut #defer))
         } else if let Some(i) = i {
+            // named or tuple struct
             let ident = self.ident_or_index(i);
             quote_spanned!(self.span()=> ::core::result::Result::Ok(&mut self.#ident))
         } else {
+            // enum
             quote_spanned!(self.span()=> ::core::result::Result::Ok(value))
         }
     }
@@ -143,10 +147,8 @@ impl TreeField {
     fn validator(&self) -> Option<TokenStream> {
         self.validate.as_ref().map(|validate| {
             quote_spanned! { validate.span()=>
-                .and_then(|ok| #validate()
-                    .and(Ok(ok))
+                .and_then(|()| #validate()
                     .map_err(|msg| ::miniconf::Traversal::Invalid(0, msg).into())
-
                 )
             }
         })

--- a/miniconf_derive/src/field.rs
+++ b/miniconf_derive/src/field.rs
@@ -142,8 +142,10 @@ impl TreeField {
     fn validator(&self) -> Option<TokenStream> {
         self.validate.as_ref().map(|validate| {
             quote_spanned! { validate.span()=>
-                .and_then(|depth| #validate(depth)
+                .and_then(|ok| #validate()
+                    .and(Ok(ok))
                     .map_err(|msg| ::miniconf::Traversal::Invalid(0, msg).into())
+
                 )
             }
         })

--- a/miniconf_derive/src/field.rs
+++ b/miniconf_derive/src/field.rs
@@ -20,6 +20,7 @@ pub enum TreeTrait {
 struct Deny {
     serialize: Option<String>,
     deserialize: Option<String>,
+    typ: Option<String>,
     ref_any: Option<String>,
     mut_any: Option<String>,
 }
@@ -184,6 +185,14 @@ impl TreeField {
                     )
                     #validator
             }
+        }
+    }
+
+    pub fn type_by_key(&self, i: usize) -> TokenStream {
+        // Quote context is a match of the field index with `type_by_key()` args available.
+        let typ = self.typ();
+        quote_spanned! { self.span()=>
+            #i => <#typ as ::miniconf::TreeDeserialize::<'de>>::type_by_key(keys, de)
         }
     }
 

--- a/miniconf_derive/src/tree.rs
+++ b/miniconf_derive/src/tree.rs
@@ -232,7 +232,7 @@ impl Tree {
                     .map_err(|err| ::miniconf::Error::Inner(1, err))?;
                 }),
                 Some(quote!(.map_err(::miniconf::Error::increment).map(|depth| depth + 1))),
-                quote!(W::internal(&[#(&#w? ,)*], &Self::__MINICONF_LOOKUP)),
+                quote!(W::internal(&[#(#w? ,)*], &Self::__MINICONF_LOOKUP)),
             )
         };
 

--- a/miniconf_derive/src/tree.rs
+++ b/miniconf_derive/src/tree.rs
@@ -314,7 +314,7 @@ impl Tree {
         let ident = &self.ident;
         let (mat, deserialize_arms, default) = self.arms(|f, i| f.deserialize_by_key(i));
         let fields = self.fields();
-        let type_arms = fields.iter().enumerate().map(|(i, f)| f.type_by_key(i));
+        let probe_arms = fields.iter().enumerate().map(|(i, f)| f.probe_by_key(i));
         let increment =
             (!self.flatten.is_present()).then_some(quote!(.map_err(::miniconf::Error::increment)));
 
@@ -334,14 +334,14 @@ impl Tree {
                     #increment
                 }
 
-            fn type_by_key<K, D>(mut keys: K, de: D) -> ::core::result::Result<(), ::miniconf::Error<D::Error>>
+            fn probe_by_key<K, D>(mut keys: K, de: D) -> ::core::result::Result<(), ::miniconf::Error<D::Error>>
                 where
                     K: ::miniconf::Keys,
                     D: ::miniconf::Deserializer<'de>,
                 {
                     let index = #index?;
                     match index {
-                        #(#type_arms ,)*
+                        #(#probe_arms ,)*
                         _ => unreachable!()
                     }
                     #increment

--- a/miniconf_mqtt/Cargo.toml
+++ b/miniconf_mqtt/Cargo.toml
@@ -19,7 +19,7 @@ embedded-io = "0.6"
 log = "0.4"
 heapless = "0.8"
 serde-json-core = "0.6.0"
-strum = { version = "0.26.3", features = ["derive"], default-features = false }
+strum = { version = "0.27.1", features = ["derive"], default-features = false }
 
 [[example]]
 name = "mqtt"

--- a/miniconf_mqtt/examples/mqtt.rs
+++ b/miniconf_mqtt/examples/mqtt.rs
@@ -35,16 +35,16 @@ struct Settings {
 }
 
 impl Settings {
-    fn validate_four(&mut self, depth: usize) -> Result<usize, &'static str> {
+    fn validate_four(&mut self) -> Result<(), &'static str> {
         if *self.four < 4.0 {
             Err("Less than four")
         } else {
-            Ok(depth)
+            Ok(())
         }
     }
-    fn validate_exit(&mut self, depth: usize) -> Result<usize, &'static str> {
+    fn validate_exit(&mut self) -> Result<(), &'static str> {
         self.exit = true;
-        Ok(depth)
+        Ok(())
     }
 }
 

--- a/py/miniconf-mqtt/miniconf/common.py
+++ b/py/miniconf-mqtt/miniconf/common.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=R0801,C0415,W1203,R0903,W0707
 
-from typing import Dict, Any
+from typing import Dict, Any, Tuple
 import logging
 
 import paho.mqtt
@@ -23,7 +23,7 @@ class MiniconfException(Exception):
         return f"{self.code}: {self.message}"
 
 
-def one(devices: Dict[str, Any]) -> (str, Any):
+def one(devices: Dict[str, Any]) -> Tuple[str, Any]:
     """Return the prefix for the unique alive Miniconf device.
 
     See `discover()` for arguments.


### PR DESCRIPTION
- **py: typing style**
- **pass serialize_by_key Ok**
- **trace: add example**
- **Walk::internal: pass children by value**
- **trace: elaborate**
- **examples/common: new()**
- **trace: streamline**
- **trace: trace type**
- **TreeDeserialize: add type_by_key**
- **TreeDeserialize: type_by_key -> probe_by_key**
- **probe_by_key: impls**
- **trace: update with probe_by_key**
- **CHANGELOG: update**
- **deps: sort out serde-reflection, bump strum**
- **trace: simple**
- **trace: no indexmap**
- **Revert "trace: no indexmap"**
- **trace: minimal docs**
- **trace: use a graph to phantom type**
