### PR TITLE
coap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,66 +12,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `Path` and `PathIter` now store the separator at runtime, reducing monomorphization bloat for
   dynamic path handling.
-* `IntoKeys` is now the narrow boundary normalization layer. Slash-separated `&str` remains the
-  default shorthand, while explicit separators use `PathIter` or `ConstPathIter`.
-* `Schema::get()` now performs exact lookup and returns `Lookup`.
-* `Schema::transcode()` now takes `impl IntoKeys`, default-constructs the target, and funnels
-  boundary inputs through `IntoKeys` before deeper `Keys` traversal.
-* `NodeIter` now yields leaves only. Depth-limited iteration skips leaves deeper than the limit.
+* Key handling now uses `IntoKeys` as the boundary normalization layer. Slash-separated `&str`
+  remains the default shorthand, while explicit separators use `PathIter` or `ConstPathIter`.
+* `Schema::get()` now performs exact lookup and returns `Lookup`; use `Schema::resolve_into()` for
+  consumed-depth reporting on partial or failed lookup.
+* `Schema::transcode()` now takes `impl IntoKeys` and default-constructs the target.
+* `NodeIter` now yields leaves only. Depth-limited iteration skips leaves deeper than the limit,
+  and iterator position is exposed through `indices()`, `schema()`, and `root_schema()`.
 * `Schema` is now a public enum with explicit `Leaf` and `Internal` variants backed by shared
-  `NodeSchema` and `InternalSchema`, replacing the older nullable `Schema::new(...)` shape.
+  `NodeSchema` and `InternalSchema`; schema nodes now have stable constructors and accessors.
 * Custom `#[tree(with = ...)]` modules now expose typed schema via `schema::<T>()` instead of a
   monomorphic `SCHEMA` constant.
-* `Meta` is now a stable always-on newtype with direct serialization support, and schema metadata
-  terminology is now consistently `node` and `edge` instead of `inner` and `outer`.
-* Schema storage now keeps plain `Meta` values with `Meta::EMPTY` instead of `Option<Meta>`.
-  Node and edge metadata are stored independently under the `meta-node` and `meta-edge` features.
+* `Meta` is now an always-available newtype with direct serialization support, and schema metadata
+  terminology is now consistently `node` and `edge`.
 * `Schema::get_meta()` now returns both edge and node metadata for one path.
-* `miniconf_mqtt::Miniconf` is now async-first and built on async `minimq::Session`;
-  `update()` was replaced by `poll().await`.
-* `miniconf_mqtt::Miniconf::poll()` now returns one session event
-  (`Changed`/`Connected`/`Reconnected`/`Other`), and the shared client now exposes direct
-  `subscribe()` / `unsubscribe()` passthroughs for non-MM2 topics.
-* `miniconf_mqtt` MM2 now publishes retained manifest and paged schema data alongside
-  authoritative retained settings, with fast broker-backed live caching.
-  Compatibility with request/response-only clients is retained behind the
+* JSON Schema output now marks Miniconf leaves explicitly and better matches the emitted JSON tree
+  for omitted named absences, nullable leaves, and `oneOf` nodes.
+* `miniconf_mqtt` is now async-first on `minimq::Session`. The old `update()` loop was replaced by
+  `Miniconf::poll().await`, which returns `Changed`, `Connected`, `Reconnected`, or `Other`.
+* `miniconf_mqtt` MM2 now publishes retained manifest, paged schema, and authoritative retained
+  settings. Compatibility with request/response-only settings writes is retained behind the
   `compat-settings-ingress` feature.
-* MM2 manifests now publish `epoch` and `schema_rev`. Long-lived Python clients keep `/alive`
-  subscribed, invalidate cached schema and settings when either changes, and treat retained
-  `settings/#` messages without `rev` as non-authoritative.
+* MM2 manifests now publish `epoch` and `schema_rev`. Long-lived Python clients use them to
+  invalidate cached schema and settings.
 * The Python package was restructured from `py/miniconf-mqtt` to `py/` and now targets the MM2
   retained schema/settings protocol with an async-first CLI and client library.
-* The schema family now exposes stable `new(...)` constructors and accessors instead of requiring
-  public field construction.
 
 ### Added
 
 * `ConstPath` and `ConstPathIter` take the separator as a const generic, allowing compile-time
   specialization of ASCII separators.
-* `Schema::resolve_into()` and `Lookup` for exact lookup with consumed-depth reporting.
-* `NodeIter::{indices,schema,root_schema}` for inspecting iterator position and the iterated tree
-  with consistent naming.
-* `json_core::{get_by_keys, set_by_keys}` and `postcard::{get_by_keys, set_by_keys}` for live key cursors.
+* `json_core::{get_by_keys, set_by_keys}` and `postcard::{get_by_keys, set_by_keys}` for live
+  key cursors.
 * `Keys` for borrowed slices `&[T]` where `T: Key`.
-* `miniconf_mqtt::Miniconf::{publish_root,publish_by_key}` for explicit app-driven retained
-  settings publication.
 * `Sem` offers semantic structured information about nodes in a `Schema`.
 * `#[tree(meta(...))]` for derive metadata syntax.
-  Derived enums now always yield structured schema semantics `{"sem":{"oneof":true}}`.
-* Structured `sem.maybe_absent` on `Option<T>` schema nodes and JSON Schema output.
-* Structured `sem.oneof` on built-in `Result<T, E>` and `Bound<T>` schema nodes and JSON Schema output.
-* `nullable` as an edge metadata hint, e.g. `#[tree(with = leaf, meta(nullable))]`, propagated into JSON Schema as `null`.
-* Generated JSON Schema now carries an explicit `tree-leaf` marker and matches the emitted JSON tree for omitted named absences and `oneOf` nodes.
+* Structured `sem.maybe_absent` on `Option<T>` schema nodes and `sem.oneof` on derived enums,
+  `Result<T, E>`, and `Bound<T>`.
+* `nullable` as an edge metadata hint, e.g. `#[tree(with = leaf, meta(nullable))]`, propagated
+  into JSON Schema as `null`.
 * `miniconf/tests/benchmark` is now the embedded code-size and workload benchmark harness, with
   `baseline`, `manual`, and `miniconf` binaries plus schema-size measurement support.
+* `miniconf_mqtt::Miniconf::{publish_root,publish_by_key}` for explicit app-driven retained
+  settings publication.
 * The Python package now ships MM2 schema parsing/rendering helpers and one-shot retained-state
   operations such as `read()`, `dump()`, `prune()`, and `force_prune()`.
+* `miniconf_coap`, a new CoAP transport crate with low-level request handlers, JSON and CBOR value
+  representations, compact schema serving, `coap-handler` integration, and a packet-level server
+  example.
 
 ### Removed
 
 * `meta-str`
-* The Python synchronous client surface (`miniconf.sync`) and the legacy request/response-only
-  package layout under `py/miniconf-mqtt`
+* The legacy `miniconf_mqtt::MqttClient` API.
+* The Python synchronous client surface (`miniconf.sync`) and the old package layout under
+  `py/miniconf-mqtt`.
 
 ## [0.20.1](https://github.com/quartiq/miniconf/compare/miniconf-v0.20.0...miniconf-v0.20.1) - 2026-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   retained schema/settings protocol with an async-first CLI and client library.
 * The schema family now exposes stable `new(...)` constructors and accessors instead of requiring
   public field construction.
-* Direct `Serialize` output for `Schema`, `Numbered`, `Named`, and `Homogeneous` now follows their
-  derived Rust data shape. Protocol users should use the compact paged schema adapter instead.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   retained schema/settings protocol with an async-first CLI and client library.
 * The schema family now exposes stable `new(...)` constructors and accessors instead of requiring
   public field construction.
+* Direct `Serialize` output for `Schema`, `Numbered`, `Named`, and `Homogeneous` now follows their
+  derived Rust data shape. Protocol users should use the compact paged schema adapter instead.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["miniconf_derive", "miniconf", "miniconf_mqtt"]
+members = ["miniconf_derive", "miniconf", "miniconf_mqtt", "miniconf_coap"]
 resolver = "2"
 
 [workspace.package]

--- a/miniconf_coap/Cargo.toml
+++ b/miniconf_coap/Cargo.toml
@@ -15,10 +15,12 @@ workspace = true
 
 [features]
 default = ["json"]
+coap-handler = ["dep:coap-handler"]
 json = ["dep:serde-json-core", "miniconf/json-core"]
 postcard = ["dep:postcard", "miniconf/postcard"]
 
 [dependencies]
+coap-handler = { version = "=0.2.1", optional = true }
 coap-message = "0.3.6"
 coap-numbers = "0.2.9"
 defmt = "1.0.1"
@@ -29,7 +31,8 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde-json-core = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
-coap-message-implementations = "0.1.10"
+coap-handler-implementations = "0.6.2"
+coap-message-implementations = { version = "0.1.10", features = ["alloc"] }
 defmt2log = "0.2.0"
 env_logger = "0.11"
 miniconf = { features = [
@@ -45,3 +48,7 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 
 [package.metadata.docs.rs]
 all-features = true
+
+[[example]]
+name = "coap_server"
+required-features = ["coap-handler", "json"]

--- a/miniconf_coap/Cargo.toml
+++ b/miniconf_coap/Cargo.toml
@@ -15,9 +15,9 @@ workspace = true
 
 [features]
 default = ["json-core"]
+cbor = ["dep:minicbor", "dep:minicbor-serde"]
 coap-handler = ["dep:coap-handler"]
 json-core = ["dep:serde-json-core", "miniconf/json-core"]
-postcard = ["dep:postcard", "miniconf/postcard"]
 
 [dependencies]
 coap-handler = { version = "=0.2.1", optional = true }
@@ -25,8 +25,9 @@ coap-message = "0.3.6"
 coap-numbers = "0.2.9"
 defmt = "1.0.1"
 heapless = "0.9.1"
+minicbor = { version = "2.2.2", default-features = false, optional = true }
+minicbor-serde = { version = "0.7.0", default-features = false, optional = true }
 miniconf = { version = "0.20.1", features = ["defmt"], default-features = false, path = "../miniconf" }
-postcard = { version = "1.0.8", optional = true }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-json-core = { version = "0.6.0", optional = true }
 

--- a/miniconf_coap/Cargo.toml
+++ b/miniconf_coap/Cargo.toml
@@ -30,6 +30,7 @@ minicbor-serde = { version = "0.7.0", default-features = false, optional = true 
 miniconf = { version = "0.20.1", features = ["defmt"], default-features = false, path = "../miniconf" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-json-core = { version = "0.6.0", optional = true }
+yafnv = { version = "3", default-features = false }
 
 [dev-dependencies]
 coap-handler-implementations = "0.6.2"

--- a/miniconf_coap/Cargo.toml
+++ b/miniconf_coap/Cargo.toml
@@ -14,9 +14,9 @@ repository.workspace = true
 workspace = true
 
 [features]
-default = ["json"]
+default = ["json-core"]
 coap-handler = ["dep:coap-handler"]
-json = ["dep:serde-json-core", "miniconf/json-core"]
+json-core = ["dep:serde-json-core", "miniconf/json-core"]
 postcard = ["dep:postcard", "miniconf/postcard"]
 
 [dependencies]
@@ -51,4 +51,4 @@ all-features = true
 
 [[example]]
 name = "coap_server"
-required-features = ["coap-handler", "json"]
+required-features = ["coap-handler", "json-core"]

--- a/miniconf_coap/Cargo.toml
+++ b/miniconf_coap/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "miniconf_coap"
+version = "0.1.0"
+description = "CoAP interface for `miniconf`"
+autoexamples = false
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+categories.workspace = true
+keywords.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = ["json"]
+json = ["dep:serde-json-core", "miniconf/json-core"]
+postcard = ["dep:postcard", "miniconf/postcard"]
+
+[dependencies]
+coap-message = "0.3.6"
+coap-numbers = "0.2.9"
+defmt = "1.0.1"
+heapless = "0.9.1"
+miniconf = { version = "0.20.1", features = ["defmt"], default-features = false, path = "../miniconf" }
+postcard = { version = "1.0.8", optional = true }
+serde = { version = "1", default-features = false, features = ["derive"] }
+serde-json-core = { version = "0.6.0", optional = true }
+
+[dev-dependencies]
+coap-message-implementations = "0.1.10"
+defmt2log = "0.2.0"
+env_logger = "0.11"
+miniconf = { features = [
+    "defmt",
+    "derive",
+    "json-core",
+    "heapless-09",
+    "sem",
+    "meta-node",
+    "meta-edge",
+], path = "../miniconf" }
+serde = { version = "1", default-features = false, features = ["derive"] }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/miniconf_coap/examples/coap_server.rs
+++ b/miniconf_coap/examples/coap_server.rs
@@ -1,22 +1,22 @@
 use std::net::UdpSocket;
 
-use coap_handler::Handler as _;
 use coap_handler_implementations::{HandlerBuilder as _, ReportingHandlerBuilder as _};
 use coap_message::error::RenderableOnMinimal as _;
 use coap_message_implementations::{inmemory, inmemory_write};
 use coap_numbers::code;
 use defmt::{info, warn};
-use miniconf::Tree;
-use miniconf_coap::{ConstPathJsonCoapHandler, JSON_CONTENT_FORMAT, MiniconfSchemaHandler};
+use heapless::{String, Vec};
+use miniconf::{Tree, TreeDeserialize, TreeSchema, TreeSerialize};
+use miniconf_coap::{ConstPathJson, JSON_CONTENT_FORMAT, MiniconfHandler, MiniconfSchemaHandler};
 
 const RESPONSE_CAPACITY: usize = 1280;
 
-#[derive(Tree)]
+#[derive(TreeSchema, TreeDeserialize, TreeSerialize)]
 struct Settings {
-    hidden: bool,
     number: u32,
+    list: Vec<usize, 16>,
     #[tree(with = label)]
-    label: heapless::String<16>,
+    label: String<16>,
     visible: Option<Visible>,
 }
 
@@ -28,9 +28,9 @@ struct Visible {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            hidden: false,
             number: 7,
-            label: "demo".try_into().unwrap(),
+            list: Vec::from_slice(&[1, 2, 3]).unwrap(),
+            label: "Hello".try_into().unwrap(),
             visible: Some(Visible { value: 9 }),
         }
     }
@@ -38,19 +38,10 @@ impl Default for Settings {
 
 mod label {
     use miniconf::{Keys, SerdeError, ValueError, leaf};
-    use serde::{Deserializer, Serializer};
 
-    pub use leaf::{mut_any_by_key, probe_by_key, ref_any_by_key, schema};
+    pub use leaf::{probe_by_key, schema, serialize_by_key};
 
-    pub fn serialize_by_key<S: Serializer>(
-        value: &heapless::String<16>,
-        keys: impl Keys,
-        ser: S,
-    ) -> Result<S::Ok, SerdeError<S::Error>> {
-        leaf::serialize_by_key(value, keys, ser)
-    }
-
-    pub fn deserialize_by_key<'de, D: Deserializer<'de>>(
+    pub fn deserialize_by_key<'de, D: serde::Deserializer<'de>>(
         value: &mut heapless::String<16>,
         keys: impl Keys,
         de: D,
@@ -72,7 +63,7 @@ fn main() -> std::io::Result<()> {
 
     let bind = std::env::args()
         .nth(1)
-        .unwrap_or_else(|| "127.0.0.1:5683".into());
+        .unwrap_or_else(|| "127.0.0.1:56830".into());
     let socket = UdpSocket::bind(&bind)?;
     info!("listening on coap://{=str}", bind.as_str());
     info!(
@@ -88,13 +79,13 @@ fn main() -> std::io::Result<()> {
         bind.as_str()
     );
 
-    let mut settings = Settings::default();
+    let mut handler = demo_handler();
     let mut request = [0; RESPONSE_CAPACITY];
     let mut response = [0; RESPONSE_CAPACITY];
 
     loop {
         let (len, peer) = socket.recv_from(&mut request)?;
-        match handle_packet(&request[..len], &mut settings, &mut response) {
+        match handle_packet(&request[..len], &mut handler, &mut response) {
             Ok(response_len) => {
                 socket.send_to(&response[..response_len], peer)?;
             }
@@ -106,17 +97,13 @@ fn main() -> std::io::Result<()> {
     }
 }
 
-fn handle_packet(
-    request: &[u8],
-    settings: &mut Settings,
-    response: &mut [u8],
-) -> Result<usize, &'static str> {
-    let request = WirePacket::parse(request)?;
-    let miniconf = ConstPathJsonCoapHandler::const_path_json(settings);
-    let schema = MiniconfSchemaHandler::<Settings>::json();
-    let mut handler = coap_handler_implementations::new_dispatcher()
+fn demo_handler() -> impl coap_handler::Handler + coap_handler::Reporting {
+    let miniconf =
+        MiniconfHandler::<Settings, Settings, ConstPathJson>::const_path_json(Settings::default());
+
+    coap_handler_implementations::new_dispatcher()
         .below(&["settings"], miniconf)
-        .at(&["schema"], schema)
+        .at(&["schema"], MiniconfSchemaHandler::<Settings>::json())
         .at(
             &["status"],
             coap_handler_implementations::SimpleRendered::new_typed_str(
@@ -124,8 +111,18 @@ fn handle_packet(
                 Some(JSON_CONTENT_FORMAT),
             ),
         )
-        .with_wkc();
+        .with_wkc()
+}
 
+fn handle_packet<H>(
+    request: &[u8],
+    handler: &mut H,
+    response: &mut [u8],
+) -> Result<usize, &'static str>
+where
+    H: coap_handler::Handler,
+{
+    let request = WirePacket::parse(request)?;
     let mut code = 0;
     let mut tail = [0; RESPONSE_CAPACITY];
     let mut message = inmemory_write::Message::new(&mut code, &mut tail);

--- a/miniconf_coap/examples/coap_server.rs
+++ b/miniconf_coap/examples/coap_server.rs
@@ -7,10 +7,17 @@ use coap_message::error::RenderableOnMinimal as _;
 use coap_message_implementations::{inmemory, inmemory_write};
 use coap_numbers::code;
 use defmt::{debug, info, warn};
-use miniconf_coap::{ConstPathJson, JSON_CONTENT_FORMAT, MiniconfHandler, MiniconfSchemaHandler};
+use miniconf_coap::{ConstPathJson, MiniconfHandler, MiniconfSchemaHandler};
 
 const DEFAULT_BIND: &str = "127.0.0.1:56830";
 const RESPONSE_CAPACITY: usize = 1280;
+
+const fn content_format(name: &str) -> u16 {
+    match coap_numbers::content_format::from_str(name) {
+        Some(value) => value,
+        None => panic!("unknown CoAP content format"),
+    }
+}
 
 #[path = "../../miniconf/examples/common.rs"]
 mod common;
@@ -82,7 +89,10 @@ fn demo_handler() -> impl coap_handler::Handler + coap_handler::Reporting {
         .at(&["schema"], MiniconfSchemaHandler::<Settings>::json())
         .at(
             &["status"],
-            SimpleRendered::new_typed_str(r#"{"ok":true}"#, Some(JSON_CONTENT_FORMAT)),
+            SimpleRendered::new_typed_str(
+                r#"{"ok":true}"#,
+                Some(content_format("application/json")),
+            ),
         )
         .with_wkc()
 }

--- a/miniconf_coap/examples/coap_server.rs
+++ b/miniconf_coap/examples/coap_server.rs
@@ -5,12 +5,16 @@ use coap_handler_implementations::{
 };
 use coap_message::error::RenderableOnMinimal as _;
 use coap_message_implementations::{inmemory, inmemory_write};
-use coap_numbers::{code, content_format};
+use coap_numbers::code;
 use defmt::{debug, info, warn};
 use miniconf_coap::{ConstPathJson, MiniconfHandler, MiniconfSchemaHandler};
 
 const DEFAULT_BIND: &str = "127.0.0.1:56830";
 const RESPONSE_CAPACITY: usize = 1280;
+const JSON_CONTENT_FORMAT: u16 = match coap_numbers::content_format::from_str("application/json") {
+    Some(value) => value,
+    None => panic!("unknown CoAP content format"),
+};
 
 #[path = "../../miniconf/examples/common.rs"]
 mod common;
@@ -80,10 +84,7 @@ fn demo_handler() -> impl coap_handler::Handler + coap_handler::Reporting {
         .at(&["schema"], MiniconfSchemaHandler::<Settings>::json())
         .at(
             &["status"],
-            SimpleRendered::new_typed_str(
-                r#"{"ok":true}"#,
-                Some(content_format::from_str("application/json").unwrap()),
-            ),
+            SimpleRendered::new_typed_str(r#"{"ok":true}"#, Some(JSON_CONTENT_FORMAT)),
         )
         .with_wkc()
 }

--- a/miniconf_coap/examples/coap_server.rs
+++ b/miniconf_coap/examples/coap_server.rs
@@ -33,8 +33,14 @@ fn main() -> io::Result<()> {
         "try: aiocoap-client coap://{=str}/.well-known/core",
         bind.as_str()
     );
-    info!("try: aiocoap-client coap://{=str}/schema", bind.as_str());
-    info!("try: aiocoap-client coap://{=str}/schema/0", bind.as_str());
+    info!(
+        "try schema manifest: aiocoap-client coap://{=str}/schema",
+        bind.as_str()
+    );
+    info!(
+        "try schema page 0: aiocoap-client coap://{=str}/schema/0",
+        bind.as_str()
+    );
     info!(
         "try: aiocoap-client coap://{=str}/settings/control/enabled",
         bind.as_str()

--- a/miniconf_coap/examples/coap_server.rs
+++ b/miniconf_coap/examples/coap_server.rs
@@ -34,6 +34,7 @@ fn main() -> io::Result<()> {
         bind.as_str()
     );
     info!("try: aiocoap-client coap://{=str}/schema", bind.as_str());
+    info!("try: aiocoap-client coap://{=str}/schema/0", bind.as_str());
     info!(
         "try: aiocoap-client coap://{=str}/settings/control/enabled",
         bind.as_str()
@@ -81,7 +82,7 @@ fn demo_handler() -> impl coap_handler::Handler + coap_handler::Reporting {
 
     new_dispatcher()
         .below(&["settings"], miniconf)
-        .at(&["schema"], MiniconfSchemaHandler::<Settings>::json())
+        .below(&["schema"], MiniconfSchemaHandler::<Settings>::json())
         .at(
             &["status"],
             SimpleRendered::new_typed_str(r#"{"ok":true}"#, Some(JSON_CONTENT_FORMAT)),

--- a/miniconf_coap/examples/coap_server.rs
+++ b/miniconf_coap/examples/coap_server.rs
@@ -5,56 +5,14 @@ use coap_message::error::RenderableOnMinimal as _;
 use coap_message_implementations::{inmemory, inmemory_write};
 use coap_numbers::code;
 use defmt::{info, warn};
-use heapless::{String, Vec};
-use miniconf::{Tree, TreeDeserialize, TreeSchema, TreeSerialize};
 use miniconf_coap::{ConstPathJson, JSON_CONTENT_FORMAT, MiniconfHandler, MiniconfSchemaHandler};
 
 const RESPONSE_CAPACITY: usize = 1280;
 
-#[derive(TreeSchema, TreeDeserialize, TreeSerialize)]
-struct Settings {
-    number: u32,
-    list: Vec<usize, 16>,
-    #[tree(with = label)]
-    label: String<16>,
-    visible: Option<Visible>,
-}
+#[path = "../../miniconf/examples/common.rs"]
+mod common;
 
-#[derive(Tree)]
-struct Visible {
-    value: u8,
-}
-
-impl Default for Settings {
-    fn default() -> Self {
-        Self {
-            number: 7,
-            list: Vec::from_slice(&[1, 2, 3]).unwrap(),
-            label: "Hello".try_into().unwrap(),
-            visible: Some(Visible { value: 9 }),
-        }
-    }
-}
-
-mod label {
-    use miniconf::{Keys, SerdeError, ValueError, leaf};
-
-    pub use leaf::{probe_by_key, schema, serialize_by_key};
-
-    pub fn deserialize_by_key<'de, D: serde::Deserializer<'de>>(
-        value: &mut heapless::String<16>,
-        keys: impl Keys,
-        de: D,
-    ) -> Result<(), SerdeError<D::Error>> {
-        let mut next = value.clone();
-        leaf::deserialize_by_key(&mut next, keys, de)?;
-        if next.contains('<') {
-            return Err(ValueError::Access("bad label").into());
-        }
-        *value = next;
-        Ok(())
-    }
-}
+use common::Settings;
 
 fn main() -> std::io::Result<()> {
     let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
@@ -71,11 +29,11 @@ fn main() -> std::io::Result<()> {
         bind.as_str()
     );
     info!(
-        "try: aiocoap-client coap://{=str}/settings/number",
+        "try: aiocoap-client coap://{=str}/settings/control/enabled",
         bind.as_str()
     );
     info!(
-        "try: aiocoap-client -m PUT --content-format application/json --payload 12 coap://{=str}/settings/number",
+        "try: aiocoap-client -m PUT --content-format application/json --payload false coap://{=str}/settings/control/enabled",
         bind.as_str()
     );
 
@@ -99,7 +57,7 @@ fn main() -> std::io::Result<()> {
 
 fn demo_handler() -> impl coap_handler::Handler + coap_handler::Reporting {
     let miniconf =
-        MiniconfHandler::<Settings, Settings, ConstPathJson>::const_path_json(Settings::default());
+        MiniconfHandler::<Settings, Settings, ConstPathJson>::const_path_json(Settings::new());
 
     coap_handler_implementations::new_dispatcher()
         .below(&["settings"], miniconf)

--- a/miniconf_coap/examples/coap_server.rs
+++ b/miniconf_coap/examples/coap_server.rs
@@ -1,12 +1,15 @@
 use std::net::UdpSocket;
 
-use coap_handler_implementations::{HandlerBuilder as _, ReportingHandlerBuilder as _};
+use coap_handler_implementations::{
+    HandlerBuilder as _, ReportingHandlerBuilder as _, SimpleRendered, new_dispatcher,
+};
 use coap_message::error::RenderableOnMinimal as _;
 use coap_message_implementations::{inmemory, inmemory_write};
 use coap_numbers::code;
-use defmt::{info, warn};
+use defmt::{debug, info, warn};
 use miniconf_coap::{ConstPathJson, JSON_CONTENT_FORMAT, MiniconfHandler, MiniconfSchemaHandler};
 
+const DEFAULT_BIND: &str = "127.0.0.1:56830";
 const RESPONSE_CAPACITY: usize = 1280;
 
 #[path = "../../miniconf/examples/common.rs"]
@@ -21,13 +24,14 @@ fn main() -> std::io::Result<()> {
 
     let bind = std::env::args()
         .nth(1)
-        .unwrap_or_else(|| "127.0.0.1:56830".into());
+        .unwrap_or_else(|| DEFAULT_BIND.into());
     let socket = UdpSocket::bind(&bind)?;
     info!("listening on coap://{=str}", bind.as_str());
     info!(
         "try: aiocoap-client coap://{=str}/.well-known/core",
         bind.as_str()
     );
+    info!("try: aiocoap-client coap://{=str}/schema", bind.as_str());
     info!(
         "try: aiocoap-client coap://{=str}/settings/control/enabled",
         bind.as_str()
@@ -43,13 +47,27 @@ fn main() -> std::io::Result<()> {
 
     loop {
         let (len, peer) = socket.recv_from(&mut request)?;
+        let peer_name = peer.to_string();
+        debug!(
+            "received coap datagram peer={=str} len={=usize}",
+            peer_name.as_str(),
+            len
+        );
         match handle_packet(&request[..len], &mut handler, &mut response) {
             Ok(response_len) => {
                 socket.send_to(&response[..response_len], peer)?;
+                debug!(
+                    "sent coap response peer={=str} len={=usize}",
+                    peer_name.as_str(),
+                    response_len
+                );
             }
             Err(error) => {
-                let peer = peer.to_string();
-                warn!("dropping request from {=str}: {=str}", peer.as_str(), error);
+                warn!(
+                    "dropping request from {=str}: {=str}",
+                    peer_name.as_str(),
+                    error
+                );
             }
         }
     }
@@ -59,15 +77,12 @@ fn demo_handler() -> impl coap_handler::Handler + coap_handler::Reporting {
     let miniconf =
         MiniconfHandler::<Settings, Settings, ConstPathJson>::const_path_json(Settings::new());
 
-    coap_handler_implementations::new_dispatcher()
+    new_dispatcher()
         .below(&["settings"], miniconf)
         .at(&["schema"], MiniconfSchemaHandler::<Settings>::json())
         .at(
             &["status"],
-            coap_handler_implementations::SimpleRendered::new_typed_str(
-                r#"{"ok":true}"#,
-                Some(JSON_CONTENT_FORMAT),
-            ),
+            SimpleRendered::new_typed_str(r#"{"ok":true}"#, Some(JSON_CONTENT_FORMAT)),
         )
         .with_wkc()
 }
@@ -138,8 +153,12 @@ impl<'a> WirePacket<'a> {
         if header >> 6 != 1 {
             return Err("unsupported CoAP version");
         }
-        if header & 0x30 == 0x30 {
-            return Err("reset messages do not get ACK responses");
+        match header & 0x30 {
+            0x00 => {}
+            0x10 => return Err("non-confirmable requests are not supported by this UDP loop"),
+            0x20 => return Err("ACK messages do not get ACK responses"),
+            0x30 => return Err("reset messages do not get ACK responses"),
+            _ => unreachable!(),
         }
         let token_len = usize::from(header & 0x0f);
         if token_len > 8 {

--- a/miniconf_coap/examples/coap_server.rs
+++ b/miniconf_coap/examples/coap_server.rs
@@ -1,0 +1,205 @@
+use std::net::UdpSocket;
+
+use coap_handler::Handler as _;
+use coap_handler_implementations::{HandlerBuilder as _, ReportingHandlerBuilder as _};
+use coap_message::error::RenderableOnMinimal as _;
+use coap_message_implementations::{inmemory, inmemory_write};
+use coap_numbers::code;
+use defmt::{info, warn};
+use miniconf::Tree;
+use miniconf_coap::{ConstPathJsonCoapHandler, JSON_CONTENT_FORMAT, MiniconfSchemaHandler};
+
+const RESPONSE_CAPACITY: usize = 1280;
+
+#[derive(Tree)]
+struct Settings {
+    hidden: bool,
+    number: u32,
+    #[tree(with = label)]
+    label: heapless::String<16>,
+    visible: Option<Visible>,
+}
+
+#[derive(Tree)]
+struct Visible {
+    value: u8,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            hidden: false,
+            number: 7,
+            label: "demo".try_into().unwrap(),
+            visible: Some(Visible { value: 9 }),
+        }
+    }
+}
+
+mod label {
+    use miniconf::{Keys, SerdeError, ValueError, leaf};
+    use serde::{Deserializer, Serializer};
+
+    pub use leaf::{mut_any_by_key, probe_by_key, ref_any_by_key, schema};
+
+    pub fn serialize_by_key<S: Serializer>(
+        value: &heapless::String<16>,
+        keys: impl Keys,
+        ser: S,
+    ) -> Result<S::Ok, SerdeError<S::Error>> {
+        leaf::serialize_by_key(value, keys, ser)
+    }
+
+    pub fn deserialize_by_key<'de, D: Deserializer<'de>>(
+        value: &mut heapless::String<16>,
+        keys: impl Keys,
+        de: D,
+    ) -> Result<(), SerdeError<D::Error>> {
+        let mut next = value.clone();
+        leaf::deserialize_by_key(&mut next, keys, de)?;
+        if next.contains('<') {
+            return Err(ValueError::Access("bad label").into());
+        }
+        *value = next;
+        Ok(())
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .try_init();
+    defmt2log::init_from_current_exe();
+
+    let bind = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:5683".into());
+    let socket = UdpSocket::bind(&bind)?;
+    info!("listening on coap://{=str}", bind.as_str());
+    info!(
+        "try: aiocoap-client coap://{=str}/.well-known/core",
+        bind.as_str()
+    );
+    info!(
+        "try: aiocoap-client coap://{=str}/settings/number",
+        bind.as_str()
+    );
+    info!(
+        "try: aiocoap-client -m PUT --content-format application/json --payload 12 coap://{=str}/settings/number",
+        bind.as_str()
+    );
+
+    let mut settings = Settings::default();
+    let mut request = [0; RESPONSE_CAPACITY];
+    let mut response = [0; RESPONSE_CAPACITY];
+
+    loop {
+        let (len, peer) = socket.recv_from(&mut request)?;
+        match handle_packet(&request[..len], &mut settings, &mut response) {
+            Ok(response_len) => {
+                socket.send_to(&response[..response_len], peer)?;
+            }
+            Err(error) => {
+                let peer = peer.to_string();
+                warn!("dropping request from {=str}: {=str}", peer.as_str(), error);
+            }
+        }
+    }
+}
+
+fn handle_packet(
+    request: &[u8],
+    settings: &mut Settings,
+    response: &mut [u8],
+) -> Result<usize, &'static str> {
+    let request = WirePacket::parse(request)?;
+    let miniconf = ConstPathJsonCoapHandler::const_path_json(settings);
+    let schema = MiniconfSchemaHandler::<Settings>::json();
+    let mut handler = coap_handler_implementations::new_dispatcher()
+        .below(&["settings"], miniconf)
+        .at(&["schema"], schema)
+        .at(
+            &["status"],
+            coap_handler_implementations::SimpleRendered::new_typed_str(
+                r#"{"ok":true}"#,
+                Some(JSON_CONTENT_FORMAT),
+            ),
+        )
+        .with_wkc();
+
+    let mut code = 0;
+    let mut tail = [0; RESPONSE_CAPACITY];
+    let mut message = inmemory_write::Message::new(&mut code, &mut tail);
+
+    match handler.extract_request_data(&request.message) {
+        Ok(data) => handler
+            .build_response(&mut message, data)
+            .map_err(|_| "response did not fit")?,
+        Err(error) => error
+            .render(&mut message)
+            .map_err(|_| "error response did not fit")?,
+    }
+
+    let tail_len = message.finish();
+    write_ack(
+        response,
+        code,
+        request.message_id,
+        request.token,
+        &tail[..tail_len],
+    )
+}
+
+fn write_ack(
+    response: &mut [u8],
+    code: u8,
+    message_id: [u8; 2],
+    token: &[u8],
+    tail: &[u8],
+) -> Result<usize, &'static str> {
+    let len = 4 + token.len() + tail.len();
+    if response.len() < len || token.len() > 8 {
+        return Err("response buffer too small");
+    }
+    response[0] = 0x60 | token.len() as u8;
+    response[1] = code;
+    response[2..4].copy_from_slice(&message_id);
+    response[4..4 + token.len()].copy_from_slice(token);
+    response[4 + token.len()..len].copy_from_slice(tail);
+    Ok(len)
+}
+
+#[derive(Debug)]
+struct WirePacket<'a> {
+    message_id: [u8; 2],
+    token: &'a [u8],
+    message: inmemory::Message<'a>,
+}
+
+impl<'a> WirePacket<'a> {
+    fn parse(packet: &'a [u8]) -> Result<Self, &'static str> {
+        let [header, request_code, mid_hi, mid_lo, rest @ ..] = packet else {
+            return Err("short header");
+        };
+        if header >> 6 != 1 {
+            return Err("unsupported CoAP version");
+        }
+        if header & 0x30 == 0x30 {
+            return Err("reset messages do not get ACK responses");
+        }
+        let token_len = usize::from(header & 0x0f);
+        if token_len > 8 {
+            return Err("token too long");
+        }
+        let Some((token, tail)) = rest.split_at_checked(token_len) else {
+            return Err("short token");
+        };
+        if *request_code == code::EMPTY {
+            return Err("empty request");
+        }
+        Ok(Self {
+            message_id: [*mid_hi, *mid_lo],
+            token,
+            message: inmemory::Message::new(*request_code, tail),
+        })
+    }
+}

--- a/miniconf_coap/examples/coap_server.rs
+++ b/miniconf_coap/examples/coap_server.rs
@@ -1,37 +1,28 @@
-use std::net::UdpSocket;
+use std::{env, io, net::UdpSocket};
 
 use coap_handler_implementations::{
     HandlerBuilder as _, ReportingHandlerBuilder as _, SimpleRendered, new_dispatcher,
 };
 use coap_message::error::RenderableOnMinimal as _;
 use coap_message_implementations::{inmemory, inmemory_write};
-use coap_numbers::code;
+use coap_numbers::{code, content_format};
 use defmt::{debug, info, warn};
 use miniconf_coap::{ConstPathJson, MiniconfHandler, MiniconfSchemaHandler};
 
 const DEFAULT_BIND: &str = "127.0.0.1:56830";
 const RESPONSE_CAPACITY: usize = 1280;
 
-const fn content_format(name: &str) -> u16 {
-    match coap_numbers::content_format::from_str(name) {
-        Some(value) => value,
-        None => panic!("unknown CoAP content format"),
-    }
-}
-
 #[path = "../../miniconf/examples/common.rs"]
 mod common;
 
 use common::Settings;
 
-fn main() -> std::io::Result<()> {
+fn main() -> io::Result<()> {
     let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
         .try_init();
     defmt2log::init_from_current_exe();
 
-    let bind = std::env::args()
-        .nth(1)
-        .unwrap_or_else(|| DEFAULT_BIND.into());
+    let bind = env::args().nth(1).unwrap_or_else(|| DEFAULT_BIND.into());
     let socket = UdpSocket::bind(&bind)?;
     info!("listening on coap://{=str}", bind.as_str());
     info!(
@@ -91,7 +82,7 @@ fn demo_handler() -> impl coap_handler::Handler + coap_handler::Reporting {
             &["status"],
             SimpleRendered::new_typed_str(
                 r#"{"ok":true}"#,
-                Some(content_format("application/json")),
+                Some(content_format::from_str("application/json").unwrap()),
             ),
         )
         .with_wkc()

--- a/miniconf_coap/src/handler.rs
+++ b/miniconf_coap/src/handler.rs
@@ -1,7 +1,10 @@
-use core::{borrow::BorrowMut, fmt::Write as _, marker::PhantomData};
+use core::{borrow::BorrowMut, fmt::Write as _, iter, marker::PhantomData};
 
+use coap_handler::Attribute;
 use coap_message::{MinimalWritableMessage, ReadableMessage};
 use coap_numbers::code;
+#[cfg(feature = "json-core")]
+use coap_numbers::content_format;
 use miniconf::{
     ExactSize, Meta, NodeIter, Schema, TreeDeserializeOwned, TreeSchema, TreeSerialize,
 };
@@ -11,7 +14,7 @@ use crate::ConstPathCbor;
 use crate::value::Representation;
 use crate::{
     Accepts, ChangedKey, Error, InvalidOption, MAX_DEPTH, MAX_HANDLER_PAYLOAD_LENGTH, Problem,
-    RequestParts, Response, UriPath, ValueHandler, content_format,
+    RequestParts, Response, UriPath, ValueHandler,
 };
 #[cfg(feature = "json-core")]
 use crate::{ConstPathJson, SchemaHandler};
@@ -187,8 +190,8 @@ where
     fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
         let _ = request;
         response_estimate(
-            content_format("text/plain; charset=utf-8"),
-            content_format("application/json"),
+            content_format::from_str("text/plain; charset=utf-8").unwrap(),
+            content_format::from_str("application/json").unwrap(),
         )
     }
 
@@ -274,12 +277,12 @@ where
     where
         Self: 'res;
     type Reporter<'res>
-        = core::iter::Once<SchemaRecord>
+        = iter::Once<SchemaRecord>
     where
         Self: 'res;
 
     fn report(&self) -> Self::Reporter<'_> {
-        core::iter::once(SchemaRecord)
+        iter::once(SchemaRecord)
     }
 }
 
@@ -344,16 +347,16 @@ impl<R> coap_handler::Record for MiniconfRecord<R> {
             .or_else(|| self.node_meta.get("doc"));
         Attributes {
             attrs: [
-                Some(coap_handler::Attribute::Ct(self.content_format)),
+                Some(Attribute::Ct(self.content_format)),
                 edge_meta
                     .get("rt")
                     .or_else(|| self.node_meta.get("rt"))
-                    .map(coap_handler::Attribute::ResourceType),
+                    .map(Attribute::ResourceType),
                 edge_meta
                     .get("if")
                     .or_else(|| self.node_meta.get("if"))
-                    .map(coap_handler::Attribute::Interface),
-                title.map(coap_handler::Attribute::Title),
+                    .map(Attribute::Interface),
+                title.map(Attribute::Title),
             ],
             pos: 0,
         }
@@ -405,12 +408,12 @@ impl AsRef<str> for DiscoveryPathElement {
 
 /// Iterator over CoRE Link Format attributes for a Miniconf discovery record.
 pub struct Attributes {
-    attrs: [Option<coap_handler::Attribute>; 4],
+    attrs: [Option<Attribute>; 4],
     pos: usize,
 }
 
 impl Iterator for Attributes {
-    type Item = coap_handler::Attribute;
+    type Item = Attribute;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(attr) = self.attrs.get(self.pos).copied() {
@@ -430,11 +433,11 @@ pub struct SchemaRecord;
 #[cfg(feature = "json-core")]
 impl coap_handler::Record for SchemaRecord {
     type PathElement = &'static str;
-    type PathElements = core::iter::Empty<&'static str>;
-    type Attributes = core::array::IntoIter<coap_handler::Attribute, 3>;
+    type PathElements = iter::Empty<&'static str>;
+    type Attributes = core::array::IntoIter<Attribute, 3>;
 
     fn path(&self) -> Self::PathElements {
-        core::iter::empty()
+        iter::empty()
     }
 
     fn rel(&self) -> Option<&str> {
@@ -443,9 +446,9 @@ impl coap_handler::Record for SchemaRecord {
 
     fn attributes(&self) -> Self::Attributes {
         [
-            coap_handler::Attribute::Ct(content_format("text/plain; charset=utf-8")),
-            coap_handler::Attribute::ResourceType("miniconf.schema"),
-            coap_handler::Attribute::Title("Miniconf schema"),
+            Attribute::Ct(content_format::from_str("text/plain; charset=utf-8").unwrap()),
+            Attribute::ResourceType("miniconf.schema"),
+            Attribute::Title("Miniconf schema"),
         ]
         .into_iter()
     }

--- a/miniconf_coap/src/handler.rs
+++ b/miniconf_coap/src/handler.rs
@@ -93,17 +93,6 @@ impl CoapHandlerRequest {
             payload,
         })
     }
-
-    fn as_request_parts(&self) -> RequestParts<'_> {
-        RequestParts {
-            code: self.code,
-            path: self.path.clone(),
-            accepts: self.accepts,
-            content_format: self.content_format,
-            invalid_option: self.invalid_option,
-            payload: self.payload.as_slice(),
-        }
-    }
 }
 
 impl<Storage, Settings, R> coap_handler::Handler for MiniconfHandler<Storage, Settings, R>
@@ -133,7 +122,22 @@ where
         message: &mut M,
         request: Self::RequestData,
     ) -> Result<(), Self::BuildResponseError<M>> {
-        let request = request.as_request_parts();
+        let CoapHandlerRequest {
+            code,
+            path,
+            accepts,
+            content_format,
+            invalid_option,
+            payload,
+        } = request;
+        let request = RequestParts {
+            code,
+            path,
+            accepts,
+            content_format,
+            invalid_option,
+            payload: payload.as_slice(),
+        };
         let mut response_buf = [0; MAX_HANDLER_PAYLOAD_LENGTH];
         let settings = self.settings.borrow_mut();
         // PUT currently mutates while producing the response. The 2.04 response is tiny, but a
@@ -187,7 +191,22 @@ where
         message: &mut M,
         request: Self::RequestData,
     ) -> Result<(), Self::BuildResponseError<M>> {
-        let request = request.as_request_parts();
+        let CoapHandlerRequest {
+            code,
+            path,
+            accepts,
+            content_format,
+            invalid_option,
+            payload,
+        } = request;
+        let request = RequestParts {
+            code,
+            path,
+            accepts,
+            content_format,
+            invalid_option,
+            payload: payload.as_slice(),
+        };
         let mut response_buf = [0; MAX_HANDLER_PAYLOAD_LENGTH];
         let outcome = SchemaHandler::new("").handle::<Settings>(&request, &mut response_buf);
         let response = outcome.response().unwrap_or(Response {

--- a/miniconf_coap/src/handler.rs
+++ b/miniconf_coap/src/handler.rs
@@ -2,16 +2,17 @@ use core::{borrow::BorrowMut, fmt::Write as _, marker::PhantomData};
 
 use coap_message::{MinimalWritableMessage, ReadableMessage};
 use coap_numbers::code;
-use miniconf::{TreeDeserializeOwned, TreeSchema, TreeSerialize};
+use miniconf::{ExactSize, NodeIter, Schema, TreeDeserializeOwned, TreeSchema, TreeSerialize};
 
 #[cfg(feature = "postcard")]
 use crate::PackedPostcard;
 use crate::{
-    Accepts, ChangedKey, Error, InvalidOption, MAX_DEPTH, MAX_HANDLER_PAYLOAD_LENGTH, Problem,
-    Representation, RequestParts, UriPath, ValueHandler,
+    Accepts, ChangedKey, Error, InvalidOption, JSON_CONTENT_FORMAT, MAX_DEPTH,
+    MAX_HANDLER_PAYLOAD_LENGTH, Problem, Representation, RequestParts, Response, UriPath,
+    ValueHandler,
 };
-#[cfg(feature = "json")]
-use crate::{ConstPathJson, JSON_CONTENT_FORMAT, SchemaHandler};
+#[cfg(feature = "json-core")]
+use crate::{ConstPathJson, SchemaHandler, TEXT_CONTENT_FORMAT};
 
 type HandlerPayload = heapless::Vec<u8, MAX_HANDLER_PAYLOAD_LENGTH>;
 
@@ -23,11 +24,11 @@ type HandlerPayload = heapless::Vec<u8, MAX_HANDLER_PAYLOAD_LENGTH>;
 pub struct MiniconfHandler<Storage, Settings, R> {
     settings: Storage,
     values: ValueHandler<'static, R>,
-    _settings: PhantomData<fn() -> Settings>,
+    _settings: PhantomData<Settings>,
 }
 
 /// Const-path JSON `coap-handler` adapter.
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 pub type ConstPathJsonCoapHandler<'a, Settings> =
     MiniconfHandler<&'a mut Settings, Settings, ConstPathJson>;
 
@@ -36,7 +37,7 @@ pub type ConstPathJsonCoapHandler<'a, Settings> =
 pub type PackedPostcardCoapHandler<'a, Settings> =
     MiniconfHandler<&'a mut Settings, Settings, PackedPostcard>;
 
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 impl<Storage, Settings> MiniconfHandler<Storage, Settings, ConstPathJson> {
     /// Create a route-relative JSON Miniconf value handler.
     pub const fn const_path_json(settings: Storage) -> Self {
@@ -63,11 +64,6 @@ impl<Storage, Settings> MiniconfHandler<Storage, Settings, PackedPostcard> {
 /// Request data carried from `coap-handler` extraction to response building.
 #[derive(Debug)]
 pub struct CoapHandlerRequest {
-    request: OwnedRequest,
-}
-
-#[derive(Debug)]
-struct OwnedRequest {
     code: u8,
     path: UriPath,
     accepts: Accepts,
@@ -76,7 +72,7 @@ struct OwnedRequest {
     payload: HandlerPayload,
 }
 
-impl OwnedRequest {
+impl CoapHandlerRequest {
     fn from_message<M>(message: &M) -> Result<Self, Error>
     where
         M: ReadableMessage + ?Sized,
@@ -122,9 +118,7 @@ where
         &mut self,
         request: &M,
     ) -> Result<Self::RequestData, Self::ExtractRequestError> {
-        Ok(CoapHandlerRequest {
-            request: OwnedRequest::from_message(request)?,
-        })
+        CoapHandlerRequest::from_message(request)
     }
 
     fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
@@ -137,13 +131,13 @@ where
         message: &mut M,
         request: Self::RequestData,
     ) -> Result<(), Self::BuildResponseError<M>> {
-        let request = request.request.as_request_parts();
+        let request = request.as_request_parts();
         let mut response_buf = [0; MAX_HANDLER_PAYLOAD_LENGTH];
         let settings = self.settings.borrow_mut();
         // PUT currently mutates while producing the response. The 2.04 response is tiny, but a
         // stricter version should probe/validate, write success, then commit.
         let outcome = self.values.handle(&request, settings, &mut response_buf);
-        let response = outcome.response().unwrap_or(crate::Response {
+        let response = outcome.response().unwrap_or(Response {
             code: code::NOT_FOUND,
             content_format: None,
             payload: b"",
@@ -153,25 +147,19 @@ where
 }
 
 /// `coap-handler` adapter for a Miniconf JSON schema resource.
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 #[derive(Debug)]
-pub struct MiniconfSchemaHandler<Settings> {
-    schema: SchemaHandler<'static>,
-    _settings: PhantomData<fn() -> Settings>,
-}
+pub struct MiniconfSchemaHandler<Settings>(PhantomData<Settings>);
 
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 impl<Settings> MiniconfSchemaHandler<Settings> {
     /// Create a route-relative JSON schema handler.
     pub const fn json() -> Self {
-        Self {
-            schema: SchemaHandler::new(""),
-            _settings: PhantomData,
-        }
+        Self(PhantomData)
     }
 }
 
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 impl<Settings> coap_handler::Handler for MiniconfSchemaHandler<Settings>
 where
     Settings: TreeSchema,
@@ -184,14 +172,12 @@ where
         &mut self,
         request: &M,
     ) -> Result<Self::RequestData, Self::ExtractRequestError> {
-        Ok(CoapHandlerRequest {
-            request: OwnedRequest::from_message(request)?,
-        })
+        CoapHandlerRequest::from_message(request)
     }
 
     fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
         let _ = request;
-        response_estimate(JSON_CONTENT_FORMAT)
+        response_estimate(TEXT_CONTENT_FORMAT)
     }
 
     fn build_response<M: coap_message::MutableWritableMessage>(
@@ -199,10 +185,10 @@ where
         message: &mut M,
         request: Self::RequestData,
     ) -> Result<(), Self::BuildResponseError<M>> {
-        let request = request.request.as_request_parts();
+        let request = request.as_request_parts();
         let mut response_buf = [0; MAX_HANDLER_PAYLOAD_LENGTH];
-        let outcome = self.schema.handle::<Settings>(&request, &mut response_buf);
-        let response = outcome.response().unwrap_or(crate::Response {
+        let outcome = SchemaHandler::new("").handle::<Settings>(&request, &mut response_buf);
+        let response = outcome.response().unwrap_or(Response {
             code: code::NOT_FOUND,
             content_format: None,
             payload: b"",
@@ -237,7 +223,7 @@ where
 
 fn response_estimate(content_format: u16) -> usize {
     let content_format_option =
-        1 + coap_uint_len(content_format).max(coap_uint_len(crate::JSON_CONTENT_FORMAT));
+        1 + coap_uint_len(content_format).max(coap_uint_len(JSON_CONTENT_FORMAT));
     content_format_option + 1 + MAX_HANDLER_PAYLOAD_LENGTH
 }
 
@@ -251,7 +237,7 @@ const fn coap_uint_len(value: u16) -> usize {
     }
 }
 
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 impl<Settings> coap_handler::Reporting for MiniconfSchemaHandler<Settings>
 where
     Settings: TreeSchema,
@@ -272,8 +258,8 @@ where
 
 /// Iterator over `coap-handler` discovery records for Miniconf leaves.
 pub struct MiniconfReporter<R> {
-    iter: miniconf::ExactSize<miniconf::NodeIter<ChangedKey, MAX_DEPTH>>,
-    root_schema: &'static miniconf::Schema,
+    iter: ExactSize<NodeIter<ChangedKey, MAX_DEPTH>>,
+    root_schema: &'static Schema,
     content_format: u16,
     _representation: PhantomData<R>,
 }
@@ -297,8 +283,8 @@ impl<R> Iterator for MiniconfReporter<R> {
 /// A `coap-handler` discovery record for one Miniconf leaf.
 pub struct MiniconfRecord<R> {
     key: ChangedKey,
-    root_schema: &'static miniconf::Schema,
-    schema: &'static miniconf::Schema,
+    root_schema: &'static Schema,
+    schema: &'static Schema,
     content_format: u16,
     _representation: PhantomData<R>,
 }
@@ -321,19 +307,15 @@ impl<R> coap_handler::Record for MiniconfRecord<R> {
     }
 
     fn attributes(&self) -> Self::Attributes {
-        let title = self
-            .schema
-            .node_meta_value("title")
-            .or_else(|| self.schema.node_meta_value("doc"));
+        let meta = self.schema.node_meta();
+        let title = meta.get("title").or_else(|| meta.get("doc"));
         Attributes {
             attrs: [
                 Some(coap_handler::Attribute::Ct(self.content_format)),
                 Some(coap_handler::Attribute::ResourceType(
-                    self.schema.node_meta_value("rt").unwrap_or("miniconf.leaf"),
+                    meta.get("rt").unwrap_or("miniconf.leaf"),
                 )),
-                self.schema
-                    .node_meta_value("if")
-                    .map(coap_handler::Attribute::Interface),
+                meta.get("if").map(coap_handler::Attribute::Interface),
                 title.map(coap_handler::Attribute::Title),
             ],
             pos: 0,
@@ -343,7 +325,7 @@ impl<R> coap_handler::Record for MiniconfRecord<R> {
 
 /// Iterator over URI path segments for a Miniconf discovery record.
 pub struct PathSegments {
-    schema: &'static miniconf::Schema,
+    schema: &'static Schema,
     root: ChangedKey,
     depth: usize,
 }
@@ -405,10 +387,10 @@ impl Iterator for Attributes {
 }
 
 /// `coap-handler` discovery record for the Miniconf schema resource.
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 pub struct SchemaRecord;
 
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 impl coap_handler::Record for SchemaRecord {
     type PathElement = &'static str;
     type PathElements = core::iter::Empty<&'static str>;
@@ -424,7 +406,7 @@ impl coap_handler::Record for SchemaRecord {
 
     fn attributes(&self) -> Self::Attributes {
         [
-            coap_handler::Attribute::Ct(JSON_CONTENT_FORMAT),
+            coap_handler::Attribute::Ct(TEXT_CONTENT_FORMAT),
             coap_handler::Attribute::ResourceType("miniconf.schema"),
             coap_handler::Attribute::Title("Miniconf schema"),
         ]

--- a/miniconf_coap/src/handler.rs
+++ b/miniconf_coap/src/handler.rs
@@ -312,9 +312,7 @@ impl<R> coap_handler::Record for MiniconfRecord<R> {
         Attributes {
             attrs: [
                 Some(coap_handler::Attribute::Ct(self.content_format)),
-                Some(coap_handler::Attribute::ResourceType(
-                    meta.get("rt").unwrap_or("miniconf.leaf"),
-                )),
+                meta.get("rt").map(coap_handler::Attribute::ResourceType),
                 meta.get("if").map(coap_handler::Attribute::Interface),
                 title.map(coap_handler::Attribute::Title),
             ],

--- a/miniconf_coap/src/handler.rs
+++ b/miniconf_coap/src/handler.rs
@@ -9,23 +9,19 @@ use miniconf::{
 
 #[cfg(feature = "cbor")]
 use crate::ConstPathCbor;
-use crate::value::Representation;
 use crate::{
     Accepts, ChangedKey, Error, InvalidOption, MAX_DEPTH, MAX_HANDLER_PAYLOAD_LENGTH, Problem,
-    RequestParts, Response, UriPath, ValueHandler, format,
+    RequestParts, Response, UriPath, ValueHandler, format, value::Representation,
 };
 #[cfg(feature = "json-core")]
 use crate::{ConstPathJson, SchemaHandler};
-
-type HandlerPayload<const N: usize> = heapless::Vec<u8, N>;
 
 /// `coap-handler` adapter for Miniconf leaf value resources.
 ///
 /// This adapter is route-relative: mount it with `coap-handler-implementations`
 /// `.below(&["settings"], ...)` and leave URI prefix handling to the ecosystem router.
-/// The const parameter sets the request payload and response scratch capacity.
 #[derive(Debug)]
-pub struct MiniconfHandler<Storage, Settings, R, const N: usize = MAX_HANDLER_PAYLOAD_LENGTH> {
+pub struct MiniconfHandler<Storage, Settings, R> {
     settings: Storage,
     values: ValueHandler<'static, R>,
     _settings: PhantomData<Settings>,
@@ -42,7 +38,7 @@ pub type ConstPathCborCoapHandler<'a, Settings> =
     MiniconfHandler<&'a mut Settings, Settings, ConstPathCbor>;
 
 #[cfg(feature = "json-core")]
-impl<Storage, Settings, const N: usize> MiniconfHandler<Storage, Settings, ConstPathJson, N> {
+impl<Storage, Settings> MiniconfHandler<Storage, Settings, ConstPathJson> {
     /// Create a route-relative JSON Miniconf value handler.
     pub const fn const_path_json(settings: Storage) -> Self {
         Self {
@@ -54,7 +50,7 @@ impl<Storage, Settings, const N: usize> MiniconfHandler<Storage, Settings, Const
 }
 
 #[cfg(feature = "cbor")]
-impl<Storage, Settings, const N: usize> MiniconfHandler<Storage, Settings, ConstPathCbor, N> {
+impl<Storage, Settings> MiniconfHandler<Storage, Settings, ConstPathCbor> {
     /// Create a route-relative CBOR Miniconf value handler.
     pub const fn const_path_cbor(settings: Storage) -> Self {
         Self {
@@ -65,46 +61,61 @@ impl<Storage, Settings, const N: usize> MiniconfHandler<Storage, Settings, Const
     }
 }
 
-/// Request data carried from `coap-handler` extraction to response building.
-#[derive(Debug)]
-pub struct CoapHandlerRequest<const N: usize = MAX_HANDLER_PAYLOAD_LENGTH> {
+/// Request metadata carried from `coap-handler` extraction to response building.
+#[doc(hidden)]
+#[derive(Debug, Default)]
+pub struct CoapHandlerRequest {
     code: u8,
     path: UriPath,
     accepts: Accepts,
     content_format: Option<u16>,
     invalid_option: Option<InvalidOption>,
-    payload: HandlerPayload<N>,
 }
 
-impl<const N: usize> CoapHandlerRequest<N> {
-    fn from_message<M>(message: &M) -> Result<Self, Error>
-    where
-        M: ReadableMessage + ?Sized,
-    {
-        let request = RequestParts::from_message(message)?;
-        let mut payload = HandlerPayload::<N>::new();
-        payload
-            .extend_from_slice(request.payload())
-            .map_err(|_| Error::request_entity_too_large(Problem::PayloadTooLong))?;
-        Ok(Self {
+impl CoapHandlerRequest {
+    fn from_parts(request: &RequestParts<'_>) -> Self {
+        Self {
             code: request.code,
-            path: request.path,
+            path: request.path.clone(),
             accepts: request.accepts,
             content_format: request.content_format,
             invalid_option: request.invalid_option,
-            payload,
-        })
+        }
+    }
+
+    fn into_request_parts(self) -> RequestParts<'static> {
+        RequestParts {
+            code: self.code,
+            path: self.path,
+            accepts: self.accepts,
+            content_format: self.content_format,
+            invalid_option: self.invalid_option,
+            payload: b"",
+        }
     }
 }
 
-impl<Storage, Settings, R, const N: usize> coap_handler::Handler
-    for MiniconfHandler<Storage, Settings, R, N>
+#[derive(Debug)]
+#[doc(hidden)]
+pub struct ValueRequest {
+    request: CoapHandlerRequest,
+    action: ValueAction,
+}
+
+#[derive(Debug)]
+enum ValueAction {
+    Build,
+    Changed,
+    Error(Error),
+}
+
+impl<Storage, Settings, R> coap_handler::Handler for MiniconfHandler<Storage, Settings, R>
 where
     Storage: BorrowMut<Settings>,
     Settings: TreeSchema + TreeSerialize + TreeDeserializeOwned,
     R: Representation,
 {
-    type RequestData = CoapHandlerRequest<N>;
+    type RequestData = ValueRequest;
     type ExtractRequestError = Error;
     type BuildResponseError<M: MinimalWritableMessage> = M::UnionError;
 
@@ -112,7 +123,42 @@ where
         &mut self,
         request: &M,
     ) -> Result<Self::RequestData, Self::ExtractRequestError> {
-        CoapHandlerRequest::from_message(request)
+        let request = RequestParts::from_message(request)?;
+        if let Err(err) = request.check_options() {
+            return Ok(ValueRequest {
+                request: CoapHandlerRequest::default(),
+                action: ValueAction::Error(err),
+            });
+        }
+        if request.code() == code::GET {
+            return Ok(ValueRequest {
+                request: CoapHandlerRequest::from_parts(&request),
+                action: ValueAction::Build,
+            });
+        }
+        if request.code() != code::PUT {
+            let err = Error::new(code::METHOD_NOT_ALLOWED, Problem::MethodNotAllowed);
+            return Ok(ValueRequest {
+                request: CoapHandlerRequest::default(),
+                action: ValueAction::Error(err),
+            });
+        }
+        // `coap-handler` request data can not borrow the request payload. Apply idempotent PUTs
+        // during extraction and carry only the response action, matching the ecosystem handlers.
+        let settings = self.settings.borrow_mut();
+        let path = request.path();
+        let action = match self
+            .values
+            .put_key(path, settings, &request)
+            .map(|_key| ValueAction::Changed)
+        {
+            Ok(action) => action,
+            Err(err) => ValueAction::Error(err),
+        };
+        Ok(ValueRequest {
+            request: CoapHandlerRequest::default(),
+            action,
+        })
     }
 
     fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
@@ -120,7 +166,7 @@ where
         response_estimate(
             self.values.representation.content_format(),
             self.values.representation.error_content_format(),
-            N,
+            MAX_HANDLER_PAYLOAD_LENGTH,
         )
     }
 
@@ -129,47 +175,42 @@ where
         message: &mut M,
         request: Self::RequestData,
     ) -> Result<(), Self::BuildResponseError<M>> {
-        let CoapHandlerRequest {
-            code,
-            path,
-            accepts,
-            content_format,
-            invalid_option,
-            payload,
-        } = request;
-        let request = RequestParts {
-            code,
-            path,
-            accepts,
-            content_format,
-            invalid_option,
-            payload: payload.as_slice(),
-        };
-        let mut response_buf = [0; N];
-        let settings = self.settings.borrow_mut();
-        // PUT currently mutates while producing the response. The 2.04 response is tiny, but a
-        // stricter version should probe/validate, write success, then commit.
-        let outcome = self.values.handle(&request, settings, &mut response_buf);
-        let response = outcome.response().unwrap_or(Response {
-            code: code::NOT_FOUND,
-            content_format: None,
-            payload: b"",
-        });
-        response.write_to(message)
+        match request.action {
+            ValueAction::Build => {
+                let mut response_buf = [0; MAX_HANDLER_PAYLOAD_LENGTH];
+                let request = request.request.into_request_parts();
+                let settings = self.settings.borrow_mut();
+                let outcome = self.values.handle(&request, settings, &mut response_buf);
+                let response = outcome.response().unwrap_or(Response {
+                    code: code::NOT_FOUND,
+                    content_format: None,
+                    payload: b"",
+                });
+                response.write_to(message)
+            }
+            ValueAction::Changed => Response {
+                code: code::CHANGED,
+                content_format: None,
+                payload: b"",
+            }
+            .write_to(message),
+            ValueAction::Error(err) => {
+                self.values
+                    .representation
+                    .write_error(err, message, MAX_HANDLER_PAYLOAD_LENGTH)
+            }
+        }
     }
 }
 
 /// `coap-handler` adapter for a Miniconf JSON schema resource.
 ///
-/// The const parameter sets the request payload and response scratch capacity.
 #[cfg(feature = "json-core")]
 #[derive(Debug)]
-pub struct MiniconfSchemaHandler<Settings, const N: usize = MAX_HANDLER_PAYLOAD_LENGTH>(
-    PhantomData<Settings>,
-);
+pub struct MiniconfSchemaHandler<Settings>(PhantomData<Settings>);
 
 #[cfg(feature = "json-core")]
-impl<Settings, const N: usize> MiniconfSchemaHandler<Settings, N> {
+impl<Settings> MiniconfSchemaHandler<Settings> {
     /// Create a route-relative JSON schema handler.
     pub const fn json() -> Self {
         Self(PhantomData)
@@ -177,11 +218,11 @@ impl<Settings, const N: usize> MiniconfSchemaHandler<Settings, N> {
 }
 
 #[cfg(feature = "json-core")]
-impl<Settings, const N: usize> coap_handler::Handler for MiniconfSchemaHandler<Settings, N>
+impl<Settings> coap_handler::Handler for MiniconfSchemaHandler<Settings>
 where
     Settings: TreeSchema,
 {
-    type RequestData = CoapHandlerRequest<N>;
+    type RequestData = CoapHandlerRequest;
     type ExtractRequestError = Error;
     type BuildResponseError<M: MinimalWritableMessage> = M::UnionError;
 
@@ -189,12 +230,12 @@ where
         &mut self,
         request: &M,
     ) -> Result<Self::RequestData, Self::ExtractRequestError> {
-        CoapHandlerRequest::from_message(request)
+        RequestParts::from_message(request).map(|request| CoapHandlerRequest::from_parts(&request))
     }
 
     fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
         let _ = request;
-        response_estimate(format::TEXT, format::JSON, N)
+        response_estimate(format::TEXT, format::JSON, MAX_HANDLER_PAYLOAD_LENGTH)
     }
 
     fn build_response<M: coap_message::MutableWritableMessage>(
@@ -202,23 +243,8 @@ where
         message: &mut M,
         request: Self::RequestData,
     ) -> Result<(), Self::BuildResponseError<M>> {
-        let CoapHandlerRequest {
-            code,
-            path,
-            accepts,
-            content_format,
-            invalid_option,
-            payload,
-        } = request;
-        let request = RequestParts {
-            code,
-            path,
-            accepts,
-            content_format,
-            invalid_option,
-            payload: payload.as_slice(),
-        };
-        let mut response_buf = [0; N];
+        let request = request.into_request_parts();
+        let mut response_buf = [0; MAX_HANDLER_PAYLOAD_LENGTH];
         let outcome = SchemaHandler::new("").handle::<Settings>(&request, &mut response_buf);
         let response = outcome.response().unwrap_or(Response {
             code: code::NOT_FOUND,
@@ -229,8 +255,7 @@ where
     }
 }
 
-impl<Storage, Settings, R, const N: usize> coap_handler::Reporting
-    for MiniconfHandler<Storage, Settings, R, N>
+impl<Storage, Settings, R> coap_handler::Reporting for MiniconfHandler<Storage, Settings, R>
 where
     Settings: TreeSchema,
     R: Representation,
@@ -275,7 +300,7 @@ const fn coap_uint_len(value: u16) -> usize {
 }
 
 #[cfg(feature = "json-core")]
-impl<Settings, const N: usize> coap_handler::Reporting for MiniconfSchemaHandler<Settings, N>
+impl<Settings> coap_handler::Reporting for MiniconfSchemaHandler<Settings>
 where
     Settings: TreeSchema,
 {
@@ -453,7 +478,7 @@ impl coap_handler::Record for SchemaRecord {
 
     fn attributes(&self) -> Self::Attributes {
         [
-            Attribute::Ct(format::TEXT),
+            Attribute::Ct(format::JSON),
             Attribute::ResourceType("miniconf.schema"),
             Attribute::Title("Miniconf schema"),
         ]

--- a/miniconf_coap/src/handler.rs
+++ b/miniconf_coap/src/handler.rs
@@ -1,0 +1,433 @@
+use core::{borrow::BorrowMut, fmt::Write as _, marker::PhantomData};
+
+use coap_message::{MinimalWritableMessage, ReadableMessage};
+use coap_numbers::code;
+use miniconf::{TreeDeserializeOwned, TreeSchema, TreeSerialize};
+
+#[cfg(feature = "postcard")]
+use crate::PackedPostcard;
+use crate::{
+    Accepts, ChangedKey, Error, InvalidOption, MAX_DEPTH, MAX_HANDLER_PAYLOAD_LENGTH, Problem,
+    Representation, RequestParts, UriPath, ValueHandler,
+};
+#[cfg(feature = "json")]
+use crate::{ConstPathJson, JSON_CONTENT_FORMAT, SchemaHandler};
+
+type HandlerPayload = heapless::Vec<u8, MAX_HANDLER_PAYLOAD_LENGTH>;
+
+/// `coap-handler` adapter for Miniconf leaf value resources.
+///
+/// This adapter is route-relative: mount it with `coap-handler-implementations`
+/// `.below(&["settings"], ...)` and leave URI prefix handling to the ecosystem router.
+#[derive(Debug)]
+pub struct MiniconfHandler<Storage, Settings, R> {
+    settings: Storage,
+    values: ValueHandler<'static, R>,
+    _settings: PhantomData<fn() -> Settings>,
+}
+
+/// Const-path JSON `coap-handler` adapter.
+#[cfg(feature = "json")]
+pub type ConstPathJsonCoapHandler<'a, Settings> =
+    MiniconfHandler<&'a mut Settings, Settings, ConstPathJson>;
+
+/// Packed-key postcard `coap-handler` adapter.
+#[cfg(feature = "postcard")]
+pub type PackedPostcardCoapHandler<'a, Settings> =
+    MiniconfHandler<&'a mut Settings, Settings, PackedPostcard>;
+
+#[cfg(feature = "json")]
+impl<Storage, Settings> MiniconfHandler<Storage, Settings, ConstPathJson> {
+    /// Create a route-relative JSON Miniconf value handler.
+    pub const fn const_path_json(settings: Storage) -> Self {
+        Self {
+            settings,
+            values: ValueHandler::const_path_json(""),
+            _settings: PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "postcard")]
+impl<Storage, Settings> MiniconfHandler<Storage, Settings, PackedPostcard> {
+    /// Create a route-relative postcard Miniconf value handler.
+    pub const fn packed_postcard(settings: Storage, content_format: u16) -> Self {
+        Self {
+            settings,
+            values: ValueHandler::packed_postcard("", content_format),
+            _settings: PhantomData,
+        }
+    }
+}
+
+/// Request data carried from `coap-handler` extraction to response building.
+#[derive(Debug)]
+pub struct CoapHandlerRequest {
+    request: OwnedRequest,
+}
+
+#[derive(Debug)]
+struct OwnedRequest {
+    code: u8,
+    path: UriPath,
+    accepts: Accepts,
+    content_format: Option<u16>,
+    invalid_option: Option<InvalidOption>,
+    payload: HandlerPayload,
+}
+
+impl OwnedRequest {
+    fn from_message<M>(message: &M) -> Result<Self, Error>
+    where
+        M: ReadableMessage + ?Sized,
+    {
+        let request = RequestParts::from_message(message)?;
+        let mut payload = HandlerPayload::new();
+        payload
+            .extend_from_slice(request.payload())
+            .map_err(|_| Error::request_entity_too_large(Problem::PayloadTooLong))?;
+        Ok(Self {
+            code: request.code,
+            path: request.path,
+            accepts: request.accepts,
+            content_format: request.content_format,
+            invalid_option: request.invalid_option,
+            payload,
+        })
+    }
+
+    fn as_request_parts(&self) -> RequestParts<'_> {
+        RequestParts {
+            code: self.code,
+            path: self.path.clone(),
+            accepts: self.accepts,
+            content_format: self.content_format,
+            invalid_option: self.invalid_option,
+            payload: self.payload.as_slice(),
+        }
+    }
+}
+
+impl<Storage, Settings, R> coap_handler::Handler for MiniconfHandler<Storage, Settings, R>
+where
+    Storage: BorrowMut<Settings>,
+    Settings: TreeSchema + TreeSerialize + TreeDeserializeOwned,
+    R: Representation,
+{
+    type RequestData = CoapHandlerRequest;
+    type ExtractRequestError = Error;
+    type BuildResponseError<M: MinimalWritableMessage> = M::UnionError;
+
+    fn extract_request_data<M: ReadableMessage>(
+        &mut self,
+        request: &M,
+    ) -> Result<Self::RequestData, Self::ExtractRequestError> {
+        Ok(CoapHandlerRequest {
+            request: OwnedRequest::from_message(request)?,
+        })
+    }
+
+    fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
+        let _ = request;
+        response_estimate(self.values.representation.content_format())
+    }
+
+    fn build_response<M: coap_message::MutableWritableMessage>(
+        &mut self,
+        message: &mut M,
+        request: Self::RequestData,
+    ) -> Result<(), Self::BuildResponseError<M>> {
+        let request = request.request.as_request_parts();
+        let mut response_buf = [0; MAX_HANDLER_PAYLOAD_LENGTH];
+        let settings = self.settings.borrow_mut();
+        // PUT currently mutates while producing the response. The 2.04 response is tiny, but a
+        // stricter version should probe/validate, write success, then commit.
+        let outcome = self.values.handle(&request, settings, &mut response_buf);
+        let response = outcome.response().unwrap_or(crate::Response {
+            code: code::NOT_FOUND,
+            content_format: None,
+            payload: b"",
+        });
+        response.write_to(message)
+    }
+}
+
+/// `coap-handler` adapter for a Miniconf JSON schema resource.
+#[cfg(feature = "json")]
+#[derive(Debug)]
+pub struct MiniconfSchemaHandler<Settings> {
+    schema: SchemaHandler<'static>,
+    _settings: PhantomData<fn() -> Settings>,
+}
+
+#[cfg(feature = "json")]
+impl<Settings> MiniconfSchemaHandler<Settings> {
+    /// Create a route-relative JSON schema handler.
+    pub const fn json() -> Self {
+        Self {
+            schema: SchemaHandler::new(""),
+            _settings: PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "json")]
+impl<Settings> coap_handler::Handler for MiniconfSchemaHandler<Settings>
+where
+    Settings: TreeSchema,
+{
+    type RequestData = CoapHandlerRequest;
+    type ExtractRequestError = Error;
+    type BuildResponseError<M: MinimalWritableMessage> = M::UnionError;
+
+    fn extract_request_data<M: ReadableMessage>(
+        &mut self,
+        request: &M,
+    ) -> Result<Self::RequestData, Self::ExtractRequestError> {
+        Ok(CoapHandlerRequest {
+            request: OwnedRequest::from_message(request)?,
+        })
+    }
+
+    fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
+        let _ = request;
+        response_estimate(JSON_CONTENT_FORMAT)
+    }
+
+    fn build_response<M: coap_message::MutableWritableMessage>(
+        &mut self,
+        message: &mut M,
+        request: Self::RequestData,
+    ) -> Result<(), Self::BuildResponseError<M>> {
+        let request = request.request.as_request_parts();
+        let mut response_buf = [0; MAX_HANDLER_PAYLOAD_LENGTH];
+        let outcome = self.schema.handle::<Settings>(&request, &mut response_buf);
+        let response = outcome.response().unwrap_or(crate::Response {
+            code: code::NOT_FOUND,
+            content_format: None,
+            payload: b"",
+        });
+        response.write_to(message)
+    }
+}
+
+impl<Storage, Settings, R> coap_handler::Reporting for MiniconfHandler<Storage, Settings, R>
+where
+    Settings: TreeSchema,
+    R: Representation,
+{
+    type Record<'res>
+        = MiniconfRecord<R>
+    where
+        Self: 'res;
+    type Reporter<'res>
+        = MiniconfReporter<R>
+    where
+        Self: 'res;
+
+    fn report(&self) -> Self::Reporter<'_> {
+        MiniconfReporter {
+            iter: Settings::SCHEMA.nodes::<ChangedKey, MAX_DEPTH>(),
+            root_schema: Settings::SCHEMA,
+            content_format: self.values.representation.content_format(),
+            _representation: PhantomData,
+        }
+    }
+}
+
+fn response_estimate(content_format: u16) -> usize {
+    let content_format_option =
+        1 + coap_uint_len(content_format).max(coap_uint_len(crate::JSON_CONTENT_FORMAT));
+    content_format_option + 1 + MAX_HANDLER_PAYLOAD_LENGTH
+}
+
+const fn coap_uint_len(value: u16) -> usize {
+    if value == 0 {
+        0
+    } else if value <= u8::MAX as u16 {
+        1
+    } else {
+        2
+    }
+}
+
+#[cfg(feature = "json")]
+impl<Settings> coap_handler::Reporting for MiniconfSchemaHandler<Settings>
+where
+    Settings: TreeSchema,
+{
+    type Record<'res>
+        = SchemaRecord
+    where
+        Self: 'res;
+    type Reporter<'res>
+        = core::iter::Once<SchemaRecord>
+    where
+        Self: 'res;
+
+    fn report(&self) -> Self::Reporter<'_> {
+        core::iter::once(SchemaRecord)
+    }
+}
+
+/// Iterator over `coap-handler` discovery records for Miniconf leaves.
+pub struct MiniconfReporter<R> {
+    iter: miniconf::ExactSize<miniconf::NodeIter<ChangedKey, MAX_DEPTH>>,
+    root_schema: &'static miniconf::Schema,
+    content_format: u16,
+    _representation: PhantomData<R>,
+}
+
+impl<R> Iterator for MiniconfReporter<R> {
+    type Item = MiniconfRecord<R>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let key = self.iter.next()?.ok()?;
+        let lookup = self.root_schema.get(key.as_ref()).ok()?;
+        Some(MiniconfRecord {
+            key,
+            root_schema: self.root_schema,
+            schema: lookup.schema,
+            content_format: self.content_format,
+            _representation: PhantomData,
+        })
+    }
+}
+
+/// A `coap-handler` discovery record for one Miniconf leaf.
+pub struct MiniconfRecord<R> {
+    key: ChangedKey,
+    root_schema: &'static miniconf::Schema,
+    schema: &'static miniconf::Schema,
+    content_format: u16,
+    _representation: PhantomData<R>,
+}
+
+impl<R> coap_handler::Record for MiniconfRecord<R> {
+    type PathElement = DiscoveryPathElement;
+    type PathElements = PathSegments;
+    type Attributes = Attributes;
+
+    fn path(&self) -> Self::PathElements {
+        PathSegments {
+            schema: self.root_schema,
+            root: self.key,
+            depth: 0,
+        }
+    }
+
+    fn rel(&self) -> Option<&str> {
+        None
+    }
+
+    fn attributes(&self) -> Self::Attributes {
+        let title = self
+            .schema
+            .node_meta_value("title")
+            .or_else(|| self.schema.node_meta_value("doc"));
+        Attributes {
+            attrs: [
+                Some(coap_handler::Attribute::Ct(self.content_format)),
+                Some(coap_handler::Attribute::ResourceType(
+                    self.schema.node_meta_value("rt").unwrap_or("miniconf.leaf"),
+                )),
+                self.schema
+                    .node_meta_value("if")
+                    .map(coap_handler::Attribute::Interface),
+                title.map(coap_handler::Attribute::Title),
+            ],
+            pos: 0,
+        }
+    }
+}
+
+/// Iterator over URI path segments for a Miniconf discovery record.
+pub struct PathSegments {
+    schema: &'static miniconf::Schema,
+    root: ChangedKey,
+    depth: usize,
+}
+
+impl Iterator for PathSegments {
+    type Item = DiscoveryPathElement;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = *self.root.as_ref().get(self.depth)?;
+        let internal = self.schema.internal()?;
+        let segment = if let Some(name) = internal.get_name(index) {
+            DiscoveryPathElement::Name(name)
+        } else {
+            let mut segment = heapless::String::new();
+            write!(segment, "{index}").ok()?;
+            DiscoveryPathElement::Index(segment)
+        };
+        self.schema = internal.get_schema(index);
+        self.depth += 1;
+        Some(segment)
+    }
+}
+
+/// Path element used by Miniconf `.well-known/core` discovery records.
+pub enum DiscoveryPathElement {
+    /// Borrowed schema path name.
+    Name(&'static str),
+    /// Numeric schema path element.
+    Index(heapless::String<20>),
+}
+
+impl AsRef<str> for DiscoveryPathElement {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Name(name) => name,
+            Self::Index(index) => index,
+        }
+    }
+}
+
+/// Iterator over CoRE Link Format attributes for a Miniconf discovery record.
+pub struct Attributes {
+    attrs: [Option<coap_handler::Attribute>; 4],
+    pos: usize,
+}
+
+impl Iterator for Attributes {
+    type Item = coap_handler::Attribute;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(attr) = self.attrs.get(self.pos).copied() {
+            self.pos += 1;
+            if attr.is_some() {
+                return attr;
+            }
+        }
+        None
+    }
+}
+
+/// `coap-handler` discovery record for the Miniconf schema resource.
+#[cfg(feature = "json")]
+pub struct SchemaRecord;
+
+#[cfg(feature = "json")]
+impl coap_handler::Record for SchemaRecord {
+    type PathElement = &'static str;
+    type PathElements = core::iter::Empty<&'static str>;
+    type Attributes = core::array::IntoIter<coap_handler::Attribute, 3>;
+
+    fn path(&self) -> Self::PathElements {
+        core::iter::empty()
+    }
+
+    fn rel(&self) -> Option<&str> {
+        None
+    }
+
+    fn attributes(&self) -> Self::Attributes {
+        [
+            coap_handler::Attribute::Ct(JSON_CONTENT_FORMAT),
+            coap_handler::Attribute::ResourceType("miniconf.schema"),
+            coap_handler::Attribute::Title("Miniconf schema"),
+        ]
+        .into_iter()
+    }
+}

--- a/miniconf_coap/src/handler.rs
+++ b/miniconf_coap/src/handler.rs
@@ -9,9 +9,8 @@ use miniconf::{
 #[cfg(feature = "cbor")]
 use crate::ConstPathCbor;
 use crate::{
-    Accepts, ChangedKey, Error, InvalidOption, JSON_CONTENT_FORMAT, MAX_DEPTH,
-    MAX_HANDLER_PAYLOAD_LENGTH, Problem, Representation, RequestParts, Response, UriPath,
-    ValueHandler,
+    Accepts, ChangedKey, Error, InvalidOption, MAX_DEPTH, MAX_HANDLER_PAYLOAD_LENGTH, Problem,
+    Representation, RequestParts, Response, UriPath, ValueHandler,
 };
 #[cfg(feature = "json-core")]
 use crate::{ConstPathJson, SchemaHandler, TEXT_CONTENT_FORMAT};
@@ -114,7 +113,10 @@ where
 
     fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
         let _ = request;
-        response_estimate(self.values.representation.content_format())
+        response_estimate(
+            self.values.representation.content_format(),
+            self.values.representation.error_content_format(),
+        )
     }
 
     fn build_response<M: coap_message::MutableWritableMessage>(
@@ -183,7 +185,7 @@ where
 
     fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
         let _ = request;
-        response_estimate(TEXT_CONTENT_FORMAT)
+        response_estimate(TEXT_CONTENT_FORMAT, crate::JSON_CONTENT_FORMAT)
     }
 
     fn build_response<M: coap_message::MutableWritableMessage>(
@@ -242,9 +244,9 @@ where
     }
 }
 
-fn response_estimate(content_format: u16) -> usize {
+fn response_estimate(content_format: u16, error_content_format: u16) -> usize {
     let content_format_option =
-        1 + coap_uint_len(content_format).max(coap_uint_len(JSON_CONTENT_FORMAT));
+        1 + coap_uint_len(content_format).max(coap_uint_len(error_content_format));
     content_format_option + 1 + MAX_HANDLER_PAYLOAD_LENGTH
 }
 

--- a/miniconf_coap/src/handler.rs
+++ b/miniconf_coap/src/handler.rs
@@ -4,8 +4,8 @@ use coap_message::{MinimalWritableMessage, ReadableMessage};
 use coap_numbers::code;
 use miniconf::{ExactSize, NodeIter, Schema, TreeDeserializeOwned, TreeSchema, TreeSerialize};
 
-#[cfg(feature = "postcard")]
-use crate::PackedPostcard;
+#[cfg(feature = "cbor")]
+use crate::ConstPathCbor;
 use crate::{
     Accepts, ChangedKey, Error, InvalidOption, JSON_CONTENT_FORMAT, MAX_DEPTH,
     MAX_HANDLER_PAYLOAD_LENGTH, Problem, Representation, RequestParts, Response, UriPath,
@@ -32,10 +32,10 @@ pub struct MiniconfHandler<Storage, Settings, R> {
 pub type ConstPathJsonCoapHandler<'a, Settings> =
     MiniconfHandler<&'a mut Settings, Settings, ConstPathJson>;
 
-/// Packed-key postcard `coap-handler` adapter.
-#[cfg(feature = "postcard")]
-pub type PackedPostcardCoapHandler<'a, Settings> =
-    MiniconfHandler<&'a mut Settings, Settings, PackedPostcard>;
+/// Const-path CBOR `coap-handler` adapter.
+#[cfg(feature = "cbor")]
+pub type ConstPathCborCoapHandler<'a, Settings> =
+    MiniconfHandler<&'a mut Settings, Settings, ConstPathCbor>;
 
 #[cfg(feature = "json-core")]
 impl<Storage, Settings> MiniconfHandler<Storage, Settings, ConstPathJson> {
@@ -49,13 +49,13 @@ impl<Storage, Settings> MiniconfHandler<Storage, Settings, ConstPathJson> {
     }
 }
 
-#[cfg(feature = "postcard")]
-impl<Storage, Settings> MiniconfHandler<Storage, Settings, PackedPostcard> {
-    /// Create a route-relative postcard Miniconf value handler.
-    pub const fn packed_postcard(settings: Storage, content_format: u16) -> Self {
+#[cfg(feature = "cbor")]
+impl<Storage, Settings> MiniconfHandler<Storage, Settings, ConstPathCbor> {
+    /// Create a route-relative CBOR Miniconf value handler.
+    pub const fn const_path_cbor(settings: Storage) -> Self {
         Self {
             settings,
-            values: ValueHandler::packed_postcard("", content_format),
+            values: ValueHandler::const_path_cbor(""),
             _settings: PhantomData,
         }
     }

--- a/miniconf_coap/src/handler.rs
+++ b/miniconf_coap/src/handler.rs
@@ -2,7 +2,9 @@ use core::{borrow::BorrowMut, fmt::Write as _, marker::PhantomData};
 
 use coap_message::{MinimalWritableMessage, ReadableMessage};
 use coap_numbers::code;
-use miniconf::{ExactSize, NodeIter, Schema, TreeDeserializeOwned, TreeSchema, TreeSerialize};
+use miniconf::{
+    ExactSize, Meta, NodeIter, Schema, TreeDeserializeOwned, TreeSchema, TreeSerialize,
+};
 
 #[cfg(feature = "cbor")]
 use crate::ConstPathCbor;
@@ -269,11 +271,12 @@ impl<R> Iterator for MiniconfReporter<R> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let key = self.iter.next()?.ok()?;
-        let lookup = self.root_schema.get(key.as_ref()).ok()?;
+        let (edge_meta, node_meta) = self.root_schema.get_meta(key.as_ref()).ok()?;
         Some(MiniconfRecord {
             key,
             root_schema: self.root_schema,
-            schema: lookup.schema,
+            edge_meta,
+            node_meta,
             content_format: self.content_format,
             _representation: PhantomData,
         })
@@ -284,7 +287,8 @@ impl<R> Iterator for MiniconfReporter<R> {
 pub struct MiniconfRecord<R> {
     key: ChangedKey,
     root_schema: &'static Schema,
-    schema: &'static Schema,
+    edge_meta: Option<&'static Meta>,
+    node_meta: &'static Meta,
     content_format: u16,
     _representation: PhantomData<R>,
 }
@@ -307,13 +311,23 @@ impl<R> coap_handler::Record for MiniconfRecord<R> {
     }
 
     fn attributes(&self) -> Self::Attributes {
-        let meta = self.schema.node_meta();
-        let title = meta.get("title").or_else(|| meta.get("doc"));
+        let edge_meta = self.edge_meta.unwrap_or(&Meta::EMPTY);
+        let title = edge_meta
+            .get("title")
+            .or_else(|| self.node_meta.get("title"))
+            .or_else(|| edge_meta.get("doc"))
+            .or_else(|| self.node_meta.get("doc"));
         Attributes {
             attrs: [
                 Some(coap_handler::Attribute::Ct(self.content_format)),
-                meta.get("rt").map(coap_handler::Attribute::ResourceType),
-                meta.get("if").map(coap_handler::Attribute::Interface),
+                edge_meta
+                    .get("rt")
+                    .or_else(|| self.node_meta.get("rt"))
+                    .map(coap_handler::Attribute::ResourceType),
+                edge_meta
+                    .get("if")
+                    .or_else(|| self.node_meta.get("if"))
+                    .map(coap_handler::Attribute::Interface),
                 title.map(coap_handler::Attribute::Title),
             ],
             pos: 0,

--- a/miniconf_coap/src/handler.rs
+++ b/miniconf_coap/src/handler.rs
@@ -8,12 +8,13 @@ use miniconf::{
 
 #[cfg(feature = "cbor")]
 use crate::ConstPathCbor;
+use crate::value::Representation;
 use crate::{
     Accepts, ChangedKey, Error, InvalidOption, MAX_DEPTH, MAX_HANDLER_PAYLOAD_LENGTH, Problem,
-    Representation, RequestParts, Response, UriPath, ValueHandler,
+    RequestParts, Response, UriPath, ValueHandler, content_format,
 };
 #[cfg(feature = "json-core")]
-use crate::{ConstPathJson, SchemaHandler, TEXT_CONTENT_FORMAT};
+use crate::{ConstPathJson, SchemaHandler};
 
 type HandlerPayload = heapless::Vec<u8, MAX_HANDLER_PAYLOAD_LENGTH>;
 
@@ -185,7 +186,10 @@ where
 
     fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
         let _ = request;
-        response_estimate(TEXT_CONTENT_FORMAT, crate::JSON_CONTENT_FORMAT)
+        response_estimate(
+            content_format("text/plain; charset=utf-8"),
+            content_format("application/json"),
+        )
     }
 
     fn build_response<M: coap_message::MutableWritableMessage>(
@@ -439,7 +443,7 @@ impl coap_handler::Record for SchemaRecord {
 
     fn attributes(&self) -> Self::Attributes {
         [
-            coap_handler::Attribute::Ct(TEXT_CONTENT_FORMAT),
+            coap_handler::Attribute::Ct(content_format("text/plain; charset=utf-8")),
             coap_handler::Attribute::ResourceType("miniconf.schema"),
             coap_handler::Attribute::Title("Miniconf schema"),
         ]

--- a/miniconf_coap/src/handler.rs
+++ b/miniconf_coap/src/handler.rs
@@ -10,7 +10,7 @@ use miniconf::{
 #[cfg(feature = "cbor")]
 use crate::ConstPathCbor;
 use crate::{
-    Accepts, ChangedKey, Error, InvalidOption, MAX_DEPTH, MAX_HANDLER_PAYLOAD_LENGTH, Problem,
+    Accepts, ChangedKey, Error, InvalidOption, MAX_DEPTH, MAX_HANDLER_RESPONSE_LENGTH, Problem,
     RequestParts, Response, UriPath, ValueHandler, format, value::Representation,
 };
 #[cfg(feature = "json-core")]
@@ -166,7 +166,7 @@ where
         response_estimate(
             self.values.representation.content_format(),
             self.values.representation.error_content_format(),
-            MAX_HANDLER_PAYLOAD_LENGTH,
+            MAX_HANDLER_RESPONSE_LENGTH,
         )
     }
 
@@ -177,7 +177,7 @@ where
     ) -> Result<(), Self::BuildResponseError<M>> {
         match request.action {
             ValueAction::Build => {
-                let mut response_buf = [0; MAX_HANDLER_PAYLOAD_LENGTH];
+                let mut response_buf = [0; MAX_HANDLER_RESPONSE_LENGTH];
                 let request = request.request.into_request_parts();
                 let settings = self.settings.borrow_mut();
                 let outcome = self.values.handle(&request, settings, &mut response_buf);
@@ -197,7 +197,7 @@ where
             ValueAction::Error(err) => {
                 self.values
                     .representation
-                    .write_error(err, message, MAX_HANDLER_PAYLOAD_LENGTH)
+                    .write_error(err, message, MAX_HANDLER_RESPONSE_LENGTH)
             }
         }
     }
@@ -235,7 +235,7 @@ where
 
     fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
         let _ = request;
-        response_estimate(format::TEXT, format::JSON, MAX_HANDLER_PAYLOAD_LENGTH)
+        response_estimate(format::TEXT, format::JSON, MAX_HANDLER_RESPONSE_LENGTH)
     }
 
     fn build_response<M: coap_message::MutableWritableMessage>(
@@ -244,7 +244,7 @@ where
         request: Self::RequestData,
     ) -> Result<(), Self::BuildResponseError<M>> {
         let request = request.into_request_parts();
-        let mut response_buf = [0; MAX_HANDLER_PAYLOAD_LENGTH];
+        let mut response_buf = [0; MAX_HANDLER_RESPONSE_LENGTH];
         let outcome = SchemaHandler::new("").handle::<Settings>(&request, &mut response_buf);
         let response = outcome.response().unwrap_or(Response {
             code: code::NOT_FOUND,

--- a/miniconf_coap/src/handler.rs
+++ b/miniconf_coap/src/handler.rs
@@ -3,8 +3,6 @@ use core::{borrow::BorrowMut, fmt::Write as _, iter, marker::PhantomData};
 use coap_handler::Attribute;
 use coap_message::{MinimalWritableMessage, ReadableMessage};
 use coap_numbers::code;
-#[cfg(feature = "json-core")]
-use coap_numbers::content_format;
 use miniconf::{
     ExactSize, Meta, NodeIter, Schema, TreeDeserializeOwned, TreeSchema, TreeSerialize,
 };
@@ -14,19 +12,20 @@ use crate::ConstPathCbor;
 use crate::value::Representation;
 use crate::{
     Accepts, ChangedKey, Error, InvalidOption, MAX_DEPTH, MAX_HANDLER_PAYLOAD_LENGTH, Problem,
-    RequestParts, Response, UriPath, ValueHandler,
+    RequestParts, Response, UriPath, ValueHandler, format,
 };
 #[cfg(feature = "json-core")]
 use crate::{ConstPathJson, SchemaHandler};
 
-type HandlerPayload = heapless::Vec<u8, MAX_HANDLER_PAYLOAD_LENGTH>;
+type HandlerPayload<const N: usize> = heapless::Vec<u8, N>;
 
 /// `coap-handler` adapter for Miniconf leaf value resources.
 ///
 /// This adapter is route-relative: mount it with `coap-handler-implementations`
 /// `.below(&["settings"], ...)` and leave URI prefix handling to the ecosystem router.
+/// The const parameter sets the request payload and response scratch capacity.
 #[derive(Debug)]
-pub struct MiniconfHandler<Storage, Settings, R> {
+pub struct MiniconfHandler<Storage, Settings, R, const N: usize = MAX_HANDLER_PAYLOAD_LENGTH> {
     settings: Storage,
     values: ValueHandler<'static, R>,
     _settings: PhantomData<Settings>,
@@ -43,7 +42,7 @@ pub type ConstPathCborCoapHandler<'a, Settings> =
     MiniconfHandler<&'a mut Settings, Settings, ConstPathCbor>;
 
 #[cfg(feature = "json-core")]
-impl<Storage, Settings> MiniconfHandler<Storage, Settings, ConstPathJson> {
+impl<Storage, Settings, const N: usize> MiniconfHandler<Storage, Settings, ConstPathJson, N> {
     /// Create a route-relative JSON Miniconf value handler.
     pub const fn const_path_json(settings: Storage) -> Self {
         Self {
@@ -55,7 +54,7 @@ impl<Storage, Settings> MiniconfHandler<Storage, Settings, ConstPathJson> {
 }
 
 #[cfg(feature = "cbor")]
-impl<Storage, Settings> MiniconfHandler<Storage, Settings, ConstPathCbor> {
+impl<Storage, Settings, const N: usize> MiniconfHandler<Storage, Settings, ConstPathCbor, N> {
     /// Create a route-relative CBOR Miniconf value handler.
     pub const fn const_path_cbor(settings: Storage) -> Self {
         Self {
@@ -68,22 +67,22 @@ impl<Storage, Settings> MiniconfHandler<Storage, Settings, ConstPathCbor> {
 
 /// Request data carried from `coap-handler` extraction to response building.
 #[derive(Debug)]
-pub struct CoapHandlerRequest {
+pub struct CoapHandlerRequest<const N: usize = MAX_HANDLER_PAYLOAD_LENGTH> {
     code: u8,
     path: UriPath,
     accepts: Accepts,
     content_format: Option<u16>,
     invalid_option: Option<InvalidOption>,
-    payload: HandlerPayload,
+    payload: HandlerPayload<N>,
 }
 
-impl CoapHandlerRequest {
+impl<const N: usize> CoapHandlerRequest<N> {
     fn from_message<M>(message: &M) -> Result<Self, Error>
     where
         M: ReadableMessage + ?Sized,
     {
         let request = RequestParts::from_message(message)?;
-        let mut payload = HandlerPayload::new();
+        let mut payload = HandlerPayload::<N>::new();
         payload
             .extend_from_slice(request.payload())
             .map_err(|_| Error::request_entity_too_large(Problem::PayloadTooLong))?;
@@ -98,13 +97,14 @@ impl CoapHandlerRequest {
     }
 }
 
-impl<Storage, Settings, R> coap_handler::Handler for MiniconfHandler<Storage, Settings, R>
+impl<Storage, Settings, R, const N: usize> coap_handler::Handler
+    for MiniconfHandler<Storage, Settings, R, N>
 where
     Storage: BorrowMut<Settings>,
     Settings: TreeSchema + TreeSerialize + TreeDeserializeOwned,
     R: Representation,
 {
-    type RequestData = CoapHandlerRequest;
+    type RequestData = CoapHandlerRequest<N>;
     type ExtractRequestError = Error;
     type BuildResponseError<M: MinimalWritableMessage> = M::UnionError;
 
@@ -120,6 +120,7 @@ where
         response_estimate(
             self.values.representation.content_format(),
             self.values.representation.error_content_format(),
+            N,
         )
     }
 
@@ -144,7 +145,7 @@ where
             invalid_option,
             payload: payload.as_slice(),
         };
-        let mut response_buf = [0; MAX_HANDLER_PAYLOAD_LENGTH];
+        let mut response_buf = [0; N];
         let settings = self.settings.borrow_mut();
         // PUT currently mutates while producing the response. The 2.04 response is tiny, but a
         // stricter version should probe/validate, write success, then commit.
@@ -159,12 +160,16 @@ where
 }
 
 /// `coap-handler` adapter for a Miniconf JSON schema resource.
+///
+/// The const parameter sets the request payload and response scratch capacity.
 #[cfg(feature = "json-core")]
 #[derive(Debug)]
-pub struct MiniconfSchemaHandler<Settings>(PhantomData<Settings>);
+pub struct MiniconfSchemaHandler<Settings, const N: usize = MAX_HANDLER_PAYLOAD_LENGTH>(
+    PhantomData<Settings>,
+);
 
 #[cfg(feature = "json-core")]
-impl<Settings> MiniconfSchemaHandler<Settings> {
+impl<Settings, const N: usize> MiniconfSchemaHandler<Settings, N> {
     /// Create a route-relative JSON schema handler.
     pub const fn json() -> Self {
         Self(PhantomData)
@@ -172,11 +177,11 @@ impl<Settings> MiniconfSchemaHandler<Settings> {
 }
 
 #[cfg(feature = "json-core")]
-impl<Settings> coap_handler::Handler for MiniconfSchemaHandler<Settings>
+impl<Settings, const N: usize> coap_handler::Handler for MiniconfSchemaHandler<Settings, N>
 where
     Settings: TreeSchema,
 {
-    type RequestData = CoapHandlerRequest;
+    type RequestData = CoapHandlerRequest<N>;
     type ExtractRequestError = Error;
     type BuildResponseError<M: MinimalWritableMessage> = M::UnionError;
 
@@ -189,10 +194,7 @@ where
 
     fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
         let _ = request;
-        response_estimate(
-            content_format::from_str("text/plain; charset=utf-8").unwrap(),
-            content_format::from_str("application/json").unwrap(),
-        )
+        response_estimate(format::TEXT, format::JSON, N)
     }
 
     fn build_response<M: coap_message::MutableWritableMessage>(
@@ -216,7 +218,7 @@ where
             invalid_option,
             payload: payload.as_slice(),
         };
-        let mut response_buf = [0; MAX_HANDLER_PAYLOAD_LENGTH];
+        let mut response_buf = [0; N];
         let outcome = SchemaHandler::new("").handle::<Settings>(&request, &mut response_buf);
         let response = outcome.response().unwrap_or(Response {
             code: code::NOT_FOUND,
@@ -227,7 +229,8 @@ where
     }
 }
 
-impl<Storage, Settings, R> coap_handler::Reporting for MiniconfHandler<Storage, Settings, R>
+impl<Storage, Settings, R, const N: usize> coap_handler::Reporting
+    for MiniconfHandler<Storage, Settings, R, N>
 where
     Settings: TreeSchema,
     R: Representation,
@@ -251,10 +254,14 @@ where
     }
 }
 
-fn response_estimate(content_format: u16, error_content_format: u16) -> usize {
+fn response_estimate(
+    content_format: u16,
+    error_content_format: u16,
+    payload_capacity: usize,
+) -> usize {
     let content_format_option =
         1 + coap_uint_len(content_format).max(coap_uint_len(error_content_format));
-    content_format_option + 1 + MAX_HANDLER_PAYLOAD_LENGTH
+    content_format_option + 1 + payload_capacity
 }
 
 const fn coap_uint_len(value: u16) -> usize {
@@ -268,7 +275,7 @@ const fn coap_uint_len(value: u16) -> usize {
 }
 
 #[cfg(feature = "json-core")]
-impl<Settings> coap_handler::Reporting for MiniconfSchemaHandler<Settings>
+impl<Settings, const N: usize> coap_handler::Reporting for MiniconfSchemaHandler<Settings, N>
 where
     Settings: TreeSchema,
 {
@@ -446,7 +453,7 @@ impl coap_handler::Record for SchemaRecord {
 
     fn attributes(&self) -> Self::Attributes {
         [
-            Attribute::Ct(content_format::from_str("text/plain; charset=utf-8").unwrap()),
+            Attribute::Ct(format::TEXT),
             Attribute::ResourceType("miniconf.schema"),
             Attribute::Title("Miniconf schema"),
         ]

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -580,64 +580,6 @@ where
         }
     }
 
-    /// Handle a `GET` request with read-only settings bounds.
-    pub fn handle_get<'b, Settings>(
-        &self,
-        request: &RequestParts<'_>,
-        settings: &Settings,
-        response_buf: &'b mut [u8],
-    ) -> Outcome<'b>
-    where
-        Settings: TreeSchema + TreeSerialize,
-    {
-        let Some(path) = request.relative_to(self.base) else {
-            trace!("Ignoring non-Miniconf CoAP route request={}", request);
-            return Outcome::Unhandled;
-        };
-        if let Err(err) = request.check_options() {
-            return Outcome::Handled(err.response(response_buf));
-        }
-
-        trace!(
-            "Handling Miniconf CoAP GET request base={=str} request={}",
-            self.base, request
-        );
-
-        if request.code != code::GET {
-            return method_not_allowed(request, response_buf);
-        }
-        self.get(path, settings, request, response_buf)
-    }
-
-    /// Handle a `PUT` request with write-only settings bounds.
-    pub fn handle_put<'b, Settings>(
-        &self,
-        request: &RequestParts<'_>,
-        settings: &mut Settings,
-        response_buf: &'b mut [u8],
-    ) -> Outcome<'b>
-    where
-        Settings: TreeSchema + TreeDeserializeOwned,
-    {
-        let Some(path) = request.relative_to(self.base) else {
-            trace!("Ignoring non-Miniconf CoAP route request={}", request);
-            return Outcome::Unhandled;
-        };
-        if let Err(err) = request.check_options() {
-            return Outcome::Handled(err.response(response_buf));
-        }
-
-        trace!(
-            "Handling Miniconf CoAP PUT request base={=str} request={}",
-            self.base, request
-        );
-
-        if request.code != code::PUT {
-            return method_not_allowed(request, response_buf);
-        }
-        self.put(path, settings, request, response_buf)
-    }
-
     fn get<'b, Settings>(
         &self,
         path: &str,
@@ -1602,14 +1544,14 @@ mod tests {
     }
 
     #[test]
-    fn get_and_put_can_be_used_separately() {
+    fn get_and_put_leaf() {
         init_host_logging();
         let handler = ConstPathJsonHandler::const_path_json("/settings");
         let mut settings = Settings::default();
         let mut response = [0; 128];
 
         let req = request(code::GET, &["settings", "number"], None, b"");
-        let outcome = handler.handle_get(&req, &settings, &mut response);
+        let outcome = handler.handle(&req, &mut settings, &mut response);
         let response = outcome.response().unwrap();
         assert_eq!(response.payload, b"7");
 
@@ -1621,7 +1563,7 @@ mod tests {
             b"14",
         );
         assert!(matches!(
-            handler.handle_put(&req, &mut settings, &mut response),
+            handler.handle(&req, &mut settings, &mut response),
             Outcome::Changed { .. }
         ));
         assert_eq!(settings.number, 14);
@@ -1637,10 +1579,10 @@ mod tests {
             .uint_option(option::ACCEPT, JSON_CONTENT_FORMAT);
         let request = RequestParts::from_message(&request).unwrap();
         let handler = ConstPathJsonHandler::const_path_json("/settings");
-        let settings = Settings::default();
+        let mut settings = Settings::default();
         let mut response = [0; 128];
 
-        let outcome = handler.handle_get(&request, &settings, &mut response);
+        let outcome = handler.handle(&request, &mut settings, &mut response);
         let response = outcome.response().unwrap();
         assert_eq!(response.code, code::CONTENT);
         assert_eq!(response.payload, b"7");
@@ -1651,7 +1593,7 @@ mod tests {
             .uint_option(option::ACCEPT, 0);
         let request = RequestParts::from_message(&request).unwrap();
         let mut response = [0; 128];
-        let outcome = handler.handle_get(&request, &settings, &mut response);
+        let outcome = handler.handle(&request, &mut settings, &mut response);
         let response = outcome.response().unwrap();
         assert_eq!(response.code, code::NOT_ACCEPTABLE);
 
@@ -1681,9 +1623,9 @@ mod tests {
             .uint_option(option::ACCEPT, 3);
         let request = RequestParts::from_message(&request).unwrap();
         let handler = ConstPathJsonHandler::const_path_json("/settings");
-        let settings = Settings::default();
+        let mut settings = Settings::default();
         let mut response = [0; 128];
-        let outcome = handler.handle_get(&request, &settings, &mut response);
+        let outcome = handler.handle(&request, &mut settings, &mut response);
         assert_eq!(outcome.response().unwrap().code, code::CONTENT);
 
         let request = TestMessage::new(code::GET)
@@ -1696,7 +1638,7 @@ mod tests {
             .uint_option(option::ACCEPT, 4);
         let request = RequestParts::from_message(&request).unwrap();
         let mut response = [0; 128];
-        let outcome = handler.handle_get(&request, &settings, &mut response);
+        let outcome = handler.handle(&request, &mut settings, &mut response);
         let response = outcome.response().unwrap();
         assert_eq!(response.code, code::BAD_OPTION);
         assert_eq!(response.payload, br#"{"kind":"too_many_accept_options"}"#);
@@ -1761,10 +1703,10 @@ mod tests {
     fn get_serialization_failures_are_not_bad_payload() {
         init_host_logging();
         let handler = ConstPathJsonHandler::const_path_json("/settings");
-        let settings = Settings::default();
+        let mut settings = Settings::default();
         let mut response = [0; 0];
         let req = request(code::GET, &["settings", "number"], None, b"");
-        let outcome = handler.handle_get(&req, &settings, &mut response);
+        let outcome = handler.handle(&req, &mut settings, &mut response);
         let response = outcome.response().unwrap();
         assert_eq!(response.code, code::INTERNAL_SERVER_ERROR);
         assert_eq!(response.payload, b"");
@@ -1834,7 +1776,7 @@ mod tests {
         let mut response = [0; 128];
 
         let req = request(code::GET, &["settings", "number"], None, b"");
-        let out = handler.handle_get(&req, &settings, &mut response);
+        let out = handler.handle(&req, &mut settings, &mut response);
         let response = out.response().unwrap();
         assert_eq!(response.code, code::CONTENT);
         assert_eq!(response.content_format, Some(CBOR_CONTENT_FORMAT));
@@ -1847,7 +1789,7 @@ mod tests {
             Some(CBOR_CONTENT_FORMAT),
             &[21],
         );
-        let out = handler.handle_put(&req, &mut settings, &mut response);
+        let out = handler.handle(&req, &mut settings, &mut response);
         assert!(matches!(out, Outcome::Changed { .. }));
         assert_eq!(settings.number, 21);
     }

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -68,8 +68,14 @@ type UriPath = heapless::String<MAX_URI_PATH_LENGTH>;
 
 #[cfg(feature = "coap-handler")]
 mod handler;
+#[cfg(all(feature = "coap-handler", feature = "cbor"))]
+pub use handler::ConstPathCborCoapHandler;
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
+pub use handler::ConstPathJsonCoapHandler;
 #[cfg(feature = "coap-handler")]
-pub use handler::*;
+pub use handler::MiniconfHandler;
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
+pub use handler::MiniconfSchemaHandler;
 
 #[derive(Debug, Clone, Copy, Default)]
 struct Accepts {
@@ -492,18 +498,20 @@ impl Error {
 
 /// Leaf value route backed by a Miniconf tree.
 #[derive(defmt::Format, Debug, Clone, Copy)]
-pub struct ValueHandler<'a, R> {
+pub(crate) struct ValueHandler<'a, R> {
     base: &'a str,
     representation: R,
 }
 
 /// Const-path-addressed JSON value route.
 #[cfg(feature = "json-core")]
-pub type ConstPathJsonHandler<'a> = ValueHandler<'a, ConstPathJson>;
+#[derive(defmt::Format, Debug, Clone, Copy)]
+pub struct ConstPathJsonHandler<'a>(ValueHandler<'a, ConstPathJson>);
 
 /// Const-path-addressed CBOR value route.
 #[cfg(feature = "cbor")]
-pub type ConstPathCborHandler<'a> = ValueHandler<'a, ConstPathCbor>;
+#[derive(defmt::Format, Debug, Clone, Copy)]
+pub struct ConstPathCborHandler<'a>(ValueHandler<'a, ConstPathCbor>);
 
 /// URI path segments as Miniconf `ConstPath` keys, with JSON payloads.
 #[cfg(feature = "json-core")]
@@ -526,8 +534,7 @@ impl private::Sealed for ConstPathCbor {}
 
 #[cfg(feature = "json-core")]
 impl<'a> ValueHandler<'a, ConstPathJson> {
-    /// Serve JSON where remaining URI path segments are Miniconf path segments.
-    pub const fn const_path_json(base: &'a str) -> Self {
+    const fn const_path_json(base: &'a str) -> Self {
         Self {
             base,
             representation: ConstPathJson,
@@ -537,8 +544,7 @@ impl<'a> ValueHandler<'a, ConstPathJson> {
 
 #[cfg(feature = "cbor")]
 impl<'a> ValueHandler<'a, ConstPathCbor> {
-    /// Serve CBOR where remaining URI path segments are Miniconf path segments.
-    pub const fn const_path_cbor(base: &'a str) -> Self {
+    const fn const_path_cbor(base: &'a str) -> Self {
         Self {
             base,
             representation: ConstPathCbor,
@@ -546,12 +552,53 @@ impl<'a> ValueHandler<'a, ConstPathCbor> {
     }
 }
 
+#[cfg(feature = "json-core")]
+impl<'a> ConstPathJsonHandler<'a> {
+    /// Serve JSON where remaining URI path segments are Miniconf path segments.
+    pub const fn const_path_json(base: &'a str) -> Self {
+        Self(ValueHandler::const_path_json(base))
+    }
+
+    /// Handle a single request using cooperative borrows.
+    pub fn handle<'b, Settings>(
+        &self,
+        request: &RequestParts<'_>,
+        settings: &mut Settings,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b>
+    where
+        Settings: TreeSchema + TreeSerialize + TreeDeserializeOwned,
+    {
+        self.0.handle(request, settings, response_buf)
+    }
+}
+
+#[cfg(feature = "cbor")]
+impl<'a> ConstPathCborHandler<'a> {
+    /// Serve CBOR where remaining URI path segments are Miniconf path segments.
+    pub const fn const_path_cbor(base: &'a str) -> Self {
+        Self(ValueHandler::const_path_cbor(base))
+    }
+
+    /// Handle a single request using cooperative borrows.
+    pub fn handle<'b, Settings>(
+        &self,
+        request: &RequestParts<'_>,
+        settings: &mut Settings,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b>
+    where
+        Settings: TreeSchema + TreeSerialize + TreeDeserializeOwned,
+    {
+        self.0.handle(request, settings, response_buf)
+    }
+}
+
 impl<'a, R> ValueHandler<'a, R>
 where
     R: Representation,
 {
-    /// Handle a single request using cooperative borrows.
-    pub fn handle<'b, Settings>(
+    fn handle<'b, Settings>(
         &self,
         request: &RequestParts<'_>,
         settings: &mut Settings,
@@ -728,7 +775,7 @@ where
 }
 
 /// Complete value representation used by a [`ValueHandler`].
-pub trait Representation: private::Sealed {
+pub(crate) trait Representation: private::Sealed {
     /// Serialization error type.
     type SerError;
     /// Deserialization error type.

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -7,7 +7,9 @@
 //! cooperative request handlers, and keep ownership of CoAP sockets, message IDs, tokens, routing,
 //! retransmission, and unrelated resources.
 
-use core::{convert::Infallible, fmt::Write as _};
+use core::convert::Infallible;
+#[cfg(feature = "json-core")]
+use core::fmt::Write as _;
 
 use coap_message::{
     Code as _, MessageOption, MinimalWritableMessage, OptionNumber as _, ReadableMessage,
@@ -16,6 +18,8 @@ use coap_numbers::{code, option};
 use defmt::{debug, trace, warn};
 #[cfg(feature = "cbor")]
 use minicbor::{
+    Encoder as CborEncoder,
+    data::Int as CborInt,
     decode::{Decoder as CborDecoder, Error as CborDecodeError},
     encode::{self, write::EndOfSlice},
 };
@@ -42,6 +46,9 @@ pub const JSON_CONTENT_FORMAT: u16 = 50;
 
 /// CBOR Content-Format number.
 pub const CBOR_CONTENT_FORMAT: u16 = 60;
+
+/// Concise Problem Details CBOR Content-Format number from RFC 9290.
+pub const PROBLEM_DETAILS_CBOR_CONTENT_FORMAT: u16 = 257;
 
 /// CoRE Link Format Content-Format number.
 pub const LINK_FORMAT_CONTENT_FORMAT: u16 = 40;
@@ -481,37 +488,47 @@ impl Error {
     }
 
     fn response<'a>(self, buf: &'a mut [u8]) -> Response<'a> {
-        match problem_json(self.problem, buf) {
-            Ok(len) => Response {
-                code: self.code,
-                content_format: Some(JSON_CONTENT_FORMAT),
-                payload: &buf[..len],
-            },
-            Err(_) => Response {
+        #[cfg(feature = "json-core")]
+        {
+            match problem_json(self.problem, buf) {
+                Ok(len) => Response {
+                    code: self.code,
+                    content_format: Some(JSON_CONTENT_FORMAT),
+                    payload: &buf[..len],
+                },
+                Err(_) => Response {
+                    code: self.code,
+                    content_format: None,
+                    payload: b"",
+                },
+            }
+        }
+        #[cfg(not(feature = "json-core"))]
+        {
+            let _ = buf;
+            Response {
                 code: self.code,
                 content_format: None,
                 payload: b"",
-            },
+            }
         }
     }
 }
 
 /// Leaf value route backed by a Miniconf tree.
 #[derive(defmt::Format, Debug, Clone, Copy)]
-pub(crate) struct ValueHandler<'a, R> {
+pub struct ValueHandler<'a, R> {
     base: &'a str,
     representation: R,
 }
 
 /// Const-path-addressed JSON value route.
 #[cfg(feature = "json-core")]
-#[derive(defmt::Format, Debug, Clone, Copy)]
-pub struct ConstPathJsonHandler<'a>(ValueHandler<'a, ConstPathJson>);
+pub type ConstPathJsonHandler<'a> = ValueHandler<'a, ConstPathJson>;
 
 /// Const-path-addressed CBOR value route.
 #[cfg(feature = "cbor")]
-#[derive(defmt::Format, Debug, Clone, Copy)]
-pub struct ConstPathCborHandler<'a>(ValueHandler<'a, ConstPathCbor>);
+pub type ConstPathCborHandler<'a> = ValueHandler<'a, ConstPathCbor>;
 
 /// URI path segments as Miniconf `ConstPath` keys, with JSON payloads.
 #[cfg(feature = "json-core")]
@@ -534,7 +551,8 @@ impl private::Sealed for ConstPathCbor {}
 
 #[cfg(feature = "json-core")]
 impl<'a> ValueHandler<'a, ConstPathJson> {
-    const fn const_path_json(base: &'a str) -> Self {
+    /// Serve JSON where remaining URI path segments are Miniconf path segments.
+    pub const fn const_path_json(base: &'a str) -> Self {
         Self {
             base,
             representation: ConstPathJson,
@@ -544,7 +562,8 @@ impl<'a> ValueHandler<'a, ConstPathJson> {
 
 #[cfg(feature = "cbor")]
 impl<'a> ValueHandler<'a, ConstPathCbor> {
-    const fn const_path_cbor(base: &'a str) -> Self {
+    /// Serve CBOR where remaining URI path segments are Miniconf path segments.
+    pub const fn const_path_cbor(base: &'a str) -> Self {
         Self {
             base,
             representation: ConstPathCbor,
@@ -552,53 +571,12 @@ impl<'a> ValueHandler<'a, ConstPathCbor> {
     }
 }
 
-#[cfg(feature = "json-core")]
-impl<'a> ConstPathJsonHandler<'a> {
-    /// Serve JSON where remaining URI path segments are Miniconf path segments.
-    pub const fn const_path_json(base: &'a str) -> Self {
-        Self(ValueHandler::const_path_json(base))
-    }
-
-    /// Handle a single request using cooperative borrows.
-    pub fn handle<'b, Settings>(
-        &self,
-        request: &RequestParts<'_>,
-        settings: &mut Settings,
-        response_buf: &'b mut [u8],
-    ) -> Outcome<'b>
-    where
-        Settings: TreeSchema + TreeSerialize + TreeDeserializeOwned,
-    {
-        self.0.handle(request, settings, response_buf)
-    }
-}
-
-#[cfg(feature = "cbor")]
-impl<'a> ConstPathCborHandler<'a> {
-    /// Serve CBOR where remaining URI path segments are Miniconf path segments.
-    pub const fn const_path_cbor(base: &'a str) -> Self {
-        Self(ValueHandler::const_path_cbor(base))
-    }
-
-    /// Handle a single request using cooperative borrows.
-    pub fn handle<'b, Settings>(
-        &self,
-        request: &RequestParts<'_>,
-        settings: &mut Settings,
-        response_buf: &'b mut [u8],
-    ) -> Outcome<'b>
-    where
-        Settings: TreeSchema + TreeSerialize + TreeDeserializeOwned,
-    {
-        self.0.handle(request, settings, response_buf)
-    }
-}
-
 impl<'a, R> ValueHandler<'a, R>
 where
     R: Representation,
 {
-    fn handle<'b, Settings>(
+    /// Handle a single request using cooperative borrows.
+    pub fn handle<'b, Settings>(
         &self,
         request: &RequestParts<'_>,
         settings: &mut Settings,
@@ -612,7 +590,7 @@ where
             return Outcome::Unhandled;
         };
         if let Err(err) = request.check_options() {
-            return Outcome::Handled(err.response(response_buf));
+            return Outcome::Handled(self.representation.error_response(err, response_buf));
         }
 
         trace!(
@@ -623,7 +601,7 @@ where
         match request.code {
             code::GET => self.get(path, &*settings, request, response_buf),
             code::PUT => self.put(path, settings, request, response_buf),
-            _ => method_not_allowed(request, response_buf),
+            _ => self.method_not_allowed(request, response_buf),
         }
     }
 
@@ -653,7 +631,7 @@ where
             }
             Err(err) => {
                 debug!("Rejecting Miniconf CoAP GET err={}", err);
-                Outcome::Handled(err.response(response_buf))
+                Outcome::Handled(self.representation.error_response(err, response_buf))
             }
         }
     }
@@ -707,7 +685,7 @@ where
             },
             Err(err) => {
                 debug!("Rejecting Miniconf CoAP PUT err={}", err);
-                Outcome::Handled(err.response(response_buf))
+                Outcome::Handled(self.representation.error_response(err, response_buf))
             }
         }
     }
@@ -772,10 +750,24 @@ where
         let lookup = self.representation.resolve::<Settings>(path, &mut state)?;
         Ok((lookup, Indices::new(state, lookup.depth)))
     }
+
+    fn method_not_allowed<'b>(
+        &self,
+        request: &RequestParts<'_>,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b> {
+        let err = Error::new(code::METHOD_NOT_ALLOWED, Problem::MethodNotAllowed);
+        debug!(
+            "Rejecting Miniconf CoAP request code={=u8} err={}",
+            request.code, err
+        );
+        Outcome::Handled(self.representation.error_response(err, response_buf))
+    }
 }
 
 /// Complete value representation used by a [`ValueHandler`].
-pub(crate) trait Representation: private::Sealed {
+#[doc(hidden)]
+pub trait Representation: private::Sealed {
     /// Serialization error type.
     type SerError;
     /// Deserialization error type.
@@ -783,6 +775,12 @@ pub(crate) trait Representation: private::Sealed {
 
     /// CoAP Content-Format used for successful responses and accepted request payloads.
     fn content_format(&self) -> u16;
+
+    /// CoAP Content-Format used for structured error responses.
+    fn error_content_format(&self) -> u16;
+
+    /// Serialize this route's structured error response into the response buffer.
+    fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a>;
 
     /// Resolve a route-relative URI path into a Miniconf schema lookup.
     fn resolve<Settings: TreeSchema>(
@@ -815,6 +813,14 @@ impl Representation for ConstPathJson {
 
     fn content_format(&self) -> u16 {
         JSON_CONTENT_FORMAT
+    }
+
+    fn error_content_format(&self) -> u16 {
+        JSON_CONTENT_FORMAT
+    }
+
+    fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a> {
+        error.response(buf)
     }
 
     fn resolve<Settings: TreeSchema>(
@@ -853,6 +859,25 @@ impl Representation for ConstPathCbor {
 
     fn content_format(&self) -> u16 {
         CBOR_CONTENT_FORMAT
+    }
+
+    fn error_content_format(&self) -> u16 {
+        PROBLEM_DETAILS_CBOR_CONTENT_FORMAT
+    }
+
+    fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a> {
+        match problem_cbor(error, buf) {
+            Ok(len) => Response {
+                code: error.code,
+                content_format: Some(PROBLEM_DETAILS_CBOR_CONTENT_FORMAT),
+                payload: &buf[..len],
+            },
+            Err(_) => Response {
+                code: error.code,
+                content_format: None,
+                payload: b"",
+            },
+        }
     }
 
     fn resolve<Settings: TreeSchema>(
@@ -1097,31 +1122,28 @@ fn value_error<E>(err: SerdeError<E>, op: Operation, depth: usize) -> Error {
     }
 }
 
-fn method_not_allowed<'a>(request: &RequestParts<'_>, response_buf: &'a mut [u8]) -> Outcome<'a> {
-    let err = Error::new(code::METHOD_NOT_ALLOWED, Problem::MethodNotAllowed);
-    debug!(
-        "Rejecting Miniconf CoAP request code={=u8} err={}",
-        request.code, err
-    );
-    Outcome::Handled(err.response(response_buf))
-}
-
+#[cfg(feature = "json-core")]
 fn problem_json(problem: Problem, buf: &mut [u8]) -> Result<usize, core::fmt::Error> {
     let mut out = SliceWriter::new(buf);
     match problem {
-        Problem::InvalidUriPath => write_kind(&mut out, "invalid_uri_path")?,
-        Problem::InvalidAccept => write_kind(&mut out, "invalid_accept")?,
-        Problem::InvalidContentFormat => write_kind(&mut out, "invalid_content_format")?,
-        Problem::DuplicateContentFormat => write_kind(&mut out, "duplicate_content_format")?,
+        Problem::InvalidUriPath
+        | Problem::InvalidAccept
+        | Problem::InvalidContentFormat
+        | Problem::DuplicateContentFormat
+        | Problem::UriPathTooLong
+        | Problem::PayloadTooLong
+        | Problem::TooManyAcceptOptions
+        | Problem::MethodNotAllowed
+        | Problem::NotAcceptable
+        | Problem::UnsupportedContentFormat
+        | Problem::BadPayload
+        | Problem::Serialization => write_kind(&mut out, problem_kind(problem))?,
         Problem::UnknownCriticalOption { number } => {
             write!(
                 out,
                 "{{\"kind\":\"unknown_critical_option\",\"number\":{number}}}"
             )?;
         }
-        Problem::UriPathTooLong => write_kind(&mut out, "uri_path_too_long")?,
-        Problem::PayloadTooLong => write_kind(&mut out, "payload_too_long")?,
-        Problem::TooManyAcceptOptions => write_kind(&mut out, "too_many_accept_options")?,
         Problem::NotFound { depth } => write_depth(&mut out, "not_found", depth)?,
         Problem::TooLong { depth } => write_depth(&mut out, "too_long", depth)?,
         Problem::NonLeaf { depth } => write_depth(&mut out, "non_leaf", depth)?,
@@ -1130,28 +1152,109 @@ fn problem_json(problem: Problem, buf: &mut [u8]) -> Result<usize, core::fmt::Er
             write!(
                 out,
                 "{{\"kind\":\"access\",\"op\":\"{}\",\"message\":",
-                match op {
-                    Operation::Read => "read",
-                    Operation::Write => "write",
-                }
+                operation_name(op)
             )?;
             write_json_string_truncated(&mut out, message, 1)?;
             out.push('}')?;
         }
-        Problem::MethodNotAllowed => write_kind(&mut out, "method_not_allowed")?,
-        Problem::NotAcceptable => write_kind(&mut out, "not_acceptable")?,
-        Problem::UnsupportedContentFormat => write_kind(&mut out, "unsupported_content_format")?,
-        Problem::BadPayload => write_kind(&mut out, "bad_payload")?,
-        Problem::Serialization => write_kind(&mut out, "serialization")?,
     }
     Ok(out.len())
 }
 
+#[cfg(feature = "cbor")]
+fn problem_cbor(error: Error, buf: &mut [u8]) -> Result<usize, encode::Error<EndOfSlice>> {
+    const MINICONF_PROBLEM_KEY: &str = "tag:quartiq.de,2026:miniconf";
+
+    let mut cursor = encode::write::Cursor::new(buf);
+    {
+        let kind = problem_kind(error.problem);
+        let mut encoder = CborEncoder::new(&mut cursor);
+        encoder
+            .map(3)?
+            .int(CborInt::from(-1i8))?
+            .str(kind)?
+            .int(CborInt::from(-4i8))?
+            .u8(error.code)?
+            .str(MINICONF_PROBLEM_KEY)?
+            .map(problem_detail_len(error.problem))?
+            .str("kind")?
+            .str(kind)?;
+
+        match error.problem {
+            Problem::UnknownCriticalOption { number } => {
+                encoder.str("number")?.u16(number)?;
+            }
+            Problem::NotFound { depth }
+            | Problem::TooLong { depth }
+            | Problem::NonLeaf { depth }
+            | Problem::Absent { depth } => {
+                encoder.str("depth")?.u64(depth as u64)?;
+            }
+            Problem::Access { op, message } => {
+                encoder
+                    .str("op")?
+                    .str(operation_name(op))?
+                    .str("message")?
+                    .str(message)?;
+            }
+            _ => {}
+        }
+    }
+    Ok(cursor.position())
+}
+
+#[cfg(feature = "cbor")]
+const fn problem_detail_len(problem: Problem) -> u64 {
+    match problem {
+        Problem::UnknownCriticalOption { .. }
+        | Problem::NotFound { .. }
+        | Problem::TooLong { .. }
+        | Problem::NonLeaf { .. }
+        | Problem::Absent { .. } => 2,
+        Problem::Access { .. } => 3,
+        _ => 1,
+    }
+}
+
+#[cfg(any(feature = "json-core", feature = "cbor"))]
+const fn problem_kind(problem: Problem) -> &'static str {
+    match problem {
+        Problem::InvalidUriPath => "invalid_uri_path",
+        Problem::InvalidAccept => "invalid_accept",
+        Problem::InvalidContentFormat => "invalid_content_format",
+        Problem::DuplicateContentFormat => "duplicate_content_format",
+        Problem::UnknownCriticalOption { .. } => "unknown_critical_option",
+        Problem::UriPathTooLong => "uri_path_too_long",
+        Problem::PayloadTooLong => "payload_too_long",
+        Problem::TooManyAcceptOptions => "too_many_accept_options",
+        Problem::NotFound { .. } => "not_found",
+        Problem::TooLong { .. } => "too_long",
+        Problem::NonLeaf { .. } => "non_leaf",
+        Problem::Absent { .. } => "absent",
+        Problem::Access { .. } => "access",
+        Problem::MethodNotAllowed => "method_not_allowed",
+        Problem::NotAcceptable => "not_acceptable",
+        Problem::UnsupportedContentFormat => "unsupported_content_format",
+        Problem::BadPayload => "bad_payload",
+        Problem::Serialization => "serialization",
+    }
+}
+
+#[cfg(any(feature = "json-core", feature = "cbor"))]
+const fn operation_name(op: Operation) -> &'static str {
+    match op {
+        Operation::Read => "read",
+        Operation::Write => "write",
+    }
+}
+
+#[cfg(feature = "json-core")]
 struct SliceWriter<'a> {
     buf: &'a mut [u8],
     len: usize,
 }
 
+#[cfg(feature = "json-core")]
 impl<'a> SliceWriter<'a> {
     fn new(buf: &'a mut [u8]) -> Self {
         Self { buf, len: 0 }
@@ -1170,6 +1273,7 @@ impl<'a> SliceWriter<'a> {
     }
 }
 
+#[cfg(feature = "json-core")]
 impl core::fmt::Write for SliceWriter<'_> {
     fn write_str(&mut self, value: &str) -> core::fmt::Result {
         let bytes = value.as_bytes();
@@ -1182,14 +1286,17 @@ impl core::fmt::Write for SliceWriter<'_> {
     }
 }
 
+#[cfg(feature = "json-core")]
 fn write_kind(out: &mut impl core::fmt::Write, kind: &str) -> core::fmt::Result {
     write!(out, "{{\"kind\":\"{}\"}}", kind)
 }
 
+#[cfg(feature = "json-core")]
 fn write_depth(out: &mut impl core::fmt::Write, kind: &str, depth: usize) -> core::fmt::Result {
     write!(out, "{{\"kind\":\"{}\",\"depth\":{}}}", kind, depth)
 }
 
+#[cfg(feature = "json-core")]
 fn write_json_string_truncated(
     out: &mut SliceWriter<'_>,
     value: &str,

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -24,14 +24,6 @@ pub const MAX_SCHEMA_DEFS: usize = 64;
 /// Exact changed leaf indices produced by a successful `PUT`.
 pub type ChangedKey = Indices<[usize; MAX_DEPTH]>;
 
-#[cfg(any(feature = "json-core", feature = "cbor", feature = "coap-handler"))]
-pub(crate) const fn content_format(name: &str) -> u16 {
-    match coap_numbers::content_format::from_str(name) {
-        Some(value) => value,
-        None => panic!("unknown CoAP content format"),
-    }
-}
-
 #[cfg(feature = "coap-handler")]
 mod handler;
 mod message;
@@ -66,11 +58,16 @@ mod tests {
     use core::convert::Infallible;
 
     use coap_message::{MessageOption as _, MinimalWritableMessage, ReadableMessage};
-    use coap_numbers::{code, option};
+    use coap_numbers::{code, content_format, option};
     use miniconf::Tree;
     use std::{sync::OnceLock, vec::Vec};
 
-    use super::*;
+    #[cfg(feature = "cbor")]
+    use crate::ConstPathCborHandler;
+    use crate::{
+        ConstPathJsonHandler, Error, Operation, Outcome, Problem, RequestParts, Response,
+        SchemaHandler,
+    };
 
     #[derive(Tree)]
     struct Settings {
@@ -280,7 +277,7 @@ mod tests {
         if request.path() == "/status" {
             return Outcome::Handled(Response {
                 code: code::CONTENT,
-                content_format: Some(content_format("application/json")),
+                content_format: Some(content_format::from_str("application/json").unwrap()),
                 payload: br#"{"ok":true}"#,
             });
         }
@@ -300,7 +297,7 @@ mod tests {
         assert_eq!(response.code, code::CONTENT);
         assert_eq!(
             response.content_format,
-            Some(content_format("application/json"))
+            Some(content_format::from_str("application/json").unwrap())
         );
         assert_eq!(response.payload, b"7");
 
@@ -308,7 +305,7 @@ mod tests {
         let req = request(
             code::PUT,
             &["settings", "number"],
-            Some(content_format("application/json")),
+            Some(content_format::from_str("application/json").unwrap()),
             b"12",
         );
         let out = handler.handle(&req, &mut settings, &mut response);
@@ -357,7 +354,7 @@ mod tests {
         let req = request(
             code::PUT,
             &["settings", "label"],
-            Some(content_format("application/json")),
+            Some(content_format::from_str("application/json").unwrap()),
             br#""bad<label""#,
         );
         let out = handler.handle(&req, &mut settings, &mut response);
@@ -380,7 +377,7 @@ mod tests {
         assert_eq!(response.code, code::CONTENT);
         assert_eq!(
             response.content_format,
-            Some(content_format("text/plain; charset=utf-8"))
+            Some(content_format::from_str("text/plain; charset=utf-8").unwrap())
         );
         assert!(response.payload.starts_with(b"{"));
     }
@@ -396,7 +393,7 @@ mod tests {
         assert_eq!(response.code, code::CONTENT);
         assert_eq!(
             response.content_format,
-            Some(content_format("text/plain; charset=utf-8"))
+            Some(content_format::from_str("text/plain; charset=utf-8").unwrap())
         );
         assert!(response.payload.starts_with(b"{"));
 
@@ -424,7 +421,7 @@ mod tests {
         let req = request(
             code::PUT,
             &["settings", "number"],
-            Some(content_format("application/json")),
+            Some(content_format::from_str("application/json").unwrap()),
             b"14",
         );
         assert!(matches!(
@@ -441,7 +438,10 @@ mod tests {
             .str_option(option::URI_PATH, "settings")
             .str_option(option::URI_PATH, "number")
             .uint_option(option::ACCEPT, 0)
-            .uint_option(option::ACCEPT, content_format("application/json"));
+            .uint_option(
+                option::ACCEPT,
+                content_format::from_str("application/json").unwrap(),
+            );
         let request = RequestParts::from_message(&request).unwrap();
         let handler = ConstPathJsonHandler::const_path_json("/settings");
         let mut settings = Settings::default();
@@ -465,7 +465,10 @@ mod tests {
         let request = TestMessage::new(code::GET)
             .str_option(option::URI_PATH, "schema")
             .uint_option(option::ACCEPT, 0)
-            .uint_option(option::ACCEPT, content_format("application/json"));
+            .uint_option(
+                option::ACCEPT,
+                content_format::from_str("application/json").unwrap(),
+            );
         let request = RequestParts::from_message(&request).unwrap();
         let handler = SchemaHandler::new("/schema");
         let mut response = [0; 512];
@@ -474,7 +477,7 @@ mod tests {
         assert_eq!(response.code, code::CONTENT);
         assert_eq!(
             response.content_format,
-            Some(content_format("text/plain; charset=utf-8"))
+            Some(content_format::from_str("text/plain; charset=utf-8").unwrap())
         );
     }
 
@@ -484,7 +487,10 @@ mod tests {
         let request = TestMessage::new(code::GET)
             .str_option(option::URI_PATH, "settings")
             .str_option(option::URI_PATH, "number")
-            .uint_option(option::ACCEPT, content_format("application/json"))
+            .uint_option(
+                option::ACCEPT,
+                content_format::from_str("application/json").unwrap(),
+            )
             .uint_option(option::ACCEPT, 0)
             .uint_option(option::ACCEPT, 1)
             .uint_option(option::ACCEPT, 2)
@@ -533,8 +539,14 @@ mod tests {
         let request = TestMessage::new(code::PUT)
             .str_option(option::URI_PATH, "settings")
             .str_option(option::URI_PATH, "number")
-            .uint_option(option::CONTENT_FORMAT, content_format("application/json"))
-            .uint_option(option::CONTENT_FORMAT, content_format("application/json"))
+            .uint_option(
+                option::CONTENT_FORMAT,
+                content_format::from_str("application/json").unwrap(),
+            )
+            .uint_option(
+                option::CONTENT_FORMAT,
+                content_format::from_str("application/json").unwrap(),
+            )
             .with_payload(b"12");
         let request = RequestParts::from_message(&request).unwrap();
         let mut response = [0; 128];
@@ -593,7 +605,7 @@ mod tests {
         let response = err.response(&mut response);
         assert_eq!(
             response.content_format,
-            Some(content_format("application/json"))
+            Some(content_format::from_str("application/json").unwrap())
         );
         assert!(
             response
@@ -609,7 +621,10 @@ mod tests {
         let request = TestMessage::new(code::PUT)
             .str_option(option::URI_PATH, "settings")
             .str_option(option::URI_PATH, "number")
-            .uint_option(option::CONTENT_FORMAT, content_format("application/json"))
+            .uint_option(
+                option::CONTENT_FORMAT,
+                content_format::from_str("application/json").unwrap(),
+            )
             .with_payload(b"18");
         let request = RequestParts::from_message(&request).unwrap();
         let mut settings = Settings::default();
@@ -623,7 +638,10 @@ mod tests {
 
         let request = TestMessage::new(code::GET)
             .str_option(option::URI_PATH, "status")
-            .uint_option(option::ACCEPT, content_format("application/json"));
+            .uint_option(
+                option::ACCEPT,
+                content_format::from_str("application/json").unwrap(),
+            );
         let request = RequestParts::from_message(&request).unwrap();
         let mut response_buf = [0; 128];
         let outcome = route(&request, &mut settings, &mut response_buf);
@@ -637,7 +655,7 @@ mod tests {
             .and_then(|opt| opt.value_uint::<u16>());
         assert_eq!(
             content_format_option,
-            Some(content_format("application/json"))
+            Some(content_format::from_str("application/json").unwrap())
         );
     }
 
@@ -655,7 +673,7 @@ mod tests {
         assert_eq!(response.code, code::CONTENT);
         assert_eq!(
             response.content_format,
-            Some(content_format("application/cbor"))
+            Some(content_format::from_str("application/cbor").unwrap())
         );
         assert_eq!(response.payload, &[7]);
 
@@ -663,7 +681,7 @@ mod tests {
         let req = request(
             code::PUT,
             &["settings", "number"],
-            Some(content_format("application/cbor")),
+            Some(content_format::from_str("application/cbor").unwrap()),
             &[21],
         );
         let out = handler.handle(&req, &mut settings, &mut response);

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -7,54 +7,7 @@
 //! cooperative request handlers, and keep ownership of CoAP sockets, message IDs, tokens, routing,
 //! retransmission, and unrelated resources.
 
-use core::convert::Infallible;
-#[cfg(feature = "json-core")]
-use core::fmt::Write as _;
-
-use coap_message::{
-    Code as _, MessageOption, MinimalWritableMessage, OptionNumber as _, ReadableMessage,
-};
-use coap_numbers::{code, option};
-use defmt::{debug, trace, warn};
-#[cfg(feature = "cbor")]
-use minicbor::{
-    Encoder as CborEncoder,
-    data::Int as CborInt,
-    decode::{Decoder as CborDecoder, Error as CborDecodeError},
-    encode::{self, write::EndOfSlice},
-};
-#[cfg(feature = "cbor")]
-use minicbor_serde::error::{DecodeError as CborDeError, EncodeError as CborSerError};
-#[cfg(any(feature = "json-core", feature = "cbor"))]
-use miniconf::{DescendError, ResolveError};
-use miniconf::{
-    Indices, KeyError, Lookup, SerdeError, TreeDeserializeOwned, TreeSchema, TreeSerialize,
-    ValueError,
-};
-#[cfg(feature = "json-core")]
-use miniconf::{
-    compact_schema::{SchemaDefs, serialize_schema_page},
-    json_core,
-};
-#[cfg(feature = "json-core")]
-use serde_json_core::{de::Error as JsonDeError, ser::Error as JsonSerError};
-
-const MAX_ACCEPT_OPTIONS: usize = 4;
-
-/// JSON Content-Format number.
-pub const JSON_CONTENT_FORMAT: u16 = 50;
-
-/// CBOR Content-Format number.
-pub const CBOR_CONTENT_FORMAT: u16 = 60;
-
-/// Concise Problem Details CBOR Content-Format number from RFC 9290.
-pub const PROBLEM_DETAILS_CBOR_CONTENT_FORMAT: u16 = 257;
-
-/// CoRE Link Format Content-Format number.
-pub const LINK_FORMAT_CONTENT_FORMAT: u16 = 40;
-
-/// Text Content-Format number.
-pub const TEXT_CONTENT_FORMAT: u16 = 0;
+use miniconf::Indices;
 
 /// Maximum Miniconf tree depth supported by `miniconf_coap`.
 pub const MAX_DEPTH: usize = 12;
@@ -71,10 +24,21 @@ pub const MAX_SCHEMA_DEFS: usize = 64;
 /// Exact changed leaf indices produced by a successful `PUT`.
 pub type ChangedKey = Indices<[usize; MAX_DEPTH]>;
 
-type UriPath = heapless::String<MAX_URI_PATH_LENGTH>;
+#[cfg(any(feature = "json-core", feature = "cbor", feature = "coap-handler"))]
+pub(crate) const fn content_format(name: &str) -> u16 {
+    match coap_numbers::content_format::from_str(name) {
+        Some(value) => value,
+        None => panic!("unknown CoAP content format"),
+    }
+}
 
 #[cfg(feature = "coap-handler")]
 mod handler;
+mod message;
+#[cfg(feature = "json-core")]
+mod schema;
+mod value;
+
 #[cfg(all(feature = "coap-handler", feature = "cbor"))]
 pub use handler::ConstPathCborCoapHandler;
 #[cfg(all(feature = "coap-handler", feature = "json-core"))]
@@ -83,1279 +47,17 @@ pub use handler::ConstPathJsonCoapHandler;
 pub use handler::MiniconfHandler;
 #[cfg(all(feature = "coap-handler", feature = "json-core"))]
 pub use handler::MiniconfSchemaHandler;
-
-#[derive(Debug, Clone, Copy, Default)]
-struct Accepts {
-    values: [u16; MAX_ACCEPT_OPTIONS],
-    len: usize,
-    overflow: bool,
-}
-
-impl Accepts {
-    const fn new() -> Self {
-        Self {
-            values: [0; MAX_ACCEPT_OPTIONS],
-            len: 0,
-            overflow: false,
-        }
-    }
-
-    fn from_option(value: Option<u16>) -> Self {
-        let mut accepts = Self::new();
-        if let Some(value) = value {
-            accepts.values[0] = value;
-            accepts.len = 1;
-        }
-        accepts
-    }
-
-    fn push(&mut self, value: u16) {
-        if let Some(slot) = self.values.get_mut(self.len) {
-            *slot = value;
-            self.len += 1;
-        } else {
-            self.overflow = true;
-        }
-    }
-
-    const fn is_present(&self) -> bool {
-        self.len != 0
-    }
-
-    fn first(&self) -> Option<u16> {
-        self.values.first().copied().filter(|_| self.len != 0)
-    }
-
-    fn contains(&self, content_format: u16) -> bool {
-        self.values[..self.len].contains(&content_format)
-    }
-
-    fn accepts(&self, content_format: u16) -> Result<(), Error> {
-        if !self.is_present() || self.contains(content_format) {
-            Ok(())
-        } else if self.overflow {
-            Err(Error::new(code::BAD_OPTION, Problem::TooManyAcceptOptions))
-        } else {
-            Err(Error::new(code::NOT_ACCEPTABLE, Problem::NotAcceptable))
-        }
-    }
-}
-
-/// Parsed CoAP request data used by cooperative handlers.
-#[derive(Debug)]
-pub struct RequestParts<'a> {
-    code: u8,
-    path: UriPath,
-    accepts: Accepts,
-    content_format: Option<u16>,
-    invalid_option: Option<InvalidOption>,
-    payload: &'a [u8],
-}
-
-impl<'a> RequestParts<'a> {
-    /// Build request parts from already-decoded fields.
-    pub fn new(
-        code: u8,
-        path: &[&str],
-        accept: Option<u16>,
-        content_format: Option<u16>,
-        payload: &'a [u8],
-    ) -> Result<Self, Error> {
-        let mut request = Self {
-            code,
-            path: UriPath::new(),
-            accepts: Accepts::from_option(accept),
-            content_format,
-            invalid_option: None,
-            payload,
-        };
-        for segment in path {
-            request.push_path_segment(segment)?;
-        }
-        Ok(request)
-    }
-
-    /// Extract method, URI path, content negotiation options, and payload from a readable message.
-    pub fn from_message<M>(message: &'a M) -> Result<Self, Error>
-    where
-        M: ReadableMessage + ?Sized,
-    {
-        let mut request = Self {
-            code: message.code().into(),
-            path: UriPath::new(),
-            accepts: Accepts::new(),
-            content_format: None,
-            invalid_option: None,
-            payload: message.payload(),
-        };
-
-        for opt in message.options() {
-            match opt.number() {
-                option::URI_PATH => {
-                    let Some(segment) = opt.value_str() else {
-                        return Err(Error::bad_request(Problem::InvalidUriPath));
-                    };
-                    request.push_path_segment(segment)?;
-                }
-                option::ACCEPT => {
-                    let Some(accept) = opt.value_uint() else {
-                        return Err(Error::bad_request(Problem::InvalidAccept));
-                    };
-                    request.accepts.push(accept);
-                }
-                option::CONTENT_FORMAT => {
-                    let Some(content_format) = opt.value_uint() else {
-                        return Err(Error::bad_request(Problem::InvalidContentFormat));
-                    };
-                    if request.content_format.is_some() {
-                        if request.invalid_option.is_none() {
-                            request.invalid_option = Some(InvalidOption::DuplicateContentFormat);
-                        }
-                        continue;
-                    }
-                    request.content_format = Some(content_format);
-                }
-                option::URI_HOST | option::URI_PORT => {}
-                number
-                    if coap_numbers::option::get_criticality(number)
-                        == coap_numbers::option::Criticality::Critical
-                        && request.invalid_option.is_none() =>
-                {
-                    request.invalid_option = Some(InvalidOption::UnknownCritical(number));
-                }
-                _ => {}
-            }
-        }
-
-        Ok(request)
-    }
-
-    /// Request method code.
-    pub const fn code(&self) -> u8 {
-        self.code
-    }
-
-    /// URI path segments.
-    pub fn path(&self) -> &str {
-        self.path.as_str()
-    }
-
-    /// Request payload.
-    pub const fn payload(&self) -> &'a [u8] {
-        self.payload
-    }
-
-    fn accepts(&self, content_format: u16) -> Result<(), Error> {
-        self.accepts.accepts(content_format)
-    }
-
-    fn check_options(&self) -> Result<(), Error> {
-        match self.invalid_option {
-            Some(InvalidOption::DuplicateContentFormat) => {
-                Err(Error::bad_request(Problem::DuplicateContentFormat))
-            }
-            Some(InvalidOption::UnknownCritical(number)) => Err(Error::new(
-                code::BAD_OPTION,
-                Problem::UnknownCriticalOption { number },
-            )),
-            None => Ok(()),
-        }
-    }
-
-    fn push_path_segment(&mut self, segment: &str) -> Result<(), Error> {
-        if segment.contains('/') {
-            return Err(Error::bad_request(Problem::InvalidUriPath));
-        }
-        self.path
-            .push('/')
-            .map_err(|_| Error::request_entity_too_large(Problem::UriPathTooLong))?;
-        self.path
-            .push_str(segment)
-            .map_err(|_| Error::request_entity_too_large(Problem::UriPathTooLong))
-    }
-
-    fn relative_to(&self, base: &str) -> Option<&str> {
-        if base.is_empty() {
-            return Some(self.path.as_str());
-        }
-        if self.path.as_str() == base {
-            return Some("");
-        }
-        let tail = self.path.as_str().strip_prefix(base)?;
-        tail.starts_with('/').then_some(tail)
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum InvalidOption {
-    DuplicateContentFormat,
-    UnknownCritical(u16),
-}
-
-impl defmt::Format for RequestParts<'_> {
-    fn format(&self, fmt: defmt::Formatter<'_>) {
-        defmt::write!(
-            fmt,
-            "RequestParts {{ code: {=u8}, path: {=str}, accept_present: {=bool}, accept: {=u16}, content_format_present: {=bool}, content_format: {=u16}, payload_len: {=usize} }}",
-            self.code,
-            self.path.as_str(),
-            self.accepts.is_present(),
-            self.accepts.first().unwrap_or(0),
-            self.content_format.is_some(),
-            self.content_format.unwrap_or(0),
-            self.payload.len()
-        )
-    }
-}
-
-/// CoAP response data produced by cooperative handlers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Response<'a> {
-    /// CoAP response code.
-    pub code: u8,
-    /// Optional CoAP Content-Format value.
-    pub content_format: Option<u16>,
-    /// Response payload.
-    pub payload: &'a [u8],
-}
-
-impl Response<'_> {
-    /// Render this response into a writable CoAP message.
-    pub fn write_to<M: MinimalWritableMessage>(
-        &self,
-        message: &mut M,
-    ) -> Result<(), M::UnionError> {
-        message.set_code(M::Code::new(self.code).map_err(M::convert_code_error)?);
-        if let Some(content_format) = self.content_format {
-            message
-                .add_option_uint(
-                    M::OptionNumber::new(option::CONTENT_FORMAT)
-                        .map_err(M::convert_option_number_error)?,
-                    content_format,
-                )
-                .map_err(M::convert_add_option_error)?;
-        }
-        message
-            .set_payload(self.payload)
-            .map_err(M::convert_set_payload_error)
-    }
-}
-
-impl defmt::Format for Response<'_> {
-    fn format(&self, fmt: defmt::Formatter<'_>) {
-        defmt::write!(
-            fmt,
-            "Response {{ code: {=u8}, content_format_present: {=bool}, content_format: {=u16}, payload_len: {=usize} }}",
-            self.code,
-            self.content_format.is_some(),
-            self.content_format.unwrap_or(0),
-            self.payload.len()
-        )
-    }
-}
-
-/// Handler outcome.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Outcome<'a> {
-    /// Request path is outside this handler's route.
-    Unhandled,
-    /// Request was handled without changing settings.
-    Handled(Response<'a>),
-    /// Request changed one exact leaf.
-    Changed {
-        /// Changed Miniconf leaf key.
-        key: ChangedKey,
-        /// CoAP response to send.
-        response: Response<'a>,
-    },
-}
-
-impl Outcome<'_> {
-    /// Return the response, if any.
-    pub const fn response(&self) -> Option<Response<'_>> {
-        match self {
-            Self::Unhandled => None,
-            Self::Handled(response) | Self::Changed { response, .. } => Some(*response),
-        }
-    }
-}
-
-impl defmt::Format for Outcome<'_> {
-    fn format(&self, fmt: defmt::Formatter<'_>) {
-        match self {
-            Self::Unhandled => defmt::write!(fmt, "Outcome::Unhandled"),
-            Self::Handled(response) => defmt::write!(fmt, "Outcome::Handled({})", response),
-            Self::Changed { key, response } => defmt::write!(
-                fmt,
-                "Outcome::Changed {{ key: {}, response: {} }}",
-                key,
-                response
-            ),
-        }
-    }
-}
-
-/// Problem details preserved in error responses.
-#[derive(defmt::Format, Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Problem {
-    /// URI path option was not valid UTF-8.
-    InvalidUriPath,
-    /// Accept option could not be decoded as a CoAP uint.
-    InvalidAccept,
-    /// Content-Format option could not be decoded as a CoAP uint.
-    InvalidContentFormat,
-    /// More than one Content-Format option was present.
-    DuplicateContentFormat,
-    /// An unknown critical CoAP option was present.
-    UnknownCriticalOption {
-        /// CoAP option number.
-        number: u16,
-    },
-    /// URI path had more segments than this handler captured.
-    UriPathTooLong,
-    /// A response payload exceeded the optional handler adapter buffer.
-    PayloadTooLong,
-    /// Request had more Accept options than this handler captures.
-    TooManyAcceptOptions,
-    /// Request path names no static Miniconf resource.
-    NotFound {
-        /// Depth reached before lookup failed.
-        depth: usize,
-    },
-    /// Request path continues below a leaf.
-    TooLong {
-        /// Depth of the leaf under which the request continued.
-        depth: usize,
-    },
-    /// Request path names a known branch, but this route handles leaves only.
-    NonLeaf {
-        /// Depth of the branch resource.
-        depth: usize,
-    },
-    /// Static schema contains the leaf, but runtime state makes it absent.
-    Absent {
-        /// Depth of the runtime-absent leaf.
-        depth: usize,
-    },
-    /// Runtime access policy denied the operation.
-    Access {
-        /// Operation being performed.
-        op: Operation,
-        /// Error text from Miniconf.
-        message: &'static str,
-    },
-    /// Request method is not supported here.
-    MethodNotAllowed,
-    /// Request `Accept` option does not allow this route's representation.
-    NotAcceptable,
-    /// Request payload Content-Format is not supported here.
-    UnsupportedContentFormat,
-    /// Payload could not be decoded.
-    BadPayload,
-    /// A read-side value serialization failed.
-    Serialization,
-}
-
-/// CoAP operation being performed.
-#[derive(defmt::Format, Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Operation {
-    /// Read operation.
-    Read,
-    /// Write operation.
-    Write,
-}
-
-/// CoAP handler error.
-#[derive(defmt::Format, Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Error {
-    /// CoAP response code.
-    pub code: u8,
-    /// Machine-readable problem.
-    pub problem: Problem,
-}
-
-impl Error {
-    const fn new(code: u8, problem: Problem) -> Self {
-        Self { code, problem }
-    }
-
-    const fn bad_request(problem: Problem) -> Self {
-        Self::new(code::BAD_REQUEST, problem)
-    }
-
-    const fn request_entity_too_large(problem: Problem) -> Self {
-        Self::new(code::REQUEST_ENTITY_TOO_LARGE, problem)
-    }
-
-    fn response<'a>(self, buf: &'a mut [u8]) -> Response<'a> {
-        #[cfg(feature = "json-core")]
-        {
-            match problem_json(self.problem, buf) {
-                Ok(len) => Response {
-                    code: self.code,
-                    content_format: Some(JSON_CONTENT_FORMAT),
-                    payload: &buf[..len],
-                },
-                Err(_) => Response {
-                    code: self.code,
-                    content_format: None,
-                    payload: b"",
-                },
-            }
-        }
-        #[cfg(not(feature = "json-core"))]
-        {
-            let _ = buf;
-            Response {
-                code: self.code,
-                content_format: None,
-                payload: b"",
-            }
-        }
-    }
-}
-
-/// Leaf value route backed by a Miniconf tree.
-#[derive(defmt::Format, Debug, Clone, Copy)]
-pub struct ValueHandler<'a, R> {
-    base: &'a str,
-    representation: R,
-}
-
-/// Const-path-addressed JSON value route.
+pub use message::{Error, Operation, Outcome, Problem, RequestParts, Response};
 #[cfg(feature = "json-core")]
-pub type ConstPathJsonHandler<'a> = ValueHandler<'a, ConstPathJson>;
-
-/// Const-path-addressed CBOR value route.
+pub use schema::SchemaHandler;
+pub use value::ValueHandler;
 #[cfg(feature = "cbor")]
-pub type ConstPathCborHandler<'a> = ValueHandler<'a, ConstPathCbor>;
-
-/// URI path segments as Miniconf `ConstPath` keys, with JSON payloads.
+pub use value::{ConstPathCbor, ConstPathCborHandler};
 #[cfg(feature = "json-core")]
-#[derive(defmt::Format, Debug, Clone, Copy)]
-pub struct ConstPathJson;
+pub use value::{ConstPathJson, ConstPathJsonHandler};
 
-/// URI path segments as Miniconf `ConstPath` keys, with CBOR payloads.
-#[cfg(feature = "cbor")]
-#[derive(defmt::Format, Debug, Clone, Copy)]
-pub struct ConstPathCbor;
-
-mod private {
-    pub trait Sealed {}
-}
-
-#[cfg(feature = "json-core")]
-impl private::Sealed for ConstPathJson {}
-#[cfg(feature = "cbor")]
-impl private::Sealed for ConstPathCbor {}
-
-#[cfg(feature = "json-core")]
-impl<'a> ValueHandler<'a, ConstPathJson> {
-    /// Serve JSON where remaining URI path segments are Miniconf path segments.
-    pub const fn const_path_json(base: &'a str) -> Self {
-        Self {
-            base,
-            representation: ConstPathJson,
-        }
-    }
-}
-
-#[cfg(feature = "cbor")]
-impl<'a> ValueHandler<'a, ConstPathCbor> {
-    /// Serve CBOR where remaining URI path segments are Miniconf path segments.
-    pub const fn const_path_cbor(base: &'a str) -> Self {
-        Self {
-            base,
-            representation: ConstPathCbor,
-        }
-    }
-}
-
-impl<'a, R> ValueHandler<'a, R>
-where
-    R: Representation,
-{
-    /// Handle a single request using cooperative borrows.
-    pub fn handle<'b, Settings>(
-        &self,
-        request: &RequestParts<'_>,
-        settings: &mut Settings,
-        response_buf: &'b mut [u8],
-    ) -> Outcome<'b>
-    where
-        Settings: TreeSchema + TreeSerialize + TreeDeserializeOwned,
-    {
-        let Some(path) = request.relative_to(self.base) else {
-            trace!("Ignoring non-Miniconf CoAP route request={}", request);
-            return Outcome::Unhandled;
-        };
-        if let Err(err) = request.check_options() {
-            return Outcome::Handled(self.representation.error_response(err, response_buf));
-        }
-
-        trace!(
-            "Handling Miniconf CoAP request base={=str} request={}",
-            self.base, request
-        );
-
-        match request.code {
-            code::GET => self.get(path, &*settings, request, response_buf),
-            code::PUT => self.put(path, settings, request, response_buf),
-            _ => self.method_not_allowed(request, response_buf),
-        }
-    }
-
-    fn get<'b, Settings>(
-        &self,
-        path: &str,
-        settings: &Settings,
-        request: &RequestParts<'_>,
-        response_buf: &'b mut [u8],
-    ) -> Outcome<'b>
-    where
-        Settings: TreeSchema + TreeSerialize,
-    {
-        match self.get_len::<Settings>(path, settings, request, response_buf) {
-            Ok(len) => {
-                debug!(
-                    "Handled Miniconf CoAP GET path={=str} depth={=usize} response_len={=usize}",
-                    request.path(),
-                    path_depth(path),
-                    len
-                );
-                Outcome::Handled(Response {
-                    code: code::CONTENT,
-                    content_format: Some(self.representation.content_format()),
-                    payload: &response_buf[..len],
-                })
-            }
-            Err(err) => {
-                debug!("Rejecting Miniconf CoAP GET err={}", err);
-                Outcome::Handled(self.representation.error_response(err, response_buf))
-            }
-        }
-    }
-
-    fn get_len<Settings>(
-        &self,
-        path: &str,
-        settings: &Settings,
-        request: &RequestParts<'_>,
-        response_buf: &mut [u8],
-    ) -> Result<usize, Error>
-    where
-        Settings: TreeSchema + TreeSerialize,
-    {
-        request.accepts(self.representation.content_format())?;
-        let (lookup, state) = self.resolve::<Settings>(path)?;
-        if !lookup.schema.is_leaf() {
-            return Err(Error::new(
-                code::METHOD_NOT_ALLOWED,
-                Problem::NonLeaf {
-                    depth: lookup.depth,
-                },
-            ));
-        }
-
-        let len = self
-            .representation
-            .get(settings, &state.as_ref()[..lookup.depth], response_buf)
-            .map_err(|err| read_error(err, lookup.depth))?;
-        Ok(len)
-    }
-
-    fn put<'b, Settings>(
-        &self,
-        path: &str,
-        settings: &mut Settings,
-        request: &RequestParts<'_>,
-        response_buf: &'b mut [u8],
-    ) -> Outcome<'b>
-    where
-        Settings: TreeSchema + TreeDeserializeOwned,
-    {
-        match self.put_key::<Settings>(path, settings, request) {
-            Ok(key) => Outcome::Changed {
-                key,
-                response: Response {
-                    code: code::CHANGED,
-                    content_format: None,
-                    payload: b"",
-                },
-            },
-            Err(err) => {
-                debug!("Rejecting Miniconf CoAP PUT err={}", err);
-                Outcome::Handled(self.representation.error_response(err, response_buf))
-            }
-        }
-    }
-
-    fn put_key<Settings>(
-        &self,
-        path: &str,
-        settings: &mut Settings,
-        request: &RequestParts<'_>,
-    ) -> Result<ChangedKey, Error>
-    where
-        Settings: TreeSchema + TreeDeserializeOwned,
-    {
-        match request.content_format {
-            Some(format) if format == self.representation.content_format() => {}
-            _ => {
-                return Err(Error::new(
-                    code::UNSUPPORTED_CONTENT_FORMAT,
-                    Problem::UnsupportedContentFormat,
-                ));
-            }
-        }
-
-        let (lookup, state) = self.resolve::<Settings>(path)?;
-        if !lookup.schema.is_leaf() {
-            return Err(Error::new(
-                code::METHOD_NOT_ALLOWED,
-                Problem::NonLeaf {
-                    depth: lookup.depth,
-                },
-            ));
-        }
-
-        self.representation
-            .set(settings, &state.as_ref()[..lookup.depth], request.payload)
-            .map_err(|err| value_error(err, Operation::Write, lookup.depth))?;
-        debug!(
-            "Accepted Miniconf CoAP PUT path={=str} depth={=usize} payload_len={=usize}",
-            request.path(),
-            lookup.depth,
-            request.payload.len()
-        );
-        Ok(state)
-    }
-
-    fn resolve<Settings>(&self, path: &str) -> Result<(Lookup, ChangedKey), Error>
-    where
-        Settings: TreeSchema,
-    {
-        if Settings::SCHEMA.max_depth() > MAX_DEPTH {
-            warn!(
-                "Rejecting Miniconf CoAP request because schema depth={=usize} exceeds max_depth={=usize}",
-                Settings::SCHEMA.max_depth(),
-                MAX_DEPTH
-            );
-            return Err(Error::new(
-                code::REQUEST_ENTITY_TOO_LARGE,
-                Problem::UriPathTooLong,
-            ));
-        }
-        let mut state = [0; MAX_DEPTH];
-        let lookup = self.representation.resolve::<Settings>(path, &mut state)?;
-        Ok((lookup, Indices::new(state, lookup.depth)))
-    }
-
-    fn method_not_allowed<'b>(
-        &self,
-        request: &RequestParts<'_>,
-        response_buf: &'b mut [u8],
-    ) -> Outcome<'b> {
-        let err = Error::new(code::METHOD_NOT_ALLOWED, Problem::MethodNotAllowed);
-        debug!(
-            "Rejecting Miniconf CoAP request code={=u8} err={}",
-            request.code, err
-        );
-        Outcome::Handled(self.representation.error_response(err, response_buf))
-    }
-}
-
-/// Complete value representation used by a [`ValueHandler`].
-#[doc(hidden)]
-pub trait Representation: private::Sealed {
-    /// Serialization error type.
-    type SerError;
-    /// Deserialization error type.
-    type DeError;
-
-    /// CoAP Content-Format used for successful responses and accepted request payloads.
-    fn content_format(&self) -> u16;
-
-    /// CoAP Content-Format used for structured error responses.
-    fn error_content_format(&self) -> u16;
-
-    /// Serialize this route's structured error response into the response buffer.
-    fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a>;
-
-    /// Resolve a route-relative URI path into a Miniconf schema lookup.
-    fn resolve<Settings: TreeSchema>(
-        &self,
-        path: &str,
-        state: &mut [usize],
-    ) -> Result<Lookup, Error>;
-
-    /// Serialize a leaf value into the response buffer.
-    fn get<Settings: TreeSerialize + ?Sized>(
-        &self,
-        settings: &Settings,
-        keys: &[usize],
-        buf: &mut [u8],
-    ) -> Result<usize, SerdeError<Self::SerError>>;
-
-    /// Deserialize and set a leaf value from a request payload.
-    fn set<Settings: TreeDeserializeOwned + ?Sized>(
-        &self,
-        settings: &mut Settings,
-        keys: &[usize],
-        payload: &[u8],
-    ) -> Result<(), SerdeError<Self::DeError>>;
-}
-
-#[cfg(feature = "json-core")]
-impl Representation for ConstPathJson {
-    type SerError = JsonSerError;
-    type DeError = JsonDeError;
-
-    fn content_format(&self) -> u16 {
-        JSON_CONTENT_FORMAT
-    }
-
-    fn error_content_format(&self) -> u16 {
-        JSON_CONTENT_FORMAT
-    }
-
-    fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a> {
-        error.response(buf)
-    }
-
-    fn resolve<Settings: TreeSchema>(
-        &self,
-        path: &str,
-        state: &mut [usize],
-    ) -> Result<Lookup, Error> {
-        Settings::SCHEMA
-            .resolve_into(path, state)
-            .map_err(resolve_error)
-    }
-
-    fn get<Settings: TreeSerialize + ?Sized>(
-        &self,
-        settings: &Settings,
-        mut keys: &[usize],
-        buf: &mut [u8],
-    ) -> Result<usize, SerdeError<Self::SerError>> {
-        json_core::get_by_keys(settings, &mut keys, buf)
-    }
-
-    fn set<Settings: TreeDeserializeOwned + ?Sized>(
-        &self,
-        settings: &mut Settings,
-        mut keys: &[usize],
-        payload: &[u8],
-    ) -> Result<(), SerdeError<Self::DeError>> {
-        json_core::set_by_keys(settings, &mut keys, payload).map(|_| ())
-    }
-}
-
-#[cfg(feature = "cbor")]
-impl Representation for ConstPathCbor {
-    type SerError = CborSerError<EndOfSlice>;
-    type DeError = CborDeError;
-
-    fn content_format(&self) -> u16 {
-        CBOR_CONTENT_FORMAT
-    }
-
-    fn error_content_format(&self) -> u16 {
-        PROBLEM_DETAILS_CBOR_CONTENT_FORMAT
-    }
-
-    fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a> {
-        match problem_cbor(error, buf) {
-            Ok(len) => Response {
-                code: error.code,
-                content_format: Some(PROBLEM_DETAILS_CBOR_CONTENT_FORMAT),
-                payload: &buf[..len],
-            },
-            Err(_) => Response {
-                code: error.code,
-                content_format: None,
-                payload: b"",
-            },
-        }
-    }
-
-    fn resolve<Settings: TreeSchema>(
-        &self,
-        path: &str,
-        state: &mut [usize],
-    ) -> Result<Lookup, Error> {
-        Settings::SCHEMA
-            .resolve_into(path, state)
-            .map_err(resolve_error)
-    }
-
-    fn get<Settings: TreeSerialize + ?Sized>(
-        &self,
-        settings: &Settings,
-        mut keys: &[usize],
-        buf: &mut [u8],
-    ) -> Result<usize, SerdeError<Self::SerError>> {
-        let mut cursor = encode::write::Cursor::new(buf);
-        let mut serializer = minicbor_serde::Serializer::new(&mut cursor);
-        settings.serialize_by_key(&mut keys, &mut serializer)?;
-        Ok(cursor.position())
-    }
-
-    fn set<Settings: TreeDeserializeOwned + ?Sized>(
-        &self,
-        settings: &mut Settings,
-        mut keys: &[usize],
-        payload: &[u8],
-    ) -> Result<(), SerdeError<Self::DeError>> {
-        validate_cbor_payload(payload).map_err(SerdeError::Finalization)?;
-        let mut deserializer = minicbor_serde::Deserializer::new(payload);
-        settings.deserialize_by_key(&mut keys, &mut deserializer)
-    }
-}
-
-#[cfg(feature = "cbor")]
-fn validate_cbor_payload(payload: &[u8]) -> Result<(), CborDeError> {
-    let mut decoder = CborDecoder::new(payload);
-    decoder.skip()?;
-    if decoder.position() == decoder.input().len() {
-        Ok(())
-    } else {
-        Err(CborDecodeError::message("trailing data").into())
-    }
-}
-
-/// Schema route backed by `TreeSchema`.
-#[cfg(feature = "json-core")]
-#[derive(defmt::Format, Debug, Clone, Copy)]
-pub struct SchemaHandler<'a> {
-    base: &'a str,
-}
-
-#[cfg(feature = "json-core")]
-impl<'a> SchemaHandler<'a> {
-    /// Construct a compact paged schema route.
-    ///
-    /// The base path and `base/0` both serve the first newline-delimited compact schema page.
-    pub const fn new(base: &'a str) -> Self {
-        Self { base }
-    }
-
-    /// Handle a schema `GET` request.
-    pub fn handle<'b, Settings>(
-        &self,
-        request: &RequestParts<'_>,
-        response_buf: &'b mut [u8],
-    ) -> Outcome<'b>
-    where
-        Settings: TreeSchema,
-    {
-        let Some(page_index) = self.page_index(request.path()) else {
-            trace!("Ignoring non-schema CoAP route request={}", request);
-            return Outcome::Unhandled;
-        };
-        if let Err(err) = request.check_options() {
-            return Outcome::Handled(err.response(response_buf));
-        }
-        trace!("Handling Miniconf CoAP schema request request={}", request);
-        if request.code != code::GET {
-            return Outcome::Handled(
-                Error::new(code::METHOD_NOT_ALLOWED, Problem::MethodNotAllowed)
-                    .response(response_buf),
-            );
-        }
-        if let Err(err) = request.accepts(TEXT_CONTENT_FORMAT) {
-            return Outcome::Handled(err.response(response_buf));
-        }
-        let Ok(defs) = SchemaDefs::<MAX_SCHEMA_DEFS>::new(Settings::SCHEMA) else {
-            return Outcome::Handled(
-                Error::new(code::INTERNAL_SERVER_ERROR, Problem::Serialization)
-                    .response(response_buf),
-            );
-        };
-        let mut next = 0;
-        for _ in 0..page_index {
-            match serialize_schema_page(&defs, next, response_buf) {
-                Ok(page) if page.count != 0 => next += page.count,
-                _ => {
-                    return Outcome::Handled(
-                        Error::new(code::NOT_FOUND, Problem::NotFound { depth: 1 })
-                            .response(response_buf),
-                    );
-                }
-            }
-        }
-        if next >= defs.len() {
-            return Outcome::Handled(
-                Error::new(code::NOT_FOUND, Problem::NotFound { depth: 1 }).response(response_buf),
-            );
-        }
-        match serialize_schema_page(&defs, next, response_buf) {
-            Ok(page) => {
-                debug!(
-                    "Handled Miniconf CoAP schema GET path={=str} page={=usize} defs={=usize} response_len={=usize}",
-                    request.path(),
-                    page_index,
-                    page.count,
-                    page.len
-                );
-                Outcome::Handled(Response {
-                    code: code::CONTENT,
-                    content_format: Some(TEXT_CONTENT_FORMAT),
-                    payload: &response_buf[..page.len],
-                })
-            }
-            Err(id) => {
-                warn!(
-                    "Failed to serialize Miniconf CoAP schema path={=str} definition={=usize}",
-                    request.path(),
-                    id
-                );
-                Outcome::Handled(
-                    Error::request_entity_too_large(Problem::PayloadTooLong).response(response_buf),
-                )
-            }
-        }
-    }
-
-    fn page_index(&self, path: &str) -> Option<usize> {
-        if path == self.base {
-            return Some(0);
-        }
-        let suffix = if self.base.is_empty() {
-            path.strip_prefix('/')?
-        } else {
-            path.strip_prefix(self.base)?.strip_prefix('/')?
-        };
-        (!suffix.is_empty() && !suffix.contains('/')).then(|| parse_usize(suffix))?
-    }
-}
-
-#[cfg(feature = "json-core")]
-fn parse_usize(value: &str) -> Option<usize> {
-    let mut parsed = 0usize;
-    for byte in value.bytes() {
-        if !byte.is_ascii_digit() {
-            return None;
-        }
-        parsed = parsed
-            .checked_mul(10)?
-            .checked_add(usize::from(byte - b'0'))?;
-    }
-    Some(parsed)
-}
-
-fn path_depth(path: &str) -> usize {
-    path.as_bytes().iter().filter(|byte| **byte == b'/').count()
-}
-
-#[cfg(any(feature = "json-core", feature = "cbor"))]
-fn resolve_error(err: ResolveError) -> Error {
-    let depth = err.lookup.depth;
-    match err.error {
-        DescendError::Key(KeyError::NotFound) => {
-            Error::new(code::NOT_FOUND, Problem::NotFound { depth })
-        }
-        DescendError::Key(KeyError::TooLong) => {
-            Error::new(code::NOT_FOUND, Problem::TooLong { depth })
-        }
-        DescendError::Key(KeyError::TooShort) => {
-            Error::new(code::METHOD_NOT_ALLOWED, Problem::NonLeaf { depth })
-        }
-        DescendError::Inner(()) => {
-            Error::new(code::REQUEST_ENTITY_TOO_LARGE, Problem::UriPathTooLong)
-        }
-    }
-}
-
-fn read_error<E>(err: SerdeError<E>, depth: usize) -> Error {
-    match err {
-        SerdeError::Value(ValueError::Key(KeyError::NotFound)) => {
-            Error::new(code::NOT_FOUND, Problem::NotFound { depth })
-        }
-        SerdeError::Value(ValueError::Key(KeyError::TooLong)) => {
-            Error::new(code::NOT_FOUND, Problem::TooLong { depth })
-        }
-        SerdeError::Value(ValueError::Key(KeyError::TooShort)) => {
-            Error::new(code::METHOD_NOT_ALLOWED, Problem::NonLeaf { depth })
-        }
-        SerdeError::Value(ValueError::Absent) => {
-            Error::new(code::CONFLICT, Problem::Absent { depth })
-        }
-        SerdeError::Value(ValueError::Access(message)) => Error::new(
-            code::FORBIDDEN,
-            Problem::Access {
-                op: Operation::Read,
-                message,
-            },
-        ),
-        SerdeError::Inner(_) | SerdeError::Finalization(_) => {
-            Error::new(code::INTERNAL_SERVER_ERROR, Problem::Serialization)
-        }
-    }
-}
-
-fn value_error<E>(err: SerdeError<E>, op: Operation, depth: usize) -> Error {
-    match err {
-        SerdeError::Value(ValueError::Key(KeyError::NotFound)) => {
-            Error::new(code::NOT_FOUND, Problem::NotFound { depth })
-        }
-        SerdeError::Value(ValueError::Key(KeyError::TooLong)) => {
-            Error::new(code::NOT_FOUND, Problem::TooLong { depth })
-        }
-        SerdeError::Value(ValueError::Key(KeyError::TooShort)) => {
-            Error::new(code::METHOD_NOT_ALLOWED, Problem::NonLeaf { depth })
-        }
-        SerdeError::Value(ValueError::Absent) => {
-            Error::new(code::CONFLICT, Problem::Absent { depth })
-        }
-        SerdeError::Value(ValueError::Access(message)) => Error::new(
-            match op {
-                Operation::Read => code::FORBIDDEN,
-                Operation::Write => code::UNPROCESSABLE_ENTITY,
-            },
-            Problem::Access { op, message },
-        ),
-        SerdeError::Inner(_) | SerdeError::Finalization(_) => {
-            Error::new(code::BAD_REQUEST, Problem::BadPayload)
-        }
-    }
-}
-
-#[cfg(feature = "json-core")]
-fn problem_json(problem: Problem, buf: &mut [u8]) -> Result<usize, core::fmt::Error> {
-    let mut out = SliceWriter::new(buf);
-    match problem {
-        Problem::InvalidUriPath
-        | Problem::InvalidAccept
-        | Problem::InvalidContentFormat
-        | Problem::DuplicateContentFormat
-        | Problem::UriPathTooLong
-        | Problem::PayloadTooLong
-        | Problem::TooManyAcceptOptions
-        | Problem::MethodNotAllowed
-        | Problem::NotAcceptable
-        | Problem::UnsupportedContentFormat
-        | Problem::BadPayload
-        | Problem::Serialization => write_kind(&mut out, problem_kind(problem))?,
-        Problem::UnknownCriticalOption { number } => {
-            write!(
-                out,
-                "{{\"kind\":\"unknown_critical_option\",\"number\":{number}}}"
-            )?;
-        }
-        Problem::NotFound { depth } => write_depth(&mut out, "not_found", depth)?,
-        Problem::TooLong { depth } => write_depth(&mut out, "too_long", depth)?,
-        Problem::NonLeaf { depth } => write_depth(&mut out, "non_leaf", depth)?,
-        Problem::Absent { depth } => write_depth(&mut out, "absent", depth)?,
-        Problem::Access { op, message } => {
-            write!(
-                out,
-                "{{\"kind\":\"access\",\"op\":\"{}\",\"message\":",
-                operation_name(op)
-            )?;
-            write_json_string_truncated(&mut out, message, 1)?;
-            out.push('}')?;
-        }
-    }
-    Ok(out.len())
-}
-
-#[cfg(feature = "cbor")]
-fn problem_cbor(error: Error, buf: &mut [u8]) -> Result<usize, encode::Error<EndOfSlice>> {
-    const MINICONF_PROBLEM_KEY: &str = "tag:quartiq.de,2026:miniconf";
-
-    let mut cursor = encode::write::Cursor::new(buf);
-    {
-        let kind = problem_kind(error.problem);
-        let mut encoder = CborEncoder::new(&mut cursor);
-        encoder
-            .map(3)?
-            .int(CborInt::from(-1i8))?
-            .str(kind)?
-            .int(CborInt::from(-4i8))?
-            .u8(error.code)?
-            .str(MINICONF_PROBLEM_KEY)?
-            .map(problem_detail_len(error.problem))?
-            .str("kind")?
-            .str(kind)?;
-
-        match error.problem {
-            Problem::UnknownCriticalOption { number } => {
-                encoder.str("number")?.u16(number)?;
-            }
-            Problem::NotFound { depth }
-            | Problem::TooLong { depth }
-            | Problem::NonLeaf { depth }
-            | Problem::Absent { depth } => {
-                encoder.str("depth")?.u64(depth as u64)?;
-            }
-            Problem::Access { op, message } => {
-                encoder
-                    .str("op")?
-                    .str(operation_name(op))?
-                    .str("message")?
-                    .str(message)?;
-            }
-            _ => {}
-        }
-    }
-    Ok(cursor.position())
-}
-
-#[cfg(feature = "cbor")]
-const fn problem_detail_len(problem: Problem) -> u64 {
-    match problem {
-        Problem::UnknownCriticalOption { .. }
-        | Problem::NotFound { .. }
-        | Problem::TooLong { .. }
-        | Problem::NonLeaf { .. }
-        | Problem::Absent { .. } => 2,
-        Problem::Access { .. } => 3,
-        _ => 1,
-    }
-}
-
-#[cfg(any(feature = "json-core", feature = "cbor"))]
-const fn problem_kind(problem: Problem) -> &'static str {
-    match problem {
-        Problem::InvalidUriPath => "invalid_uri_path",
-        Problem::InvalidAccept => "invalid_accept",
-        Problem::InvalidContentFormat => "invalid_content_format",
-        Problem::DuplicateContentFormat => "duplicate_content_format",
-        Problem::UnknownCriticalOption { .. } => "unknown_critical_option",
-        Problem::UriPathTooLong => "uri_path_too_long",
-        Problem::PayloadTooLong => "payload_too_long",
-        Problem::TooManyAcceptOptions => "too_many_accept_options",
-        Problem::NotFound { .. } => "not_found",
-        Problem::TooLong { .. } => "too_long",
-        Problem::NonLeaf { .. } => "non_leaf",
-        Problem::Absent { .. } => "absent",
-        Problem::Access { .. } => "access",
-        Problem::MethodNotAllowed => "method_not_allowed",
-        Problem::NotAcceptable => "not_acceptable",
-        Problem::UnsupportedContentFormat => "unsupported_content_format",
-        Problem::BadPayload => "bad_payload",
-        Problem::Serialization => "serialization",
-    }
-}
-
-#[cfg(any(feature = "json-core", feature = "cbor"))]
-const fn operation_name(op: Operation) -> &'static str {
-    match op {
-        Operation::Read => "read",
-        Operation::Write => "write",
-    }
-}
-
-#[cfg(feature = "json-core")]
-struct SliceWriter<'a> {
-    buf: &'a mut [u8],
-    len: usize,
-}
-
-#[cfg(feature = "json-core")]
-impl<'a> SliceWriter<'a> {
-    fn new(buf: &'a mut [u8]) -> Self {
-        Self { buf, len: 0 }
-    }
-
-    const fn len(&self) -> usize {
-        self.len
-    }
-
-    fn remaining(&self) -> usize {
-        self.buf.len() - self.len
-    }
-
-    fn push(&mut self, value: char) -> core::fmt::Result {
-        self.write_char(value)
-    }
-}
-
-#[cfg(feature = "json-core")]
-impl core::fmt::Write for SliceWriter<'_> {
-    fn write_str(&mut self, value: &str) -> core::fmt::Result {
-        let bytes = value.as_bytes();
-        let Some(dst) = self.buf.get_mut(self.len..self.len + bytes.len()) else {
-            return Err(core::fmt::Error);
-        };
-        dst.copy_from_slice(bytes);
-        self.len += bytes.len();
-        Ok(())
-    }
-}
-
-#[cfg(feature = "json-core")]
-fn write_kind(out: &mut impl core::fmt::Write, kind: &str) -> core::fmt::Result {
-    write!(out, "{{\"kind\":\"{}\"}}", kind)
-}
-
-#[cfg(feature = "json-core")]
-fn write_depth(out: &mut impl core::fmt::Write, kind: &str, depth: usize) -> core::fmt::Result {
-    write!(out, "{{\"kind\":\"{}\",\"depth\":{}}}", kind, depth)
-}
-
-#[cfg(feature = "json-core")]
-fn write_json_string_truncated(
-    out: &mut SliceWriter<'_>,
-    value: &str,
-    reserve: usize,
-) -> core::fmt::Result {
-    out.push('"')?;
-    for byte in value.bytes() {
-        let escaped = match byte {
-            b'"' => "\\\"",
-            b'\\' => "\\\\",
-            0x08 => "\\b",
-            0x0c => "\\f",
-            b'\n' => "\\n",
-            b'\r' => "\\r",
-            b'\t' => "\\t",
-            _ => "",
-        };
-        if !escaped.is_empty() {
-            if out.remaining() <= reserve + 1 || escaped.len() > out.remaining() - reserve - 1 {
-                break;
-            }
-            out.write_str(escaped)?;
-            continue;
-        }
-        match byte {
-            0x00..=0x1f => {
-                if out.remaining() <= reserve + 1 || 6 > out.remaining() - reserve - 1 {
-                    break;
-                }
-                write!(out, "\\u{:04x}", byte)?;
-            }
-            _ => {
-                if out.remaining() <= reserve + 1 {
-                    break;
-                }
-                out.push(char::from(byte))?;
-            }
-        }
-    }
-    out.push('"')
-}
-
-impl coap_message::error::RenderableOnMinimal for Error {
-    type Error<IE: coap_message::error::RenderableOnMinimal + core::fmt::Debug> = IE;
-
-    fn render<M: MinimalWritableMessage>(
-        self,
-        message: &mut M,
-    ) -> Result<(), Self::Error<M::UnionError>> {
-        let mut buf = [0; 96];
-        self.response(&mut buf).write_to(message)
-    }
-}
-
-impl From<Infallible> for Error {
-    fn from(value: Infallible) -> Self {
-        match value {}
-    }
-}
+#[cfg(feature = "coap-handler")]
+pub(crate) use message::{Accepts, InvalidOption, UriPath};
 
 #[cfg(all(test, feature = "json-core"))]
 mod tests {
@@ -1364,7 +66,7 @@ mod tests {
     use core::convert::Infallible;
 
     use coap_message::{MessageOption as _, MinimalWritableMessage, ReadableMessage};
-    use coap_numbers::code;
+    use coap_numbers::{code, option};
     use miniconf::Tree;
     use std::{sync::OnceLock, vec::Vec};
 
@@ -1578,7 +280,7 @@ mod tests {
         if request.path() == "/status" {
             return Outcome::Handled(Response {
                 code: code::CONTENT,
-                content_format: Some(JSON_CONTENT_FORMAT),
+                content_format: Some(content_format("application/json")),
                 payload: br#"{"ok":true}"#,
             });
         }
@@ -1596,14 +298,17 @@ mod tests {
         let out = handler.handle(&req, &mut settings, &mut response);
         let response = out.response().unwrap();
         assert_eq!(response.code, code::CONTENT);
-        assert_eq!(response.content_format, Some(JSON_CONTENT_FORMAT));
+        assert_eq!(
+            response.content_format,
+            Some(content_format("application/json"))
+        );
         assert_eq!(response.payload, b"7");
 
         let mut response = [0; 128];
         let req = request(
             code::PUT,
             &["settings", "number"],
-            Some(JSON_CONTENT_FORMAT),
+            Some(content_format("application/json")),
             b"12",
         );
         let out = handler.handle(&req, &mut settings, &mut response);
@@ -1652,7 +357,7 @@ mod tests {
         let req = request(
             code::PUT,
             &["settings", "label"],
-            Some(JSON_CONTENT_FORMAT),
+            Some(content_format("application/json")),
             br#""bad<label""#,
         );
         let out = handler.handle(&req, &mut settings, &mut response);
@@ -1673,7 +378,10 @@ mod tests {
         let out = handler.handle::<Settings>(&req, &mut response);
         let response = out.response().unwrap();
         assert_eq!(response.code, code::CONTENT);
-        assert_eq!(response.content_format, Some(TEXT_CONTENT_FORMAT));
+        assert_eq!(
+            response.content_format,
+            Some(content_format("text/plain; charset=utf-8"))
+        );
         assert!(response.payload.starts_with(b"{"));
     }
 
@@ -1686,7 +394,10 @@ mod tests {
         let out = handler.handle::<Settings>(&req, &mut response);
         let response = out.response().unwrap();
         assert_eq!(response.code, code::CONTENT);
-        assert_eq!(response.content_format, Some(TEXT_CONTENT_FORMAT));
+        assert_eq!(
+            response.content_format,
+            Some(content_format("text/plain; charset=utf-8"))
+        );
         assert!(response.payload.starts_with(b"{"));
 
         let mut response = [0; 512];
@@ -1713,7 +424,7 @@ mod tests {
         let req = request(
             code::PUT,
             &["settings", "number"],
-            Some(JSON_CONTENT_FORMAT),
+            Some(content_format("application/json")),
             b"14",
         );
         assert!(matches!(
@@ -1730,7 +441,7 @@ mod tests {
             .str_option(option::URI_PATH, "settings")
             .str_option(option::URI_PATH, "number")
             .uint_option(option::ACCEPT, 0)
-            .uint_option(option::ACCEPT, JSON_CONTENT_FORMAT);
+            .uint_option(option::ACCEPT, content_format("application/json"));
         let request = RequestParts::from_message(&request).unwrap();
         let handler = ConstPathJsonHandler::const_path_json("/settings");
         let mut settings = Settings::default();
@@ -1754,14 +465,17 @@ mod tests {
         let request = TestMessage::new(code::GET)
             .str_option(option::URI_PATH, "schema")
             .uint_option(option::ACCEPT, 0)
-            .uint_option(option::ACCEPT, JSON_CONTENT_FORMAT);
+            .uint_option(option::ACCEPT, content_format("application/json"));
         let request = RequestParts::from_message(&request).unwrap();
         let handler = SchemaHandler::new("/schema");
         let mut response = [0; 512];
         let outcome = handler.handle::<Settings>(&request, &mut response);
         let response = outcome.response().unwrap();
         assert_eq!(response.code, code::CONTENT);
-        assert_eq!(response.content_format, Some(TEXT_CONTENT_FORMAT));
+        assert_eq!(
+            response.content_format,
+            Some(content_format("text/plain; charset=utf-8"))
+        );
     }
 
     #[test]
@@ -1770,7 +484,7 @@ mod tests {
         let request = TestMessage::new(code::GET)
             .str_option(option::URI_PATH, "settings")
             .str_option(option::URI_PATH, "number")
-            .uint_option(option::ACCEPT, JSON_CONTENT_FORMAT)
+            .uint_option(option::ACCEPT, content_format("application/json"))
             .uint_option(option::ACCEPT, 0)
             .uint_option(option::ACCEPT, 1)
             .uint_option(option::ACCEPT, 2)
@@ -1819,8 +533,8 @@ mod tests {
         let request = TestMessage::new(code::PUT)
             .str_option(option::URI_PATH, "settings")
             .str_option(option::URI_PATH, "number")
-            .uint_option(option::CONTENT_FORMAT, JSON_CONTENT_FORMAT)
-            .uint_option(option::CONTENT_FORMAT, JSON_CONTENT_FORMAT)
+            .uint_option(option::CONTENT_FORMAT, content_format("application/json"))
+            .uint_option(option::CONTENT_FORMAT, content_format("application/json"))
             .with_payload(b"12");
         let request = RequestParts::from_message(&request).unwrap();
         let mut response = [0; 128];
@@ -1877,7 +591,10 @@ mod tests {
         );
         let mut response = [0; 64];
         let response = err.response(&mut response);
-        assert_eq!(response.content_format, Some(JSON_CONTENT_FORMAT));
+        assert_eq!(
+            response.content_format,
+            Some(content_format("application/json"))
+        );
         assert!(
             response
                 .payload
@@ -1892,7 +609,7 @@ mod tests {
         let request = TestMessage::new(code::PUT)
             .str_option(option::URI_PATH, "settings")
             .str_option(option::URI_PATH, "number")
-            .uint_option(option::CONTENT_FORMAT, JSON_CONTENT_FORMAT)
+            .uint_option(option::CONTENT_FORMAT, content_format("application/json"))
             .with_payload(b"18");
         let request = RequestParts::from_message(&request).unwrap();
         let mut settings = Settings::default();
@@ -1906,7 +623,7 @@ mod tests {
 
         let request = TestMessage::new(code::GET)
             .str_option(option::URI_PATH, "status")
-            .uint_option(option::ACCEPT, JSON_CONTENT_FORMAT);
+            .uint_option(option::ACCEPT, content_format("application/json"));
         let request = RequestParts::from_message(&request).unwrap();
         let mut response_buf = [0; 128];
         let outcome = route(&request, &mut settings, &mut response_buf);
@@ -1914,11 +631,14 @@ mod tests {
         outcome.response().unwrap().write_to(&mut response).unwrap();
         assert_eq!(response.code(), code::CONTENT);
         assert_eq!(ReadableMessage::payload(&response), br#"{"ok":true}"#);
-        let content_format = response
+        let content_format_option = response
             .options()
             .find(|opt| opt.number() == option::CONTENT_FORMAT)
             .and_then(|opt| opt.value_uint::<u16>());
-        assert_eq!(content_format, Some(JSON_CONTENT_FORMAT));
+        assert_eq!(
+            content_format_option,
+            Some(content_format("application/json"))
+        );
     }
 
     #[cfg(feature = "cbor")]
@@ -1933,14 +653,17 @@ mod tests {
         let out = handler.handle(&req, &mut settings, &mut response);
         let response = out.response().unwrap();
         assert_eq!(response.code, code::CONTENT);
-        assert_eq!(response.content_format, Some(CBOR_CONTENT_FORMAT));
+        assert_eq!(
+            response.content_format,
+            Some(content_format("application/cbor"))
+        );
         assert_eq!(response.payload, &[7]);
 
         let mut response = [0; 128];
         let req = request(
             code::PUT,
             &["settings", "number"],
-            Some(CBOR_CONTENT_FORMAT),
+            Some(content_format("application/cbor")),
             &[21],
         );
         let out = handler.handle(&req, &mut settings, &mut response);

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -14,16 +14,19 @@ use coap_message::{
 };
 use coap_numbers::{code, option};
 use defmt::{debug, trace, warn};
-#[cfg(any(feature = "json", feature = "postcard"))]
-use miniconf::DescendError;
-#[cfg(feature = "postcard")]
-use miniconf::Packed;
-#[cfg(feature = "json")]
-use miniconf::json_core;
+#[cfg(any(feature = "json-core", feature = "postcard"))]
+use miniconf::{DescendError, Lookup, ResolveError};
 use miniconf::{
     Indices, KeyError, SerdeError, TreeDeserializeOwned, TreeSchema, TreeSerialize, ValueError,
 };
-#[cfg(feature = "json")]
+#[cfg(feature = "postcard")]
+use miniconf::{Packed, postcard as miniconf_postcard};
+#[cfg(feature = "json-core")]
+use miniconf::{
+    compact_schema::{SchemaDefs, serialize_schema_page},
+    json_core,
+};
+#[cfg(feature = "json-core")]
 use serde_json_core::{de::Error as JsonDeError, ser::Error as JsonSerError};
 
 const MAX_ACCEPT_OPTIONS: usize = 4;
@@ -34,6 +37,9 @@ pub const JSON_CONTENT_FORMAT: u16 = 50;
 /// CoRE Link Format Content-Format number.
 pub const LINK_FORMAT_CONTENT_FORMAT: u16 = 40;
 
+/// Text Content-Format number.
+pub const TEXT_CONTENT_FORMAT: u16 = 0;
+
 /// Maximum Miniconf tree depth supported by `miniconf_coap`.
 pub const MAX_DEPTH: usize = 12;
 
@@ -42,6 +48,9 @@ pub const MAX_URI_PATH_LENGTH: usize = 256;
 
 /// Maximum request payload bytes and response scratch bytes used by the optional `coap-handler` adapter.
 pub const MAX_HANDLER_PAYLOAD_LENGTH: usize = 512;
+
+/// Maximum compact schema definitions served by `miniconf_coap`.
+pub const MAX_SCHEMA_DEFS: usize = 64;
 
 /// Exact changed leaf indices produced by a successful `PUT`.
 pub type ChangedKey = Indices<[usize; MAX_DEPTH]>;
@@ -480,7 +489,7 @@ pub struct ValueHandler<'a, R> {
 }
 
 /// Const-path-addressed JSON value route.
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 pub type ConstPathJsonHandler<'a> = ValueHandler<'a, ConstPathJson>;
 
 /// Packed-key postcard value route.
@@ -488,7 +497,7 @@ pub type ConstPathJsonHandler<'a> = ValueHandler<'a, ConstPathJson>;
 pub type PackedPostcardHandler<'a> = ValueHandler<'a, PackedPostcard>;
 
 /// URI path segments as Miniconf `ConstPath` keys, with JSON payloads.
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 #[derive(defmt::Format, Debug, Clone, Copy)]
 pub struct ConstPathJson;
 
@@ -503,12 +512,12 @@ mod private {
     pub trait Sealed {}
 }
 
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 impl private::Sealed for ConstPathJson {}
 #[cfg(feature = "postcard")]
 impl private::Sealed for PackedPostcard {}
 
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 impl<'a> ValueHandler<'a, ConstPathJson> {
     /// Serve JSON where remaining URI path segments are Miniconf path segments.
     pub const fn const_path_json(base: &'a str) -> Self {
@@ -748,7 +757,7 @@ where
         Ok(state)
     }
 
-    fn resolve<Settings>(&self, path: &str) -> Result<(miniconf::Lookup, ChangedKey), Error>
+    fn resolve<Settings>(&self, path: &str) -> Result<(Lookup, ChangedKey), Error>
     where
         Settings: TreeSchema,
     {
@@ -784,7 +793,7 @@ pub trait Representation: private::Sealed {
         &self,
         path: &str,
         state: &mut [usize],
-    ) -> Result<miniconf::Lookup, Error>;
+    ) -> Result<Lookup, Error>;
 
     /// Serialize a leaf value into the response buffer.
     fn get<Settings: TreeSerialize + ?Sized>(
@@ -803,7 +812,7 @@ pub trait Representation: private::Sealed {
     ) -> Result<(), SerdeError<Self::DeError>>;
 }
 
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 impl Representation for ConstPathJson {
     type SerError = JsonSerError;
     type DeError = JsonDeError;
@@ -816,7 +825,7 @@ impl Representation for ConstPathJson {
         &self,
         path: &str,
         state: &mut [usize],
-    ) -> Result<miniconf::Lookup, Error> {
+    ) -> Result<Lookup, Error> {
         Settings::SCHEMA
             .resolve_into(path, state)
             .map_err(resolve_error)
@@ -854,7 +863,7 @@ impl Representation for PackedPostcard {
         &self,
         path: &str,
         state: &mut [usize],
-    ) -> Result<miniconf::Lookup, Error> {
+    ) -> Result<Lookup, Error> {
         Settings::SCHEMA
             .resolve_into(packed_key(path)?, state)
             .map_err(resolve_error)
@@ -866,7 +875,7 @@ impl Representation for PackedPostcard {
         mut keys: &[usize],
         buf: &mut [u8],
     ) -> Result<usize, SerdeError<Self::SerError>> {
-        let used = miniconf::postcard::get_by_keys(
+        let used = miniconf_postcard::get_by_keys(
             settings,
             &mut keys,
             postcard::ser_flavors::Slice::new(buf),
@@ -880,7 +889,7 @@ impl Representation for PackedPostcard {
         mut keys: &[usize],
         payload: &[u8],
     ) -> Result<(), SerdeError<Self::DeError>> {
-        let remainder = miniconf::postcard::set_by_keys(
+        let remainder = miniconf_postcard::set_by_keys(
             settings,
             &mut keys,
             postcard::de_flavors::Slice::new(payload),
@@ -896,15 +905,17 @@ impl Representation for PackedPostcard {
 }
 
 /// Schema route backed by `TreeSchema`.
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 #[derive(defmt::Format, Debug, Clone, Copy)]
 pub struct SchemaHandler<'a> {
     base: &'a str,
 }
 
-#[cfg(feature = "json")]
+#[cfg(feature = "json-core")]
 impl<'a> SchemaHandler<'a> {
-    /// Construct a schema route mounted at an exact URI path.
+    /// Construct a compact paged schema route.
+    ///
+    /// The base path and `base/0` both serve the first newline-delimited compact schema page.
     pub const fn new(base: &'a str) -> Self {
         Self { base }
     }
@@ -918,10 +929,10 @@ impl<'a> SchemaHandler<'a> {
     where
         Settings: TreeSchema,
     {
-        if request.path() != self.base {
+        let Some(page_index) = self.page_index(request.path()) else {
             trace!("Ignoring non-schema CoAP route request={}", request);
             return Outcome::Unhandled;
-        }
+        };
         if let Err(err) = request.check_options() {
             return Outcome::Handled(err.response(response_buf));
         }
@@ -932,34 +943,70 @@ impl<'a> SchemaHandler<'a> {
                     .response(response_buf),
             );
         }
-        if let Err(err) = request.accepts(JSON_CONTENT_FORMAT) {
+        if let Err(err) = request.accepts(TEXT_CONTENT_FORMAT) {
             return Outcome::Handled(err.response(response_buf));
         }
-        match serde_json_core::to_slice(Settings::SCHEMA, response_buf) {
-            Ok(len) => {
+        let Ok(defs) = SchemaDefs::<MAX_SCHEMA_DEFS>::new(Settings::SCHEMA) else {
+            return Outcome::Handled(
+                Error::new(code::INTERNAL_SERVER_ERROR, Problem::Serialization)
+                    .response(response_buf),
+            );
+        };
+        let mut next = 0;
+        for _ in 0..page_index {
+            match serialize_schema_page(&defs, next, response_buf) {
+                Ok(page) if page.count != 0 => next += page.count,
+                _ => {
+                    return Outcome::Handled(
+                        Error::new(code::NOT_FOUND, Problem::NotFound { depth: 1 })
+                            .response(response_buf),
+                    );
+                }
+            }
+        }
+        if next >= defs.len() {
+            return Outcome::Handled(
+                Error::new(code::NOT_FOUND, Problem::NotFound { depth: 1 }).response(response_buf),
+            );
+        }
+        match serialize_schema_page(&defs, next, response_buf) {
+            Ok(page) => {
                 debug!(
-                    "Handled Miniconf CoAP schema GET path={=str} response_len={=usize}",
+                    "Handled Miniconf CoAP schema GET path={=str} page={=usize} defs={=usize} response_len={=usize}",
                     request.path(),
-                    len
+                    page_index,
+                    page.count,
+                    page.len
                 );
                 Outcome::Handled(Response {
                     code: code::CONTENT,
-                    content_format: Some(JSON_CONTENT_FORMAT),
-                    payload: &response_buf[..len],
+                    content_format: Some(TEXT_CONTENT_FORMAT),
+                    payload: &response_buf[..page.len],
                 })
             }
-            Err(_) => {
+            Err(id) => {
                 warn!(
-                    "Failed to serialize Miniconf CoAP schema path={=str}",
-                    request.path()
+                    "Failed to serialize Miniconf CoAP schema path={=str} definition={=usize}",
+                    request.path(),
+                    id
                 );
-                Outcome::Handled(Response {
-                    code: code::INTERNAL_SERVER_ERROR,
-                    content_format: None,
-                    payload: b"",
-                })
+                Outcome::Handled(
+                    Error::request_entity_too_large(Problem::PayloadTooLong).response(response_buf),
+                )
             }
         }
+    }
+
+    fn page_index(&self, path: &str) -> Option<usize> {
+        if path == self.base {
+            return Some(0);
+        }
+        let suffix = if self.base.is_empty() {
+            path.strip_prefix('/')?
+        } else {
+            path.strip_prefix(self.base)?.strip_prefix('/')?
+        };
+        (!suffix.is_empty() && !suffix.contains('/')).then(|| parse_usize(suffix))?
     }
 }
 
@@ -986,7 +1033,7 @@ fn packed_key(path: &str) -> Result<Packed, Error> {
     Packed::new_from_lsb(parsed).ok_or(Error::new(code::NOT_FOUND, Problem::NotFound { depth: 0 }))
 }
 
-#[cfg(feature = "postcard")]
+#[cfg(any(feature = "json-core", feature = "postcard"))]
 fn parse_usize(value: &str) -> Option<usize> {
     let mut parsed = 0usize;
     for byte in value.bytes() {
@@ -1004,8 +1051,8 @@ fn path_depth(path: &str) -> usize {
     path.as_bytes().iter().filter(|byte| **byte == b'/').count()
 }
 
-#[cfg(any(feature = "json", feature = "postcard"))]
-fn resolve_error(err: miniconf::ResolveError) -> Error {
+#[cfg(any(feature = "json-core", feature = "postcard"))]
+fn resolve_error(err: ResolveError) -> Error {
     let depth = err.lookup.depth;
     match err.error {
         DescendError::Key(KeyError::NotFound) => {
@@ -1230,7 +1277,7 @@ impl From<Infallible> for Error {
     }
 }
 
-#[cfg(all(test, feature = "json"))]
+#[cfg(all(test, feature = "json-core"))]
 mod tests {
     extern crate std;
 
@@ -1488,8 +1535,10 @@ mod tests {
     fn absent_not_found_and_too_long_stay_distinct() {
         init_host_logging();
         let handler = ConstPathJsonHandler::const_path_json("/settings");
-        let mut settings = Settings::default();
-        settings.visible = None;
+        let mut settings = Settings {
+            visible: None,
+            ..Default::default()
+        };
 
         let mut response = [0; 128];
         let req = request(code::GET, &["settings", "visible", "value"], None, b"");
@@ -1544,8 +1593,28 @@ mod tests {
         let out = handler.handle::<Settings>(&req, &mut response);
         let response = out.response().unwrap();
         assert_eq!(response.code, code::CONTENT);
-        assert_eq!(response.content_format, Some(JSON_CONTENT_FORMAT));
+        assert_eq!(response.content_format, Some(TEXT_CONTENT_FORMAT));
         assert!(response.payload.starts_with(b"{"));
+    }
+
+    #[test]
+    fn schema_route_is_paged() {
+        init_host_logging();
+        let handler = SchemaHandler::new("/schema");
+        let mut response = [0; 512];
+        let req = request(code::GET, &["schema", "0"], None, b"");
+        let out = handler.handle::<Settings>(&req, &mut response);
+        let response = out.response().unwrap();
+        assert_eq!(response.code, code::CONTENT);
+        assert_eq!(response.content_format, Some(TEXT_CONTENT_FORMAT));
+        assert!(response.payload.starts_with(b"{"));
+
+        let mut response = [0; 512];
+        let req = request(code::GET, &["schema", "99"], None, b"");
+        let out = handler.handle::<Settings>(&req, &mut response);
+        let response = out.response().unwrap();
+        assert_eq!(response.code, code::NOT_FOUND);
+        assert_eq!(response.payload, br#"{"kind":"not_found","depth":1}"#);
     }
 
     #[test]
@@ -1612,6 +1681,7 @@ mod tests {
         let outcome = handler.handle::<Settings>(&request, &mut response);
         let response = outcome.response().unwrap();
         assert_eq!(response.code, code::CONTENT);
+        assert_eq!(response.content_format, Some(TEXT_CONTENT_FORMAT));
     }
 
     #[test]

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -22,9 +22,10 @@ use minicbor::{
 #[cfg(feature = "cbor")]
 use minicbor_serde::error::{DecodeError as CborDeError, EncodeError as CborSerError};
 #[cfg(any(feature = "json-core", feature = "cbor"))]
-use miniconf::{DescendError, Lookup, ResolveError};
+use miniconf::{DescendError, ResolveError};
 use miniconf::{
-    Indices, KeyError, SerdeError, TreeDeserializeOwned, TreeSchema, TreeSerialize, ValueError,
+    Indices, KeyError, Lookup, SerdeError, TreeDeserializeOwned, TreeSchema, TreeSerialize,
+    ValueError,
 };
 #[cfg(feature = "json-core")]
 use miniconf::{

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -31,16 +31,27 @@ const MAX_ACCEPT_OPTIONS: usize = 4;
 /// JSON Content-Format number.
 pub const JSON_CONTENT_FORMAT: u16 = 50;
 
+/// CoRE Link Format Content-Format number.
+pub const LINK_FORMAT_CONTENT_FORMAT: u16 = 40;
+
 /// Maximum Miniconf tree depth supported by `miniconf_coap`.
 pub const MAX_DEPTH: usize = 12;
 
 /// Maximum bytes in a captured rooted CoAP URI path.
 pub const MAX_URI_PATH_LENGTH: usize = 256;
 
+/// Maximum request payload bytes and response scratch bytes used by the optional `coap-handler` adapter.
+pub const MAX_HANDLER_PAYLOAD_LENGTH: usize = 512;
+
 /// Exact changed leaf indices produced by a successful `PUT`.
 pub type ChangedKey = Indices<[usize; MAX_DEPTH]>;
 
 type UriPath = heapless::String<MAX_URI_PATH_LENGTH>;
+
+#[cfg(feature = "coap-handler")]
+mod handler;
+#[cfg(feature = "coap-handler")]
+pub use handler::*;
 
 #[derive(Debug, Clone, Copy, Default)]
 struct Accepts {
@@ -106,6 +117,7 @@ pub struct RequestParts<'a> {
     path: UriPath,
     accepts: Accepts,
     content_format: Option<u16>,
+    invalid_option: Option<InvalidOption>,
     payload: &'a [u8],
 }
 
@@ -123,6 +135,7 @@ impl<'a> RequestParts<'a> {
             path: UriPath::new(),
             accepts: Accepts::from_option(accept),
             content_format,
+            invalid_option: None,
             payload,
         };
         for segment in path {
@@ -141,6 +154,7 @@ impl<'a> RequestParts<'a> {
             path: UriPath::new(),
             accepts: Accepts::new(),
             content_format: None,
+            invalid_option: None,
             payload: message.payload(),
         };
 
@@ -162,7 +176,21 @@ impl<'a> RequestParts<'a> {
                     let Some(content_format) = opt.value_uint() else {
                         return Err(Error::bad_request(Problem::InvalidContentFormat));
                     };
+                    if request.content_format.is_some() {
+                        if request.invalid_option.is_none() {
+                            request.invalid_option = Some(InvalidOption::DuplicateContentFormat);
+                        }
+                        continue;
+                    }
                     request.content_format = Some(content_format);
+                }
+                option::URI_HOST | option::URI_PORT => {}
+                number
+                    if coap_numbers::option::get_criticality(number)
+                        == coap_numbers::option::Criticality::Critical
+                        && request.invalid_option.is_none() =>
+                {
+                    request.invalid_option = Some(InvalidOption::UnknownCritical(number));
                 }
                 _ => {}
             }
@@ -190,6 +218,19 @@ impl<'a> RequestParts<'a> {
         self.accepts.accepts(content_format)
     }
 
+    fn check_options(&self) -> Result<(), Error> {
+        match self.invalid_option {
+            Some(InvalidOption::DuplicateContentFormat) => {
+                Err(Error::bad_request(Problem::DuplicateContentFormat))
+            }
+            Some(InvalidOption::UnknownCritical(number)) => Err(Error::new(
+                code::BAD_OPTION,
+                Problem::UnknownCriticalOption { number },
+            )),
+            None => Ok(()),
+        }
+    }
+
     fn push_path_segment(&mut self, segment: &str) -> Result<(), Error> {
         if segment.contains('/') {
             return Err(Error::bad_request(Problem::InvalidUriPath));
@@ -212,6 +253,12 @@ impl<'a> RequestParts<'a> {
         let tail = self.path.as_str().strip_prefix(base)?;
         tail.starts_with('/').then_some(tail)
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum InvalidOption {
+    DuplicateContentFormat,
+    UnknownCritical(u16),
 }
 
 impl defmt::Format for RequestParts<'_> {
@@ -326,8 +373,17 @@ pub enum Problem {
     InvalidAccept,
     /// Content-Format option could not be decoded as a CoAP uint.
     InvalidContentFormat,
+    /// More than one Content-Format option was present.
+    DuplicateContentFormat,
+    /// An unknown critical CoAP option was present.
+    UnknownCriticalOption {
+        /// CoAP option number.
+        number: u16,
+    },
     /// URI path had more segments than this handler captured.
     UriPathTooLong,
+    /// A response payload exceeded the optional handler adapter buffer.
+    PayloadTooLong,
     /// Request had more Accept options than this handler captures.
     TooManyAcceptOptions,
     /// Request path names no static Miniconf resource.
@@ -492,6 +548,9 @@ where
             trace!("Ignoring non-Miniconf CoAP route request={}", request);
             return Outcome::Unhandled;
         };
+        if let Err(err) = request.check_options() {
+            return Outcome::Handled(err.response(response_buf));
+        }
 
         trace!(
             "Handling Miniconf CoAP request base={=str} request={}",
@@ -519,6 +578,9 @@ where
             trace!("Ignoring non-Miniconf CoAP route request={}", request);
             return Outcome::Unhandled;
         };
+        if let Err(err) = request.check_options() {
+            return Outcome::Handled(err.response(response_buf));
+        }
 
         trace!(
             "Handling Miniconf CoAP GET request base={=str} request={}",
@@ -545,6 +607,9 @@ where
             trace!("Ignoring non-Miniconf CoAP route request={}", request);
             return Outcome::Unhandled;
         };
+        if let Err(err) = request.check_options() {
+            return Outcome::Handled(err.response(response_buf));
+        }
 
         trace!(
             "Handling Miniconf CoAP PUT request base={=str} request={}",
@@ -857,6 +922,9 @@ impl<'a> SchemaHandler<'a> {
             trace!("Ignoring non-schema CoAP route request={}", request);
             return Outcome::Unhandled;
         }
+        if let Err(err) = request.check_options() {
+            return Outcome::Handled(err.response(response_buf));
+        }
         trace!("Handling Miniconf CoAP schema request request={}", request);
         if request.code != code::GET {
             return Outcome::Handled(
@@ -1024,7 +1092,15 @@ fn problem_json(problem: Problem, buf: &mut [u8]) -> Result<usize, core::fmt::Er
         Problem::InvalidUriPath => write_kind(&mut out, "invalid_uri_path")?,
         Problem::InvalidAccept => write_kind(&mut out, "invalid_accept")?,
         Problem::InvalidContentFormat => write_kind(&mut out, "invalid_content_format")?,
+        Problem::DuplicateContentFormat => write_kind(&mut out, "duplicate_content_format")?,
+        Problem::UnknownCriticalOption { number } => {
+            write!(
+                out,
+                "{{\"kind\":\"unknown_critical_option\",\"number\":{number}}}"
+            )?;
+        }
         Problem::UriPathTooLong => write_kind(&mut out, "uri_path_too_long")?,
+        Problem::PayloadTooLong => write_kind(&mut out, "payload_too_long")?,
         Problem::TooManyAcceptOptions => write_kind(&mut out, "too_many_accept_options")?,
         Problem::NotFound { depth } => write_depth(&mut out, "not_found", depth)?,
         Problem::TooLong { depth } => write_depth(&mut out, "too_long", depth)?,
@@ -1154,7 +1230,7 @@ impl From<Infallible> for Error {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "json"))]
 mod tests {
     extern crate std;
 
@@ -1583,6 +1659,48 @@ mod tests {
         let err = RequestParts::from_message(&request).unwrap_err();
         assert_eq!(err.code, code::BAD_REQUEST);
         assert_eq!(err.problem, Problem::InvalidContentFormat);
+    }
+
+    #[test]
+    fn duplicate_content_format_is_bad_request_on_matched_route() {
+        init_host_logging();
+        let handler = ConstPathJsonHandler::const_path_json("/settings");
+        let mut settings = Settings::default();
+        let request = TestMessage::new(code::PUT)
+            .str_option(option::URI_PATH, "settings")
+            .str_option(option::URI_PATH, "number")
+            .uint_option(option::CONTENT_FORMAT, JSON_CONTENT_FORMAT)
+            .uint_option(option::CONTENT_FORMAT, JSON_CONTENT_FORMAT)
+            .with_payload(b"12");
+        let request = RequestParts::from_message(&request).unwrap();
+        let mut response = [0; 128];
+        let outcome = handler.handle(&request, &mut settings, &mut response);
+        let response = outcome.response().unwrap();
+
+        assert_eq!(response.code, code::BAD_REQUEST);
+        assert_eq!(response.payload, br#"{"kind":"duplicate_content_format"}"#);
+        assert_eq!(settings.number, 7);
+    }
+
+    #[test]
+    fn unknown_critical_option_is_bad_option_on_matched_route() {
+        init_host_logging();
+        let handler = ConstPathJsonHandler::const_path_json("/settings");
+        let mut settings = Settings::default();
+        let request = TestMessage::new(code::GET)
+            .str_option(option::URI_PATH, "settings")
+            .str_option(option::URI_PATH, "number")
+            .option(99, b"critical");
+        let request = RequestParts::from_message(&request).unwrap();
+        let mut response = [0; 128];
+        let outcome = handler.handle(&request, &mut settings, &mut response);
+        let response = outcome.response().unwrap();
+
+        assert_eq!(response.code, code::BAD_OPTION);
+        assert_eq!(
+            response.payload,
+            br#"{"kind":"unknown_critical_option","number":99}"#
+        );
     }
 
     #[test]

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -15,7 +15,7 @@ pub const MAX_DEPTH: usize = 12;
 /// Maximum bytes in a captured rooted CoAP URI path.
 pub const MAX_URI_PATH_LENGTH: usize = 256;
 
-/// Maximum request payload bytes and response scratch bytes used by the optional `coap-handler` adapter.
+/// Maximum response scratch bytes used by the optional `coap-handler` adapter.
 pub const MAX_HANDLER_PAYLOAD_LENGTH: usize = 512;
 
 /// Maximum compact schema definitions served by `miniconf_coap`.
@@ -297,6 +297,9 @@ mod tests {
 
         match request.path() {
             "/schema" => return schema.handle::<Settings>(request, response_buf),
+            path if path.starts_with("/schema/") => {
+                return schema.handle::<Settings>(request, response_buf);
+            }
             "/settings" => return values.handle(request, settings, response_buf),
             path if path.starts_with("/settings/") => {
                 return values.handle(request, settings, response_buf);
@@ -406,9 +409,14 @@ mod tests {
         assert_eq!(response.code, code::CONTENT);
         assert_eq!(
             response.content_format,
-            Some(content_format::from_str("text/plain; charset=utf-8").unwrap())
+            Some(content_format::from_str("application/json").unwrap())
         );
-        assert!(response.payload.starts_with(b"{"));
+        assert!(
+            response
+                .payload
+                .starts_with(br#"{"proto":1,"epoch":0,"schema_rev":"#)
+        );
+        assert!(response.payload.ends_with(br#","pages":1}"#));
     }
 
     #[test]
@@ -506,7 +514,7 @@ mod tests {
         assert_eq!(response.code, code::CONTENT);
         assert_eq!(
             response.content_format,
-            Some(content_format::from_str("text/plain; charset=utf-8").unwrap())
+            Some(content_format::from_str("application/json").unwrap())
         );
     }
 

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -24,6 +24,35 @@ pub const MAX_SCHEMA_DEFS: usize = 64;
 /// Exact changed leaf indices produced by a successful `PUT`.
 pub type ChangedKey = Indices<[usize; MAX_DEPTH]>;
 
+#[cfg(any(feature = "json-core", feature = "cbor", feature = "coap-handler"))]
+pub(crate) mod format {
+    #[cfg(any(feature = "json-core", feature = "coap-handler"))]
+    pub const JSON: u16 = match coap_numbers::content_format::from_str("application/json") {
+        Some(value) => value,
+        None => panic!("unknown CoAP content format"),
+    };
+
+    #[cfg(feature = "cbor")]
+    pub const CBOR: u16 = match coap_numbers::content_format::from_str("application/cbor") {
+        Some(value) => value,
+        None => panic!("unknown CoAP content format"),
+    };
+
+    #[cfg(any(feature = "json-core", feature = "coap-handler"))]
+    pub const TEXT: u16 = match coap_numbers::content_format::from_str("text/plain; charset=utf-8")
+    {
+        Some(value) => value,
+        None => panic!("unknown CoAP content format"),
+    };
+
+    #[cfg(feature = "cbor")]
+    pub const CONCISE_PROBLEM_CBOR: u16 =
+        match coap_numbers::content_format::from_str("application/concise-problem-details+cbor") {
+            Some(value) => value,
+            None => panic!("unknown CoAP content format"),
+        };
+}
+
 #[cfg(feature = "coap-handler")]
 mod handler;
 mod message;

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -14,13 +14,18 @@ use coap_message::{
 };
 use coap_numbers::{code, option};
 use defmt::{debug, trace, warn};
-#[cfg(any(feature = "json-core", feature = "postcard"))]
+#[cfg(feature = "cbor")]
+use minicbor::{
+    decode::Error as CborDecodeError,
+    encode::{self, write::EndOfSlice},
+};
+#[cfg(feature = "cbor")]
+use minicbor_serde::error::{DecodeError as CborDeError, EncodeError as CborSerError};
+#[cfg(any(feature = "json-core", feature = "cbor"))]
 use miniconf::{DescendError, Lookup, ResolveError};
 use miniconf::{
     Indices, KeyError, SerdeError, TreeDeserializeOwned, TreeSchema, TreeSerialize, ValueError,
 };
-#[cfg(feature = "postcard")]
-use miniconf::{Packed, postcard as miniconf_postcard};
 #[cfg(feature = "json-core")]
 use miniconf::{
     compact_schema::{SchemaDefs, serialize_schema_page},
@@ -33,6 +38,9 @@ const MAX_ACCEPT_OPTIONS: usize = 4;
 
 /// JSON Content-Format number.
 pub const JSON_CONTENT_FORMAT: u16 = 50;
+
+/// CBOR Content-Format number.
+pub const CBOR_CONTENT_FORMAT: u16 = 60;
 
 /// CoRE Link Format Content-Format number.
 pub const LINK_FORMAT_CONTENT_FORMAT: u16 = 40;
@@ -492,21 +500,19 @@ pub struct ValueHandler<'a, R> {
 #[cfg(feature = "json-core")]
 pub type ConstPathJsonHandler<'a> = ValueHandler<'a, ConstPathJson>;
 
-/// Packed-key postcard value route.
-#[cfg(feature = "postcard")]
-pub type PackedPostcardHandler<'a> = ValueHandler<'a, PackedPostcard>;
+/// Const-path-addressed CBOR value route.
+#[cfg(feature = "cbor")]
+pub type ConstPathCborHandler<'a> = ValueHandler<'a, ConstPathCbor>;
 
 /// URI path segments as Miniconf `ConstPath` keys, with JSON payloads.
 #[cfg(feature = "json-core")]
 #[derive(defmt::Format, Debug, Clone, Copy)]
 pub struct ConstPathJson;
 
-/// One URI path segment as a Miniconf `Packed` LSB key, with postcard payloads.
-#[cfg(feature = "postcard")]
+/// URI path segments as Miniconf `ConstPath` keys, with CBOR payloads.
+#[cfg(feature = "cbor")]
 #[derive(defmt::Format, Debug, Clone, Copy)]
-pub struct PackedPostcard {
-    content_format: u16,
-}
+pub struct ConstPathCbor;
 
 mod private {
     pub trait Sealed {}
@@ -514,8 +520,8 @@ mod private {
 
 #[cfg(feature = "json-core")]
 impl private::Sealed for ConstPathJson {}
-#[cfg(feature = "postcard")]
-impl private::Sealed for PackedPostcard {}
+#[cfg(feature = "cbor")]
+impl private::Sealed for ConstPathCbor {}
 
 #[cfg(feature = "json-core")]
 impl<'a> ValueHandler<'a, ConstPathJson> {
@@ -528,13 +534,13 @@ impl<'a> ValueHandler<'a, ConstPathJson> {
     }
 }
 
-#[cfg(feature = "postcard")]
-impl<'a> ValueHandler<'a, PackedPostcard> {
-    /// Serve postcard where the next URI path segment is a `Packed` key in LSB notation.
-    pub const fn packed_postcard(base: &'a str, content_format: u16) -> Self {
+#[cfg(feature = "cbor")]
+impl<'a> ValueHandler<'a, ConstPathCbor> {
+    /// Serve CBOR where remaining URI path segments are Miniconf path segments.
+    pub const fn const_path_cbor(base: &'a str) -> Self {
         Self {
             base,
-            representation: PackedPostcard { content_format },
+            representation: ConstPathCbor,
         }
     }
 }
@@ -850,13 +856,13 @@ impl Representation for ConstPathJson {
     }
 }
 
-#[cfg(feature = "postcard")]
-impl Representation for PackedPostcard {
-    type SerError = postcard::Error;
-    type DeError = postcard::Error;
+#[cfg(feature = "cbor")]
+impl Representation for ConstPathCbor {
+    type SerError = CborSerError<EndOfSlice>;
+    type DeError = CborDeError;
 
     fn content_format(&self) -> u16 {
-        self.content_format
+        CBOR_CONTENT_FORMAT
     }
 
     fn resolve<Settings: TreeSchema>(
@@ -865,7 +871,7 @@ impl Representation for PackedPostcard {
         state: &mut [usize],
     ) -> Result<Lookup, Error> {
         Settings::SCHEMA
-            .resolve_into(packed_key(path)?, state)
+            .resolve_into(path, state)
             .map_err(resolve_error)
     }
 
@@ -875,12 +881,10 @@ impl Representation for PackedPostcard {
         mut keys: &[usize],
         buf: &mut [u8],
     ) -> Result<usize, SerdeError<Self::SerError>> {
-        let used = miniconf_postcard::get_by_keys(
-            settings,
-            &mut keys,
-            postcard::ser_flavors::Slice::new(buf),
-        )?;
-        Ok(used.len())
+        let mut cursor = encode::write::Cursor::new(buf);
+        let mut serializer = minicbor_serde::Serializer::new(&mut cursor);
+        settings.serialize_by_key(&mut keys, &mut serializer)?;
+        Ok(cursor.position())
     }
 
     fn set<Settings: TreeDeserializeOwned + ?Sized>(
@@ -889,18 +893,15 @@ impl Representation for PackedPostcard {
         mut keys: &[usize],
         payload: &[u8],
     ) -> Result<(), SerdeError<Self::DeError>> {
-        let remainder = miniconf_postcard::set_by_keys(
-            settings,
-            &mut keys,
-            postcard::de_flavors::Slice::new(payload),
-        )?;
-        if remainder.is_empty() {
-            Ok(())
-        } else {
-            Err(SerdeError::Finalization(
-                postcard::Error::DeserializeUnexpectedEnd,
-            ))
+        let mut deserializer = minicbor_serde::Deserializer::new(payload);
+        settings.deserialize_by_key(&mut keys, &mut deserializer)?;
+        let decoder = deserializer.decoder();
+        if decoder.position() == decoder.input().len() {
+            return Ok(());
         }
+        Err(SerdeError::Finalization(
+            CborDecodeError::message("trailing data").into(),
+        ))
     }
 }
 
@@ -1010,30 +1011,7 @@ impl<'a> SchemaHandler<'a> {
     }
 }
 
-#[cfg(feature = "postcard")]
-fn packed_key(path: &str) -> Result<Packed, Error> {
-    let Some(value) = path.strip_prefix('/') else {
-        return Err(Error::new(
-            code::BAD_REQUEST,
-            Problem::NonLeaf {
-                depth: path_depth(path),
-            },
-        ));
-    };
-    if value.contains('/') {
-        return Err(Error::new(
-            code::BAD_REQUEST,
-            Problem::NonLeaf {
-                depth: path_depth(path),
-            },
-        ));
-    }
-    let parsed =
-        parse_usize(value).ok_or(Error::new(code::NOT_FOUND, Problem::NotFound { depth: 0 }))?;
-    Packed::new_from_lsb(parsed).ok_or(Error::new(code::NOT_FOUND, Problem::NotFound { depth: 0 }))
-}
-
-#[cfg(any(feature = "json-core", feature = "postcard"))]
+#[cfg(feature = "json-core")]
 fn parse_usize(value: &str) -> Option<usize> {
     let mut parsed = 0usize;
     for byte in value.bytes() {
@@ -1051,7 +1029,7 @@ fn path_depth(path: &str) -> usize {
     path.as_bytes().iter().filter(|byte| **byte == b'/').count()
 }
 
-#[cfg(any(feature = "json-core", feature = "postcard"))]
+#[cfg(any(feature = "json-core", feature = "cbor"))]
 fn resolve_error(err: ResolveError) -> Error {
     let depth = err.lookup.depth;
     match err.error {
@@ -1841,37 +1819,26 @@ mod tests {
         assert_eq!(content_format, Some(JSON_CONTENT_FORMAT));
     }
 
-    #[cfg(feature = "postcard")]
+    #[cfg(feature = "cbor")]
     #[test]
-    fn packed_postcard_get_and_put_leaf() {
+    fn const_path_cbor_get_and_put_leaf() {
         init_host_logging();
-        const POSTCARD_CONTENT_FORMAT: u16 = 42;
-
-        let number_key = Settings::SCHEMA
-            .nodes::<Packed, MAX_DEPTH>()
-            .nth(1)
-            .unwrap()
-            .unwrap()
-            .into_lsb()
-            .get();
-        let mut path = heapless::String::<16>::new();
-        write!(&mut path, "{}", number_key).unwrap();
-        let handler = PackedPostcardHandler::packed_postcard("/settings", POSTCARD_CONTENT_FORMAT);
+        let handler = ConstPathCborHandler::const_path_cbor("/settings");
         let mut settings = Settings::default();
         let mut response = [0; 128];
 
-        let req = request(code::GET, &["settings", path.as_str()], None, b"");
+        let req = request(code::GET, &["settings", "number"], None, b"");
         let out = handler.handle_get(&req, &settings, &mut response);
         let response = out.response().unwrap();
         assert_eq!(response.code, code::CONTENT);
-        assert_eq!(response.content_format, Some(POSTCARD_CONTENT_FORMAT));
+        assert_eq!(response.content_format, Some(CBOR_CONTENT_FORMAT));
         assert_eq!(response.payload, &[7]);
 
         let mut response = [0; 128];
         let req = request(
             code::PUT,
-            &["settings", path.as_str()],
-            Some(POSTCARD_CONTENT_FORMAT),
+            &["settings", "number"],
+            Some(CBOR_CONTENT_FORMAT),
             &[21],
         );
         let out = handler.handle_put(&req, &mut settings, &mut response);

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -16,7 +16,7 @@ use coap_numbers::{code, option};
 use defmt::{debug, trace, warn};
 #[cfg(feature = "cbor")]
 use minicbor::{
-    decode::Error as CborDecodeError,
+    decode::{Decoder as CborDecoder, Error as CborDecodeError},
     encode::{self, write::EndOfSlice},
 };
 #[cfg(feature = "cbor")]
@@ -893,15 +893,20 @@ impl Representation for ConstPathCbor {
         mut keys: &[usize],
         payload: &[u8],
     ) -> Result<(), SerdeError<Self::DeError>> {
+        validate_cbor_payload(payload).map_err(SerdeError::Finalization)?;
         let mut deserializer = minicbor_serde::Deserializer::new(payload);
-        settings.deserialize_by_key(&mut keys, &mut deserializer)?;
-        let decoder = deserializer.decoder();
-        if decoder.position() == decoder.input().len() {
-            return Ok(());
-        }
-        Err(SerdeError::Finalization(
-            CborDecodeError::message("trailing data").into(),
-        ))
+        settings.deserialize_by_key(&mut keys, &mut deserializer)
+    }
+}
+
+#[cfg(feature = "cbor")]
+fn validate_cbor_payload(payload: &[u8]) -> Result<(), CborDeError> {
+    let mut decoder = CborDecoder::new(payload);
+    decoder.skip()?;
+    if decoder.position() == decoder.input().len() {
+        Ok(())
+    } else {
+        Err(CborDecodeError::message("trailing data").into())
     }
 }
 

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -6,6 +6,9 @@
 //! The crate is deliberately sessionless. Applications pass caller-owned settings into
 //! cooperative request handlers, and keep ownership of CoAP sockets, message IDs, tokens, routing,
 //! retransmission, and unrelated resources.
+//!
+//! The schema route serves a JSON manifest at `/schema` and compact text schema pages at
+//! `/schema/{page}`.
 
 use miniconf::Indices;
 
@@ -15,8 +18,8 @@ pub const MAX_DEPTH: usize = 12;
 /// Maximum bytes in a captured rooted CoAP URI path.
 pub const MAX_URI_PATH_LENGTH: usize = 256;
 
-/// Maximum response scratch bytes used by the optional `coap-handler` adapter.
-pub const MAX_HANDLER_PAYLOAD_LENGTH: usize = 512;
+/// Maximum value, schema, or error response bytes staged by the optional `coap-handler` adapter.
+pub const MAX_HANDLER_RESPONSE_LENGTH: usize = 512;
 
 /// Maximum compact schema definitions served by `miniconf_coap`.
 pub const MAX_SCHEMA_DEFS: usize = 64;

--- a/miniconf_coap/src/lib.rs
+++ b/miniconf_coap/src/lib.rs
@@ -1,0 +1,1693 @@
+#![no_std]
+#![warn(missing_docs)]
+
+//! Serve selected `miniconf` trees as CoAP resources.
+//!
+//! The crate is deliberately sessionless. Applications pass caller-owned settings into
+//! cooperative request handlers, and keep ownership of CoAP sockets, message IDs, tokens, routing,
+//! retransmission, and unrelated resources.
+
+use core::{convert::Infallible, fmt::Write as _};
+
+use coap_message::{
+    Code as _, MessageOption, MinimalWritableMessage, OptionNumber as _, ReadableMessage,
+};
+use coap_numbers::{code, option};
+use defmt::{debug, trace, warn};
+#[cfg(any(feature = "json", feature = "postcard"))]
+use miniconf::DescendError;
+#[cfg(feature = "postcard")]
+use miniconf::Packed;
+#[cfg(feature = "json")]
+use miniconf::json_core;
+use miniconf::{
+    Indices, KeyError, SerdeError, TreeDeserializeOwned, TreeSchema, TreeSerialize, ValueError,
+};
+#[cfg(feature = "json")]
+use serde_json_core::{de::Error as JsonDeError, ser::Error as JsonSerError};
+
+const MAX_ACCEPT_OPTIONS: usize = 4;
+
+/// JSON Content-Format number.
+pub const JSON_CONTENT_FORMAT: u16 = 50;
+
+/// Maximum Miniconf tree depth supported by `miniconf_coap`.
+pub const MAX_DEPTH: usize = 12;
+
+/// Maximum bytes in a captured rooted CoAP URI path.
+pub const MAX_URI_PATH_LENGTH: usize = 256;
+
+/// Exact changed leaf indices produced by a successful `PUT`.
+pub type ChangedKey = Indices<[usize; MAX_DEPTH]>;
+
+type UriPath = heapless::String<MAX_URI_PATH_LENGTH>;
+
+#[derive(Debug, Clone, Copy, Default)]
+struct Accepts {
+    values: [u16; MAX_ACCEPT_OPTIONS],
+    len: usize,
+    overflow: bool,
+}
+
+impl Accepts {
+    const fn new() -> Self {
+        Self {
+            values: [0; MAX_ACCEPT_OPTIONS],
+            len: 0,
+            overflow: false,
+        }
+    }
+
+    fn from_option(value: Option<u16>) -> Self {
+        let mut accepts = Self::new();
+        if let Some(value) = value {
+            accepts.values[0] = value;
+            accepts.len = 1;
+        }
+        accepts
+    }
+
+    fn push(&mut self, value: u16) {
+        if let Some(slot) = self.values.get_mut(self.len) {
+            *slot = value;
+            self.len += 1;
+        } else {
+            self.overflow = true;
+        }
+    }
+
+    const fn is_present(&self) -> bool {
+        self.len != 0
+    }
+
+    fn first(&self) -> Option<u16> {
+        self.values.first().copied().filter(|_| self.len != 0)
+    }
+
+    fn contains(&self, content_format: u16) -> bool {
+        self.values[..self.len].contains(&content_format)
+    }
+
+    fn accepts(&self, content_format: u16) -> Result<(), Error> {
+        if !self.is_present() || self.contains(content_format) {
+            Ok(())
+        } else if self.overflow {
+            Err(Error::new(code::BAD_OPTION, Problem::TooManyAcceptOptions))
+        } else {
+            Err(Error::new(code::NOT_ACCEPTABLE, Problem::NotAcceptable))
+        }
+    }
+}
+
+/// Parsed CoAP request data used by cooperative handlers.
+#[derive(Debug)]
+pub struct RequestParts<'a> {
+    code: u8,
+    path: UriPath,
+    accepts: Accepts,
+    content_format: Option<u16>,
+    payload: &'a [u8],
+}
+
+impl<'a> RequestParts<'a> {
+    /// Build request parts from already-decoded fields.
+    pub fn new(
+        code: u8,
+        path: &[&str],
+        accept: Option<u16>,
+        content_format: Option<u16>,
+        payload: &'a [u8],
+    ) -> Result<Self, Error> {
+        let mut request = Self {
+            code,
+            path: UriPath::new(),
+            accepts: Accepts::from_option(accept),
+            content_format,
+            payload,
+        };
+        for segment in path {
+            request.push_path_segment(segment)?;
+        }
+        Ok(request)
+    }
+
+    /// Extract method, URI path, content negotiation options, and payload from a readable message.
+    pub fn from_message<M>(message: &'a M) -> Result<Self, Error>
+    where
+        M: ReadableMessage + ?Sized,
+    {
+        let mut request = Self {
+            code: message.code().into(),
+            path: UriPath::new(),
+            accepts: Accepts::new(),
+            content_format: None,
+            payload: message.payload(),
+        };
+
+        for opt in message.options() {
+            match opt.number() {
+                option::URI_PATH => {
+                    let Some(segment) = opt.value_str() else {
+                        return Err(Error::bad_request(Problem::InvalidUriPath));
+                    };
+                    request.push_path_segment(segment)?;
+                }
+                option::ACCEPT => {
+                    let Some(accept) = opt.value_uint() else {
+                        return Err(Error::bad_request(Problem::InvalidAccept));
+                    };
+                    request.accepts.push(accept);
+                }
+                option::CONTENT_FORMAT => {
+                    let Some(content_format) = opt.value_uint() else {
+                        return Err(Error::bad_request(Problem::InvalidContentFormat));
+                    };
+                    request.content_format = Some(content_format);
+                }
+                _ => {}
+            }
+        }
+
+        Ok(request)
+    }
+
+    /// Request method code.
+    pub const fn code(&self) -> u8 {
+        self.code
+    }
+
+    /// URI path segments.
+    pub fn path(&self) -> &str {
+        self.path.as_str()
+    }
+
+    /// Request payload.
+    pub const fn payload(&self) -> &'a [u8] {
+        self.payload
+    }
+
+    fn accepts(&self, content_format: u16) -> Result<(), Error> {
+        self.accepts.accepts(content_format)
+    }
+
+    fn push_path_segment(&mut self, segment: &str) -> Result<(), Error> {
+        if segment.contains('/') {
+            return Err(Error::bad_request(Problem::InvalidUriPath));
+        }
+        self.path
+            .push('/')
+            .map_err(|_| Error::request_entity_too_large(Problem::UriPathTooLong))?;
+        self.path
+            .push_str(segment)
+            .map_err(|_| Error::request_entity_too_large(Problem::UriPathTooLong))
+    }
+
+    fn relative_to(&self, base: &str) -> Option<&str> {
+        if base.is_empty() {
+            return Some(self.path.as_str());
+        }
+        if self.path.as_str() == base {
+            return Some("");
+        }
+        let tail = self.path.as_str().strip_prefix(base)?;
+        tail.starts_with('/').then_some(tail)
+    }
+}
+
+impl defmt::Format for RequestParts<'_> {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        defmt::write!(
+            fmt,
+            "RequestParts {{ code: {=u8}, path: {=str}, accept_present: {=bool}, accept: {=u16}, content_format_present: {=bool}, content_format: {=u16}, payload_len: {=usize} }}",
+            self.code,
+            self.path.as_str(),
+            self.accepts.is_present(),
+            self.accepts.first().unwrap_or(0),
+            self.content_format.is_some(),
+            self.content_format.unwrap_or(0),
+            self.payload.len()
+        )
+    }
+}
+
+/// CoAP response data produced by cooperative handlers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Response<'a> {
+    /// CoAP response code.
+    pub code: u8,
+    /// Optional CoAP Content-Format value.
+    pub content_format: Option<u16>,
+    /// Response payload.
+    pub payload: &'a [u8],
+}
+
+impl Response<'_> {
+    /// Render this response into a writable CoAP message.
+    pub fn write_to<M: MinimalWritableMessage>(
+        &self,
+        message: &mut M,
+    ) -> Result<(), M::UnionError> {
+        message.set_code(M::Code::new(self.code).map_err(M::convert_code_error)?);
+        if let Some(content_format) = self.content_format {
+            message
+                .add_option_uint(
+                    M::OptionNumber::new(option::CONTENT_FORMAT)
+                        .map_err(M::convert_option_number_error)?,
+                    content_format,
+                )
+                .map_err(M::convert_add_option_error)?;
+        }
+        message
+            .set_payload(self.payload)
+            .map_err(M::convert_set_payload_error)
+    }
+}
+
+impl defmt::Format for Response<'_> {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        defmt::write!(
+            fmt,
+            "Response {{ code: {=u8}, content_format_present: {=bool}, content_format: {=u16}, payload_len: {=usize} }}",
+            self.code,
+            self.content_format.is_some(),
+            self.content_format.unwrap_or(0),
+            self.payload.len()
+        )
+    }
+}
+
+/// Handler outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome<'a> {
+    /// Request path is outside this handler's route.
+    Unhandled,
+    /// Request was handled without changing settings.
+    Handled(Response<'a>),
+    /// Request changed one exact leaf.
+    Changed {
+        /// Changed Miniconf leaf key.
+        key: ChangedKey,
+        /// CoAP response to send.
+        response: Response<'a>,
+    },
+}
+
+impl Outcome<'_> {
+    /// Return the response, if any.
+    pub const fn response(&self) -> Option<Response<'_>> {
+        match self {
+            Self::Unhandled => None,
+            Self::Handled(response) | Self::Changed { response, .. } => Some(*response),
+        }
+    }
+}
+
+impl defmt::Format for Outcome<'_> {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        match self {
+            Self::Unhandled => defmt::write!(fmt, "Outcome::Unhandled"),
+            Self::Handled(response) => defmt::write!(fmt, "Outcome::Handled({})", response),
+            Self::Changed { key, response } => defmt::write!(
+                fmt,
+                "Outcome::Changed {{ key: {}, response: {} }}",
+                key,
+                response
+            ),
+        }
+    }
+}
+
+/// Problem details preserved in error responses.
+#[derive(defmt::Format, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Problem {
+    /// URI path option was not valid UTF-8.
+    InvalidUriPath,
+    /// Accept option could not be decoded as a CoAP uint.
+    InvalidAccept,
+    /// Content-Format option could not be decoded as a CoAP uint.
+    InvalidContentFormat,
+    /// URI path had more segments than this handler captured.
+    UriPathTooLong,
+    /// Request had more Accept options than this handler captures.
+    TooManyAcceptOptions,
+    /// Request path names no static Miniconf resource.
+    NotFound {
+        /// Depth reached before lookup failed.
+        depth: usize,
+    },
+    /// Request path continues below a leaf.
+    TooLong {
+        /// Depth of the leaf under which the request continued.
+        depth: usize,
+    },
+    /// Request path names a known branch, but this route handles leaves only.
+    NonLeaf {
+        /// Depth of the branch resource.
+        depth: usize,
+    },
+    /// Static schema contains the leaf, but runtime state makes it absent.
+    Absent {
+        /// Depth of the runtime-absent leaf.
+        depth: usize,
+    },
+    /// Runtime access policy denied the operation.
+    Access {
+        /// Operation being performed.
+        op: Operation,
+        /// Error text from Miniconf.
+        message: &'static str,
+    },
+    /// Request method is not supported here.
+    MethodNotAllowed,
+    /// Request `Accept` option does not allow this route's representation.
+    NotAcceptable,
+    /// Request payload Content-Format is not supported here.
+    UnsupportedContentFormat,
+    /// Payload could not be decoded.
+    BadPayload,
+    /// A read-side value serialization failed.
+    Serialization,
+}
+
+/// CoAP operation being performed.
+#[derive(defmt::Format, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operation {
+    /// Read operation.
+    Read,
+    /// Write operation.
+    Write,
+}
+
+/// CoAP handler error.
+#[derive(defmt::Format, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Error {
+    /// CoAP response code.
+    pub code: u8,
+    /// Machine-readable problem.
+    pub problem: Problem,
+}
+
+impl Error {
+    const fn new(code: u8, problem: Problem) -> Self {
+        Self { code, problem }
+    }
+
+    const fn bad_request(problem: Problem) -> Self {
+        Self::new(code::BAD_REQUEST, problem)
+    }
+
+    const fn request_entity_too_large(problem: Problem) -> Self {
+        Self::new(code::REQUEST_ENTITY_TOO_LARGE, problem)
+    }
+
+    fn response<'a>(self, buf: &'a mut [u8]) -> Response<'a> {
+        match problem_json(self.problem, buf) {
+            Ok(len) => Response {
+                code: self.code,
+                content_format: Some(JSON_CONTENT_FORMAT),
+                payload: &buf[..len],
+            },
+            Err(_) => Response {
+                code: self.code,
+                content_format: None,
+                payload: b"",
+            },
+        }
+    }
+}
+
+/// Leaf value route backed by a Miniconf tree.
+#[derive(defmt::Format, Debug, Clone, Copy)]
+pub struct ValueHandler<'a, R> {
+    base: &'a str,
+    representation: R,
+}
+
+/// Const-path-addressed JSON value route.
+#[cfg(feature = "json")]
+pub type ConstPathJsonHandler<'a> = ValueHandler<'a, ConstPathJson>;
+
+/// Packed-key postcard value route.
+#[cfg(feature = "postcard")]
+pub type PackedPostcardHandler<'a> = ValueHandler<'a, PackedPostcard>;
+
+/// URI path segments as Miniconf `ConstPath` keys, with JSON payloads.
+#[cfg(feature = "json")]
+#[derive(defmt::Format, Debug, Clone, Copy)]
+pub struct ConstPathJson;
+
+/// One URI path segment as a Miniconf `Packed` LSB key, with postcard payloads.
+#[cfg(feature = "postcard")]
+#[derive(defmt::Format, Debug, Clone, Copy)]
+pub struct PackedPostcard {
+    content_format: u16,
+}
+
+mod private {
+    pub trait Sealed {}
+}
+
+#[cfg(feature = "json")]
+impl private::Sealed for ConstPathJson {}
+#[cfg(feature = "postcard")]
+impl private::Sealed for PackedPostcard {}
+
+#[cfg(feature = "json")]
+impl<'a> ValueHandler<'a, ConstPathJson> {
+    /// Serve JSON where remaining URI path segments are Miniconf path segments.
+    pub const fn const_path_json(base: &'a str) -> Self {
+        Self {
+            base,
+            representation: ConstPathJson,
+        }
+    }
+}
+
+#[cfg(feature = "postcard")]
+impl<'a> ValueHandler<'a, PackedPostcard> {
+    /// Serve postcard where the next URI path segment is a `Packed` key in LSB notation.
+    pub const fn packed_postcard(base: &'a str, content_format: u16) -> Self {
+        Self {
+            base,
+            representation: PackedPostcard { content_format },
+        }
+    }
+}
+
+impl<'a, R> ValueHandler<'a, R>
+where
+    R: Representation,
+{
+    /// Handle a single request using cooperative borrows.
+    pub fn handle<'b, Settings>(
+        &self,
+        request: &RequestParts<'_>,
+        settings: &mut Settings,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b>
+    where
+        Settings: TreeSchema + TreeSerialize + TreeDeserializeOwned,
+    {
+        let Some(path) = request.relative_to(self.base) else {
+            trace!("Ignoring non-Miniconf CoAP route request={}", request);
+            return Outcome::Unhandled;
+        };
+
+        trace!(
+            "Handling Miniconf CoAP request base={=str} request={}",
+            self.base, request
+        );
+
+        match request.code {
+            code::GET => self.get(path, &*settings, request, response_buf),
+            code::PUT => self.put(path, settings, request, response_buf),
+            _ => method_not_allowed(request, response_buf),
+        }
+    }
+
+    /// Handle a `GET` request with read-only settings bounds.
+    pub fn handle_get<'b, Settings>(
+        &self,
+        request: &RequestParts<'_>,
+        settings: &Settings,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b>
+    where
+        Settings: TreeSchema + TreeSerialize,
+    {
+        let Some(path) = request.relative_to(self.base) else {
+            trace!("Ignoring non-Miniconf CoAP route request={}", request);
+            return Outcome::Unhandled;
+        };
+
+        trace!(
+            "Handling Miniconf CoAP GET request base={=str} request={}",
+            self.base, request
+        );
+
+        if request.code != code::GET {
+            return method_not_allowed(request, response_buf);
+        }
+        self.get(path, settings, request, response_buf)
+    }
+
+    /// Handle a `PUT` request with write-only settings bounds.
+    pub fn handle_put<'b, Settings>(
+        &self,
+        request: &RequestParts<'_>,
+        settings: &mut Settings,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b>
+    where
+        Settings: TreeSchema + TreeDeserializeOwned,
+    {
+        let Some(path) = request.relative_to(self.base) else {
+            trace!("Ignoring non-Miniconf CoAP route request={}", request);
+            return Outcome::Unhandled;
+        };
+
+        trace!(
+            "Handling Miniconf CoAP PUT request base={=str} request={}",
+            self.base, request
+        );
+
+        if request.code != code::PUT {
+            return method_not_allowed(request, response_buf);
+        }
+        self.put(path, settings, request, response_buf)
+    }
+
+    fn get<'b, Settings>(
+        &self,
+        path: &str,
+        settings: &Settings,
+        request: &RequestParts<'_>,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b>
+    where
+        Settings: TreeSchema + TreeSerialize,
+    {
+        match self.get_len::<Settings>(path, settings, request, response_buf) {
+            Ok(len) => {
+                debug!(
+                    "Handled Miniconf CoAP GET path={=str} depth={=usize} response_len={=usize}",
+                    request.path(),
+                    path_depth(path),
+                    len
+                );
+                Outcome::Handled(Response {
+                    code: code::CONTENT,
+                    content_format: Some(self.representation.content_format()),
+                    payload: &response_buf[..len],
+                })
+            }
+            Err(err) => {
+                debug!("Rejecting Miniconf CoAP GET err={}", err);
+                Outcome::Handled(err.response(response_buf))
+            }
+        }
+    }
+
+    fn get_len<Settings>(
+        &self,
+        path: &str,
+        settings: &Settings,
+        request: &RequestParts<'_>,
+        response_buf: &mut [u8],
+    ) -> Result<usize, Error>
+    where
+        Settings: TreeSchema + TreeSerialize,
+    {
+        request.accepts(self.representation.content_format())?;
+        let (lookup, state) = self.resolve::<Settings>(path)?;
+        if !lookup.schema.is_leaf() {
+            return Err(Error::new(
+                code::METHOD_NOT_ALLOWED,
+                Problem::NonLeaf {
+                    depth: lookup.depth,
+                },
+            ));
+        }
+
+        let len = self
+            .representation
+            .get(settings, &state.as_ref()[..lookup.depth], response_buf)
+            .map_err(|err| read_error(err, lookup.depth))?;
+        Ok(len)
+    }
+
+    fn put<'b, Settings>(
+        &self,
+        path: &str,
+        settings: &mut Settings,
+        request: &RequestParts<'_>,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b>
+    where
+        Settings: TreeSchema + TreeDeserializeOwned,
+    {
+        match self.put_key::<Settings>(path, settings, request) {
+            Ok(key) => Outcome::Changed {
+                key,
+                response: Response {
+                    code: code::CHANGED,
+                    content_format: None,
+                    payload: b"",
+                },
+            },
+            Err(err) => {
+                debug!("Rejecting Miniconf CoAP PUT err={}", err);
+                Outcome::Handled(err.response(response_buf))
+            }
+        }
+    }
+
+    fn put_key<Settings>(
+        &self,
+        path: &str,
+        settings: &mut Settings,
+        request: &RequestParts<'_>,
+    ) -> Result<ChangedKey, Error>
+    where
+        Settings: TreeSchema + TreeDeserializeOwned,
+    {
+        match request.content_format {
+            Some(format) if format == self.representation.content_format() => {}
+            _ => {
+                return Err(Error::new(
+                    code::UNSUPPORTED_CONTENT_FORMAT,
+                    Problem::UnsupportedContentFormat,
+                ));
+            }
+        }
+
+        let (lookup, state) = self.resolve::<Settings>(path)?;
+        if !lookup.schema.is_leaf() {
+            return Err(Error::new(
+                code::METHOD_NOT_ALLOWED,
+                Problem::NonLeaf {
+                    depth: lookup.depth,
+                },
+            ));
+        }
+
+        self.representation
+            .set(settings, &state.as_ref()[..lookup.depth], request.payload)
+            .map_err(|err| value_error(err, Operation::Write, lookup.depth))?;
+        debug!(
+            "Accepted Miniconf CoAP PUT path={=str} depth={=usize} payload_len={=usize}",
+            request.path(),
+            lookup.depth,
+            request.payload.len()
+        );
+        Ok(state)
+    }
+
+    fn resolve<Settings>(&self, path: &str) -> Result<(miniconf::Lookup, ChangedKey), Error>
+    where
+        Settings: TreeSchema,
+    {
+        if Settings::SCHEMA.max_depth() > MAX_DEPTH {
+            warn!(
+                "Rejecting Miniconf CoAP request because schema depth={=usize} exceeds max_depth={=usize}",
+                Settings::SCHEMA.max_depth(),
+                MAX_DEPTH
+            );
+            return Err(Error::new(
+                code::REQUEST_ENTITY_TOO_LARGE,
+                Problem::UriPathTooLong,
+            ));
+        }
+        let mut state = [0; MAX_DEPTH];
+        let lookup = self.representation.resolve::<Settings>(path, &mut state)?;
+        Ok((lookup, Indices::new(state, lookup.depth)))
+    }
+}
+
+/// Complete value representation used by a [`ValueHandler`].
+pub trait Representation: private::Sealed {
+    /// Serialization error type.
+    type SerError;
+    /// Deserialization error type.
+    type DeError;
+
+    /// CoAP Content-Format used for successful responses and accepted request payloads.
+    fn content_format(&self) -> u16;
+
+    /// Resolve a route-relative URI path into a Miniconf schema lookup.
+    fn resolve<Settings: TreeSchema>(
+        &self,
+        path: &str,
+        state: &mut [usize],
+    ) -> Result<miniconf::Lookup, Error>;
+
+    /// Serialize a leaf value into the response buffer.
+    fn get<Settings: TreeSerialize + ?Sized>(
+        &self,
+        settings: &Settings,
+        keys: &[usize],
+        buf: &mut [u8],
+    ) -> Result<usize, SerdeError<Self::SerError>>;
+
+    /// Deserialize and set a leaf value from a request payload.
+    fn set<Settings: TreeDeserializeOwned + ?Sized>(
+        &self,
+        settings: &mut Settings,
+        keys: &[usize],
+        payload: &[u8],
+    ) -> Result<(), SerdeError<Self::DeError>>;
+}
+
+#[cfg(feature = "json")]
+impl Representation for ConstPathJson {
+    type SerError = JsonSerError;
+    type DeError = JsonDeError;
+
+    fn content_format(&self) -> u16 {
+        JSON_CONTENT_FORMAT
+    }
+
+    fn resolve<Settings: TreeSchema>(
+        &self,
+        path: &str,
+        state: &mut [usize],
+    ) -> Result<miniconf::Lookup, Error> {
+        Settings::SCHEMA
+            .resolve_into(path, state)
+            .map_err(resolve_error)
+    }
+
+    fn get<Settings: TreeSerialize + ?Sized>(
+        &self,
+        settings: &Settings,
+        mut keys: &[usize],
+        buf: &mut [u8],
+    ) -> Result<usize, SerdeError<Self::SerError>> {
+        json_core::get_by_keys(settings, &mut keys, buf)
+    }
+
+    fn set<Settings: TreeDeserializeOwned + ?Sized>(
+        &self,
+        settings: &mut Settings,
+        mut keys: &[usize],
+        payload: &[u8],
+    ) -> Result<(), SerdeError<Self::DeError>> {
+        json_core::set_by_keys(settings, &mut keys, payload).map(|_| ())
+    }
+}
+
+#[cfg(feature = "postcard")]
+impl Representation for PackedPostcard {
+    type SerError = postcard::Error;
+    type DeError = postcard::Error;
+
+    fn content_format(&self) -> u16 {
+        self.content_format
+    }
+
+    fn resolve<Settings: TreeSchema>(
+        &self,
+        path: &str,
+        state: &mut [usize],
+    ) -> Result<miniconf::Lookup, Error> {
+        Settings::SCHEMA
+            .resolve_into(packed_key(path)?, state)
+            .map_err(resolve_error)
+    }
+
+    fn get<Settings: TreeSerialize + ?Sized>(
+        &self,
+        settings: &Settings,
+        mut keys: &[usize],
+        buf: &mut [u8],
+    ) -> Result<usize, SerdeError<Self::SerError>> {
+        let used = miniconf::postcard::get_by_keys(
+            settings,
+            &mut keys,
+            postcard::ser_flavors::Slice::new(buf),
+        )?;
+        Ok(used.len())
+    }
+
+    fn set<Settings: TreeDeserializeOwned + ?Sized>(
+        &self,
+        settings: &mut Settings,
+        mut keys: &[usize],
+        payload: &[u8],
+    ) -> Result<(), SerdeError<Self::DeError>> {
+        let remainder = miniconf::postcard::set_by_keys(
+            settings,
+            &mut keys,
+            postcard::de_flavors::Slice::new(payload),
+        )?;
+        if remainder.is_empty() {
+            Ok(())
+        } else {
+            Err(SerdeError::Finalization(
+                postcard::Error::DeserializeUnexpectedEnd,
+            ))
+        }
+    }
+}
+
+/// Schema route backed by `TreeSchema`.
+#[cfg(feature = "json")]
+#[derive(defmt::Format, Debug, Clone, Copy)]
+pub struct SchemaHandler<'a> {
+    base: &'a str,
+}
+
+#[cfg(feature = "json")]
+impl<'a> SchemaHandler<'a> {
+    /// Construct a schema route mounted at an exact URI path.
+    pub const fn new(base: &'a str) -> Self {
+        Self { base }
+    }
+
+    /// Handle a schema `GET` request.
+    pub fn handle<'b, Settings>(
+        &self,
+        request: &RequestParts<'_>,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b>
+    where
+        Settings: TreeSchema,
+    {
+        if request.path() != self.base {
+            trace!("Ignoring non-schema CoAP route request={}", request);
+            return Outcome::Unhandled;
+        }
+        trace!("Handling Miniconf CoAP schema request request={}", request);
+        if request.code != code::GET {
+            return Outcome::Handled(
+                Error::new(code::METHOD_NOT_ALLOWED, Problem::MethodNotAllowed)
+                    .response(response_buf),
+            );
+        }
+        if let Err(err) = request.accepts(JSON_CONTENT_FORMAT) {
+            return Outcome::Handled(err.response(response_buf));
+        }
+        match serde_json_core::to_slice(Settings::SCHEMA, response_buf) {
+            Ok(len) => {
+                debug!(
+                    "Handled Miniconf CoAP schema GET path={=str} response_len={=usize}",
+                    request.path(),
+                    len
+                );
+                Outcome::Handled(Response {
+                    code: code::CONTENT,
+                    content_format: Some(JSON_CONTENT_FORMAT),
+                    payload: &response_buf[..len],
+                })
+            }
+            Err(_) => {
+                warn!(
+                    "Failed to serialize Miniconf CoAP schema path={=str}",
+                    request.path()
+                );
+                Outcome::Handled(Response {
+                    code: code::INTERNAL_SERVER_ERROR,
+                    content_format: None,
+                    payload: b"",
+                })
+            }
+        }
+    }
+}
+
+#[cfg(feature = "postcard")]
+fn packed_key(path: &str) -> Result<Packed, Error> {
+    let Some(value) = path.strip_prefix('/') else {
+        return Err(Error::new(
+            code::BAD_REQUEST,
+            Problem::NonLeaf {
+                depth: path_depth(path),
+            },
+        ));
+    };
+    if value.contains('/') {
+        return Err(Error::new(
+            code::BAD_REQUEST,
+            Problem::NonLeaf {
+                depth: path_depth(path),
+            },
+        ));
+    }
+    let parsed =
+        parse_usize(value).ok_or(Error::new(code::NOT_FOUND, Problem::NotFound { depth: 0 }))?;
+    Packed::new_from_lsb(parsed).ok_or(Error::new(code::NOT_FOUND, Problem::NotFound { depth: 0 }))
+}
+
+#[cfg(feature = "postcard")]
+fn parse_usize(value: &str) -> Option<usize> {
+    let mut parsed = 0usize;
+    for byte in value.bytes() {
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+        parsed = parsed
+            .checked_mul(10)?
+            .checked_add(usize::from(byte - b'0'))?;
+    }
+    Some(parsed)
+}
+
+fn path_depth(path: &str) -> usize {
+    path.as_bytes().iter().filter(|byte| **byte == b'/').count()
+}
+
+#[cfg(any(feature = "json", feature = "postcard"))]
+fn resolve_error(err: miniconf::ResolveError) -> Error {
+    let depth = err.lookup.depth;
+    match err.error {
+        DescendError::Key(KeyError::NotFound) => {
+            Error::new(code::NOT_FOUND, Problem::NotFound { depth })
+        }
+        DescendError::Key(KeyError::TooLong) => {
+            Error::new(code::NOT_FOUND, Problem::TooLong { depth })
+        }
+        DescendError::Key(KeyError::TooShort) => {
+            Error::new(code::METHOD_NOT_ALLOWED, Problem::NonLeaf { depth })
+        }
+        DescendError::Inner(()) => {
+            Error::new(code::REQUEST_ENTITY_TOO_LARGE, Problem::UriPathTooLong)
+        }
+    }
+}
+
+fn read_error<E>(err: SerdeError<E>, depth: usize) -> Error {
+    match err {
+        SerdeError::Value(ValueError::Key(KeyError::NotFound)) => {
+            Error::new(code::NOT_FOUND, Problem::NotFound { depth })
+        }
+        SerdeError::Value(ValueError::Key(KeyError::TooLong)) => {
+            Error::new(code::NOT_FOUND, Problem::TooLong { depth })
+        }
+        SerdeError::Value(ValueError::Key(KeyError::TooShort)) => {
+            Error::new(code::METHOD_NOT_ALLOWED, Problem::NonLeaf { depth })
+        }
+        SerdeError::Value(ValueError::Absent) => {
+            Error::new(code::CONFLICT, Problem::Absent { depth })
+        }
+        SerdeError::Value(ValueError::Access(message)) => Error::new(
+            code::FORBIDDEN,
+            Problem::Access {
+                op: Operation::Read,
+                message,
+            },
+        ),
+        SerdeError::Inner(_) | SerdeError::Finalization(_) => {
+            Error::new(code::INTERNAL_SERVER_ERROR, Problem::Serialization)
+        }
+    }
+}
+
+fn value_error<E>(err: SerdeError<E>, op: Operation, depth: usize) -> Error {
+    match err {
+        SerdeError::Value(ValueError::Key(KeyError::NotFound)) => {
+            Error::new(code::NOT_FOUND, Problem::NotFound { depth })
+        }
+        SerdeError::Value(ValueError::Key(KeyError::TooLong)) => {
+            Error::new(code::NOT_FOUND, Problem::TooLong { depth })
+        }
+        SerdeError::Value(ValueError::Key(KeyError::TooShort)) => {
+            Error::new(code::METHOD_NOT_ALLOWED, Problem::NonLeaf { depth })
+        }
+        SerdeError::Value(ValueError::Absent) => {
+            Error::new(code::CONFLICT, Problem::Absent { depth })
+        }
+        SerdeError::Value(ValueError::Access(message)) => Error::new(
+            match op {
+                Operation::Read => code::FORBIDDEN,
+                Operation::Write => code::UNPROCESSABLE_ENTITY,
+            },
+            Problem::Access { op, message },
+        ),
+        SerdeError::Inner(_) | SerdeError::Finalization(_) => {
+            Error::new(code::BAD_REQUEST, Problem::BadPayload)
+        }
+    }
+}
+
+fn method_not_allowed<'a>(request: &RequestParts<'_>, response_buf: &'a mut [u8]) -> Outcome<'a> {
+    let err = Error::new(code::METHOD_NOT_ALLOWED, Problem::MethodNotAllowed);
+    debug!(
+        "Rejecting Miniconf CoAP request code={=u8} err={}",
+        request.code, err
+    );
+    Outcome::Handled(err.response(response_buf))
+}
+
+fn problem_json(problem: Problem, buf: &mut [u8]) -> Result<usize, core::fmt::Error> {
+    let mut out = SliceWriter::new(buf);
+    match problem {
+        Problem::InvalidUriPath => write_kind(&mut out, "invalid_uri_path")?,
+        Problem::InvalidAccept => write_kind(&mut out, "invalid_accept")?,
+        Problem::InvalidContentFormat => write_kind(&mut out, "invalid_content_format")?,
+        Problem::UriPathTooLong => write_kind(&mut out, "uri_path_too_long")?,
+        Problem::TooManyAcceptOptions => write_kind(&mut out, "too_many_accept_options")?,
+        Problem::NotFound { depth } => write_depth(&mut out, "not_found", depth)?,
+        Problem::TooLong { depth } => write_depth(&mut out, "too_long", depth)?,
+        Problem::NonLeaf { depth } => write_depth(&mut out, "non_leaf", depth)?,
+        Problem::Absent { depth } => write_depth(&mut out, "absent", depth)?,
+        Problem::Access { op, message } => {
+            write!(
+                out,
+                "{{\"kind\":\"access\",\"op\":\"{}\",\"message\":",
+                match op {
+                    Operation::Read => "read",
+                    Operation::Write => "write",
+                }
+            )?;
+            write_json_string_truncated(&mut out, message, 1)?;
+            out.push('}')?;
+        }
+        Problem::MethodNotAllowed => write_kind(&mut out, "method_not_allowed")?,
+        Problem::NotAcceptable => write_kind(&mut out, "not_acceptable")?,
+        Problem::UnsupportedContentFormat => write_kind(&mut out, "unsupported_content_format")?,
+        Problem::BadPayload => write_kind(&mut out, "bad_payload")?,
+        Problem::Serialization => write_kind(&mut out, "serialization")?,
+    }
+    Ok(out.len())
+}
+
+struct SliceWriter<'a> {
+    buf: &'a mut [u8],
+    len: usize,
+}
+
+impl<'a> SliceWriter<'a> {
+    fn new(buf: &'a mut [u8]) -> Self {
+        Self { buf, len: 0 }
+    }
+
+    const fn len(&self) -> usize {
+        self.len
+    }
+
+    fn remaining(&self) -> usize {
+        self.buf.len() - self.len
+    }
+
+    fn push(&mut self, value: char) -> core::fmt::Result {
+        self.write_char(value)
+    }
+}
+
+impl core::fmt::Write for SliceWriter<'_> {
+    fn write_str(&mut self, value: &str) -> core::fmt::Result {
+        let bytes = value.as_bytes();
+        let Some(dst) = self.buf.get_mut(self.len..self.len + bytes.len()) else {
+            return Err(core::fmt::Error);
+        };
+        dst.copy_from_slice(bytes);
+        self.len += bytes.len();
+        Ok(())
+    }
+}
+
+fn write_kind(out: &mut impl core::fmt::Write, kind: &str) -> core::fmt::Result {
+    write!(out, "{{\"kind\":\"{}\"}}", kind)
+}
+
+fn write_depth(out: &mut impl core::fmt::Write, kind: &str, depth: usize) -> core::fmt::Result {
+    write!(out, "{{\"kind\":\"{}\",\"depth\":{}}}", kind, depth)
+}
+
+fn write_json_string_truncated(
+    out: &mut SliceWriter<'_>,
+    value: &str,
+    reserve: usize,
+) -> core::fmt::Result {
+    out.push('"')?;
+    for byte in value.bytes() {
+        let escaped = match byte {
+            b'"' => "\\\"",
+            b'\\' => "\\\\",
+            0x08 => "\\b",
+            0x0c => "\\f",
+            b'\n' => "\\n",
+            b'\r' => "\\r",
+            b'\t' => "\\t",
+            _ => "",
+        };
+        if !escaped.is_empty() {
+            if out.remaining() <= reserve + 1 || escaped.len() > out.remaining() - reserve - 1 {
+                break;
+            }
+            out.write_str(escaped)?;
+            continue;
+        }
+        match byte {
+            0x00..=0x1f => {
+                if out.remaining() <= reserve + 1 || 6 > out.remaining() - reserve - 1 {
+                    break;
+                }
+                write!(out, "\\u{:04x}", byte)?;
+            }
+            _ => {
+                if out.remaining() <= reserve + 1 {
+                    break;
+                }
+                out.push(char::from(byte))?;
+            }
+        }
+    }
+    out.push('"')
+}
+
+impl coap_message::error::RenderableOnMinimal for Error {
+    type Error<IE: coap_message::error::RenderableOnMinimal + core::fmt::Debug> = IE;
+
+    fn render<M: MinimalWritableMessage>(
+        self,
+        message: &mut M,
+    ) -> Result<(), Self::Error<M::UnionError>> {
+        let mut buf = [0; 96];
+        self.response(&mut buf).write_to(message)
+    }
+}
+
+impl From<Infallible> for Error {
+    fn from(value: Infallible) -> Self {
+        match value {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use core::convert::Infallible;
+
+    use coap_message::{MessageOption as _, MinimalWritableMessage, ReadableMessage};
+    use coap_numbers::code;
+    use miniconf::Tree;
+    use std::{sync::OnceLock, vec::Vec};
+
+    use super::*;
+
+    #[derive(Tree)]
+    struct Settings {
+        hidden: bool,
+        number: u32,
+        #[tree(with = label)]
+        label: heapless::String<16>,
+        visible: Option<Visible>,
+    }
+
+    #[derive(Tree)]
+    struct Visible {
+        value: u8,
+    }
+
+    impl Default for Settings {
+        fn default() -> Self {
+            Self {
+                hidden: false,
+                number: 7,
+                label: "demo".try_into().unwrap(),
+                visible: Some(Visible { value: 9 }),
+            }
+        }
+    }
+
+    fn init_host_logging() {
+        static HOST_LOGGING: OnceLock<()> = OnceLock::new();
+
+        HOST_LOGGING.get_or_init(|| {
+            env_logger::builder().is_test(true).try_init().unwrap();
+            defmt2log::init_from_current_exe();
+        });
+    }
+
+    mod label {
+        use miniconf::{Keys, SerdeError, ValueError, leaf};
+        use serde::{Deserializer, Serializer};
+
+        pub use leaf::{mut_any_by_key, probe_by_key, ref_any_by_key, schema};
+
+        pub fn serialize_by_key<S: Serializer>(
+            value: &heapless::String<16>,
+            keys: impl Keys,
+            ser: S,
+        ) -> Result<S::Ok, SerdeError<S::Error>> {
+            leaf::serialize_by_key(value, keys, ser)
+        }
+
+        pub fn deserialize_by_key<'de, D: Deserializer<'de>>(
+            value: &mut heapless::String<16>,
+            keys: impl Keys,
+            de: D,
+        ) -> Result<(), SerdeError<D::Error>> {
+            let mut next = value.clone();
+            leaf::deserialize_by_key(&mut next, keys, de)?;
+            if next.contains('<') {
+                return Err(ValueError::Access("bad label").into());
+            }
+            *value = next;
+            Ok(())
+        }
+    }
+
+    fn request(
+        code: u8,
+        path: &[&str],
+        content_format: Option<u16>,
+        payload: &'static [u8],
+    ) -> RequestParts<'static> {
+        RequestParts::new(code, path, None, content_format, payload).unwrap()
+    }
+
+    #[derive(Debug, Clone)]
+    struct TestOption {
+        number: u16,
+        value: Vec<u8>,
+    }
+
+    impl coap_message::MessageOption for &TestOption {
+        fn number(&self) -> u16 {
+            self.number
+        }
+
+        fn value(&self) -> &[u8] {
+            &self.value
+        }
+    }
+
+    #[derive(Debug, Default, Clone)]
+    struct TestMessage {
+        code: u8,
+        options: Vec<TestOption>,
+        payload: Vec<u8>,
+    }
+
+    impl TestMessage {
+        fn new(code: u8) -> Self {
+            Self {
+                code,
+                options: Vec::new(),
+                payload: Vec::new(),
+            }
+        }
+
+        fn str_option(mut self, number: u16, value: &str) -> Self {
+            self.options.push(TestOption {
+                number,
+                value: value.as_bytes().to_vec(),
+            });
+            self
+        }
+
+        fn option(mut self, number: u16, value: &[u8]) -> Self {
+            self.options.push(TestOption {
+                number,
+                value: value.to_vec(),
+            });
+            self
+        }
+
+        fn uint_option(mut self, number: u16, value: u16) -> Self {
+            self.options.push(TestOption {
+                number,
+                value: uint_vec(value),
+            });
+            self
+        }
+
+        fn with_payload(mut self, payload: &[u8]) -> Self {
+            self.payload = payload.to_vec();
+            self
+        }
+    }
+
+    impl ReadableMessage for TestMessage {
+        type Code = u8;
+        type MessageOption<'a> = &'a TestOption;
+        type OptionsIter<'a> = core::slice::Iter<'a, TestOption>;
+
+        fn code(&self) -> Self::Code {
+            self.code
+        }
+
+        fn options(&self) -> Self::OptionsIter<'_> {
+            self.options.iter()
+        }
+
+        fn payload(&self) -> &[u8] {
+            &self.payload
+        }
+    }
+
+    impl MinimalWritableMessage for TestMessage {
+        type AddOptionError = Infallible;
+        type Code = u8;
+        type OptionNumber = u16;
+        type SetPayloadError = Infallible;
+        type UnionError = Infallible;
+
+        fn set_code(&mut self, code: Self::Code) {
+            self.code = code;
+        }
+
+        fn add_option(
+            &mut self,
+            number: Self::OptionNumber,
+            value: &[u8],
+        ) -> Result<(), Self::AddOptionError> {
+            self.options.push(TestOption {
+                number,
+                value: value.to_vec(),
+            });
+            Ok(())
+        }
+
+        fn set_payload(&mut self, data: &[u8]) -> Result<(), Self::SetPayloadError> {
+            self.payload = data.to_vec();
+            Ok(())
+        }
+    }
+
+    fn uint_vec(value: u16) -> Vec<u8> {
+        match value {
+            0 => Vec::new(),
+            1..=0xff => [value as u8].to_vec(),
+            _ => value.to_be_bytes().to_vec(),
+        }
+    }
+
+    fn route<'a>(
+        request: &RequestParts<'_>,
+        settings: &mut Settings,
+        response_buf: &'a mut [u8],
+    ) -> Outcome<'a> {
+        let schema = SchemaHandler::new("/schema");
+        let values = ConstPathJsonHandler::const_path_json("/settings");
+
+        match request.path() {
+            "/schema" => return schema.handle::<Settings>(request, response_buf),
+            "/settings" => return values.handle(request, settings, response_buf),
+            path if path.starts_with("/settings/") => {
+                return values.handle(request, settings, response_buf);
+            }
+            _ => {}
+        }
+        if request.path() == "/status" {
+            return Outcome::Handled(Response {
+                code: code::CONTENT,
+                content_format: Some(JSON_CONTENT_FORMAT),
+                payload: br#"{"ok":true}"#,
+            });
+        }
+        Outcome::Unhandled
+    }
+
+    #[test]
+    fn get_and_put_json_leaf() {
+        init_host_logging();
+        let handler = ConstPathJsonHandler::const_path_json("/settings");
+        let mut settings = Settings::default();
+        let mut response = [0; 128];
+
+        let req = request(code::GET, &["settings", "number"], None, b"");
+        let out = handler.handle(&req, &mut settings, &mut response);
+        let response = out.response().unwrap();
+        assert_eq!(response.code, code::CONTENT);
+        assert_eq!(response.content_format, Some(JSON_CONTENT_FORMAT));
+        assert_eq!(response.payload, b"7");
+
+        let mut response = [0; 128];
+        let req = request(
+            code::PUT,
+            &["settings", "number"],
+            Some(JSON_CONTENT_FORMAT),
+            b"12",
+        );
+        let out = handler.handle(&req, &mut settings, &mut response);
+        assert!(matches!(out, Outcome::Changed { .. }));
+        assert_eq!(settings.number, 12);
+    }
+
+    #[test]
+    fn absent_not_found_and_too_long_stay_distinct() {
+        init_host_logging();
+        let handler = ConstPathJsonHandler::const_path_json("/settings");
+        let mut settings = Settings::default();
+        settings.visible = None;
+
+        let mut response = [0; 128];
+        let req = request(code::GET, &["settings", "visible", "value"], None, b"");
+        let out = handler.handle(&req, &mut settings, &mut response);
+        let response = out.response().unwrap();
+        assert_eq!(response.code, code::CONFLICT);
+        assert_eq!(response.payload, br#"{"kind":"absent","depth":2}"#);
+
+        let mut response = [0; 128];
+        let req = request(code::GET, &["settings", "missing"], None, b"");
+        let out = handler.handle(&req, &mut settings, &mut response);
+        let response = out.response().unwrap();
+        assert_eq!(response.code, code::NOT_FOUND);
+        assert_eq!(response.payload, br#"{"kind":"not_found","depth":0}"#);
+
+        let mut response = [0; 128];
+        let req = request(code::GET, &["settings", "number", "extra"], None, b"");
+        let out = handler.handle(&req, &mut settings, &mut response);
+        let response = out.response().unwrap();
+        assert_eq!(response.code, code::NOT_FOUND);
+        assert_eq!(response.payload, br#"{"kind":"too_long","depth":1}"#);
+    }
+
+    #[test]
+    fn access_write_maps_to_unprocessable_entity() {
+        init_host_logging();
+        let handler = ConstPathJsonHandler::const_path_json("/settings");
+        let mut settings = Settings::default();
+        let mut response = [0; 128];
+
+        let req = request(
+            code::PUT,
+            &["settings", "label"],
+            Some(JSON_CONTENT_FORMAT),
+            br#""bad<label""#,
+        );
+        let out = handler.handle(&req, &mut settings, &mut response);
+        let response = out.response().unwrap();
+        assert_eq!(response.code, code::UNPROCESSABLE_ENTITY);
+        assert_eq!(
+            response.payload,
+            br#"{"kind":"access","op":"write","message":"bad label"}"#
+        );
+    }
+
+    #[test]
+    fn schema_route_is_separate() {
+        init_host_logging();
+        let handler = SchemaHandler::new("/schema");
+        let mut response = [0; 512];
+        let req = request(code::GET, &["schema"], None, b"");
+        let out = handler.handle::<Settings>(&req, &mut response);
+        let response = out.response().unwrap();
+        assert_eq!(response.code, code::CONTENT);
+        assert_eq!(response.content_format, Some(JSON_CONTENT_FORMAT));
+        assert!(response.payload.starts_with(b"{"));
+    }
+
+    #[test]
+    fn get_and_put_can_be_used_separately() {
+        init_host_logging();
+        let handler = ConstPathJsonHandler::const_path_json("/settings");
+        let mut settings = Settings::default();
+        let mut response = [0; 128];
+
+        let req = request(code::GET, &["settings", "number"], None, b"");
+        let outcome = handler.handle_get(&req, &settings, &mut response);
+        let response = outcome.response().unwrap();
+        assert_eq!(response.payload, b"7");
+
+        let mut response = [0; 128];
+        let req = request(
+            code::PUT,
+            &["settings", "number"],
+            Some(JSON_CONTENT_FORMAT),
+            b"14",
+        );
+        assert!(matches!(
+            handler.handle_put(&req, &mut settings, &mut response),
+            Outcome::Changed { .. }
+        ));
+        assert_eq!(settings.number, 14);
+    }
+
+    #[test]
+    fn repeated_accept_options_preserve_json_match() {
+        init_host_logging();
+        let request = TestMessage::new(code::GET)
+            .str_option(option::URI_PATH, "settings")
+            .str_option(option::URI_PATH, "number")
+            .uint_option(option::ACCEPT, 0)
+            .uint_option(option::ACCEPT, JSON_CONTENT_FORMAT);
+        let request = RequestParts::from_message(&request).unwrap();
+        let handler = ConstPathJsonHandler::const_path_json("/settings");
+        let settings = Settings::default();
+        let mut response = [0; 128];
+
+        let outcome = handler.handle_get(&request, &settings, &mut response);
+        let response = outcome.response().unwrap();
+        assert_eq!(response.code, code::CONTENT);
+        assert_eq!(response.payload, b"7");
+
+        let request = TestMessage::new(code::GET)
+            .str_option(option::URI_PATH, "settings")
+            .str_option(option::URI_PATH, "number")
+            .uint_option(option::ACCEPT, 0);
+        let request = RequestParts::from_message(&request).unwrap();
+        let mut response = [0; 128];
+        let outcome = handler.handle_get(&request, &settings, &mut response);
+        let response = outcome.response().unwrap();
+        assert_eq!(response.code, code::NOT_ACCEPTABLE);
+
+        let request = TestMessage::new(code::GET)
+            .str_option(option::URI_PATH, "schema")
+            .uint_option(option::ACCEPT, 0)
+            .uint_option(option::ACCEPT, JSON_CONTENT_FORMAT);
+        let request = RequestParts::from_message(&request).unwrap();
+        let handler = SchemaHandler::new("/schema");
+        let mut response = [0; 512];
+        let outcome = handler.handle::<Settings>(&request, &mut response);
+        let response = outcome.response().unwrap();
+        assert_eq!(response.code, code::CONTENT);
+    }
+
+    #[test]
+    fn accept_overflow_is_checked_at_representation_match() {
+        init_host_logging();
+        let request = TestMessage::new(code::GET)
+            .str_option(option::URI_PATH, "settings")
+            .str_option(option::URI_PATH, "number")
+            .uint_option(option::ACCEPT, JSON_CONTENT_FORMAT)
+            .uint_option(option::ACCEPT, 0)
+            .uint_option(option::ACCEPT, 1)
+            .uint_option(option::ACCEPT, 2)
+            .uint_option(option::ACCEPT, 3);
+        let request = RequestParts::from_message(&request).unwrap();
+        let handler = ConstPathJsonHandler::const_path_json("/settings");
+        let settings = Settings::default();
+        let mut response = [0; 128];
+        let outcome = handler.handle_get(&request, &settings, &mut response);
+        assert_eq!(outcome.response().unwrap().code, code::CONTENT);
+
+        let request = TestMessage::new(code::GET)
+            .str_option(option::URI_PATH, "settings")
+            .str_option(option::URI_PATH, "number")
+            .uint_option(option::ACCEPT, 0)
+            .uint_option(option::ACCEPT, 1)
+            .uint_option(option::ACCEPT, 2)
+            .uint_option(option::ACCEPT, 3)
+            .uint_option(option::ACCEPT, 4);
+        let request = RequestParts::from_message(&request).unwrap();
+        let mut response = [0; 128];
+        let outcome = handler.handle_get(&request, &settings, &mut response);
+        let response = outcome.response().unwrap();
+        assert_eq!(response.code, code::BAD_OPTION);
+        assert_eq!(response.payload, br#"{"kind":"too_many_accept_options"}"#);
+    }
+
+    #[test]
+    fn malformed_content_format_is_bad_request() {
+        init_host_logging();
+        let request = TestMessage::new(code::PUT)
+            .str_option(option::URI_PATH, "settings")
+            .str_option(option::URI_PATH, "number")
+            .option(option::CONTENT_FORMAT, &[0, 0, 50])
+            .with_payload(b"18");
+        let err = RequestParts::from_message(&request).unwrap_err();
+        assert_eq!(err.code, code::BAD_REQUEST);
+        assert_eq!(err.problem, Problem::InvalidContentFormat);
+    }
+
+    #[test]
+    fn get_serialization_failures_are_not_bad_payload() {
+        init_host_logging();
+        let handler = ConstPathJsonHandler::const_path_json("/settings");
+        let settings = Settings::default();
+        let mut response = [0; 0];
+        let req = request(code::GET, &["settings", "number"], None, b"");
+        let outcome = handler.handle_get(&req, &settings, &mut response);
+        let response = outcome.response().unwrap();
+        assert_eq!(response.code, code::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.payload, b"");
+    }
+
+    #[test]
+    fn long_problem_message_preserves_json_body() {
+        let err = Error::new(
+            code::UNPROCESSABLE_ENTITY,
+            Problem::Access {
+                op: Operation::Write,
+                message: "this access policy explanation is intentionally too long for the response buffer",
+            },
+        );
+        let mut response = [0; 64];
+        let response = err.response(&mut response);
+        assert_eq!(response.content_format, Some(JSON_CONTENT_FORMAT));
+        assert!(
+            response
+                .payload
+                .starts_with(br#"{"kind":"access","op":"write","message":""#)
+        );
+        assert!(response.payload.ends_with(b"\"}"));
+    }
+
+    #[test]
+    fn coap_message_roundtrip_and_user_route_composition() {
+        init_host_logging();
+        let request = TestMessage::new(code::PUT)
+            .str_option(option::URI_PATH, "settings")
+            .str_option(option::URI_PATH, "number")
+            .uint_option(option::CONTENT_FORMAT, JSON_CONTENT_FORMAT)
+            .with_payload(b"18");
+        let request = RequestParts::from_message(&request).unwrap();
+        let mut settings = Settings::default();
+        let mut response_buf = [0; 128];
+        let outcome = route(&request, &mut settings, &mut response_buf);
+        assert!(matches!(outcome, Outcome::Changed { .. }));
+        let mut response = TestMessage::default();
+        outcome.response().unwrap().write_to(&mut response).unwrap();
+        assert_eq!(response.code(), code::CHANGED);
+        assert_eq!(settings.number, 18);
+
+        let request = TestMessage::new(code::GET)
+            .str_option(option::URI_PATH, "status")
+            .uint_option(option::ACCEPT, JSON_CONTENT_FORMAT);
+        let request = RequestParts::from_message(&request).unwrap();
+        let mut response_buf = [0; 128];
+        let outcome = route(&request, &mut settings, &mut response_buf);
+        let mut response = TestMessage::default();
+        outcome.response().unwrap().write_to(&mut response).unwrap();
+        assert_eq!(response.code(), code::CONTENT);
+        assert_eq!(ReadableMessage::payload(&response), br#"{"ok":true}"#);
+        let content_format = response
+            .options()
+            .find(|opt| opt.number() == option::CONTENT_FORMAT)
+            .and_then(|opt| opt.value_uint::<u16>());
+        assert_eq!(content_format, Some(JSON_CONTENT_FORMAT));
+    }
+
+    #[cfg(feature = "postcard")]
+    #[test]
+    fn packed_postcard_get_and_put_leaf() {
+        init_host_logging();
+        const POSTCARD_CONTENT_FORMAT: u16 = 42;
+
+        let number_key = Settings::SCHEMA
+            .nodes::<Packed, MAX_DEPTH>()
+            .nth(1)
+            .unwrap()
+            .unwrap()
+            .into_lsb()
+            .get();
+        let mut path = heapless::String::<16>::new();
+        write!(&mut path, "{}", number_key).unwrap();
+        let handler = PackedPostcardHandler::packed_postcard("/settings", POSTCARD_CONTENT_FORMAT);
+        let mut settings = Settings::default();
+        let mut response = [0; 128];
+
+        let req = request(code::GET, &["settings", path.as_str()], None, b"");
+        let out = handler.handle_get(&req, &settings, &mut response);
+        let response = out.response().unwrap();
+        assert_eq!(response.code, code::CONTENT);
+        assert_eq!(response.content_format, Some(POSTCARD_CONTENT_FORMAT));
+        assert_eq!(response.payload, &[7]);
+
+        let mut response = [0; 128];
+        let req = request(
+            code::PUT,
+            &["settings", path.as_str()],
+            Some(POSTCARD_CONTENT_FORMAT),
+            &[21],
+        );
+        let out = handler.handle_put(&req, &mut settings, &mut response);
+        assert!(matches!(out, Outcome::Changed { .. }));
+        assert_eq!(settings.number, 21);
+    }
+}

--- a/miniconf_coap/src/message.rs
+++ b/miniconf_coap/src/message.rs
@@ -2,6 +2,8 @@ use core::{convert::Infallible, fmt};
 #[cfg(feature = "json-core")]
 use fmt::Write as _;
 
+#[cfg(any(feature = "json-core", feature = "cbor"))]
+use coap_message::MutableWritableMessage;
 use coap_message::{
     Code as _, MessageOption, MinimalWritableMessage, OptionNumber as _, ReadableMessage,
     error::RenderableOnMinimal,
@@ -451,6 +453,17 @@ impl Error {
         }
     }
 
+    #[cfg(feature = "json-core")]
+    pub(crate) fn write_json_response_to<M: MutableWritableMessage>(
+        self,
+        message: &mut M,
+        max_len: usize,
+    ) -> Result<(), M::UnionError> {
+        self.write_problem_to(message, format::JSON, max_len, |error, buf| {
+            problem_json(error.problem, buf).ok()
+        })
+    }
+
     #[cfg(feature = "cbor")]
     pub(crate) fn cbor_response<'a>(self, buf: &'a mut [u8]) -> Response<'a> {
         match problem_cbor(self, buf) {
@@ -465,6 +478,47 @@ impl Error {
                 payload: b"",
             },
         }
+    }
+
+    #[cfg(feature = "cbor")]
+    pub(crate) fn write_cbor_response_to<M: MutableWritableMessage>(
+        self,
+        message: &mut M,
+        max_len: usize,
+    ) -> Result<(), M::UnionError> {
+        self.write_problem_to(
+            message,
+            format::CONCISE_PROBLEM_CBOR,
+            max_len,
+            |error, buf| problem_cbor(error, buf).ok(),
+        )
+    }
+
+    #[cfg(any(feature = "json-core", feature = "cbor"))]
+    fn write_problem_to<M, F>(
+        self,
+        message: &mut M,
+        content_format: u16,
+        max_len: usize,
+        encode: F,
+    ) -> Result<(), M::UnionError>
+    where
+        M: MutableWritableMessage,
+        F: FnOnce(Self, &mut [u8]) -> Option<usize>,
+    {
+        message.set_code(M::Code::new(self.code).map_err(M::convert_code_error)?);
+        message
+            .add_option_uint(
+                M::OptionNumber::new(option::CONTENT_FORMAT)
+                    .map_err(M::convert_option_number_error)?,
+                content_format,
+            )
+            .map_err(M::convert_add_option_error)?;
+        let payload = message
+            .payload_mut_with_len(max_len)
+            .map_err(M::convert_set_payload_error)?;
+        let len = encode(self, payload).unwrap_or(0);
+        message.truncate(len).map_err(M::convert_set_payload_error)
     }
 }
 

--- a/miniconf_coap/src/message.rs
+++ b/miniconf_coap/src/message.rs
@@ -6,8 +6,6 @@ use coap_message::{
     Code as _, MessageOption, MinimalWritableMessage, OptionNumber as _, ReadableMessage,
     error::RenderableOnMinimal,
 };
-#[cfg(any(feature = "json-core", feature = "cbor"))]
-use coap_numbers::content_format;
 use coap_numbers::{code, option};
 #[cfg(feature = "cbor")]
 use minicbor::{
@@ -16,6 +14,8 @@ use minicbor::{
     encode::{self, write::EndOfSlice},
 };
 
+#[cfg(any(feature = "json-core", feature = "cbor"))]
+use crate::format;
 use crate::{ChangedKey, MAX_URI_PATH_LENGTH};
 
 const MAX_ACCEPT_OPTIONS: usize = 4;
@@ -430,7 +430,7 @@ impl Error {
             match problem_json(self.problem, buf) {
                 Ok(len) => Response {
                     code: self.code,
-                    content_format: Some(content_format::from_str("application/json").unwrap()),
+                    content_format: Some(format::JSON),
                     payload: &buf[..len],
                 },
                 Err(_) => Response {
@@ -456,9 +456,7 @@ impl Error {
         match problem_cbor(self, buf) {
             Ok(len) => Response {
                 code: self.code,
-                content_format: Some(
-                    content_format::from_str("application/concise-problem-details+cbor").unwrap(),
-                ),
+                content_format: Some(format::CONCISE_PROBLEM_CBOR),
                 payload: &buf[..len],
             },
             Err(_) => Response {

--- a/miniconf_coap/src/message.rs
+++ b/miniconf_coap/src/message.rs
@@ -1,10 +1,13 @@
-use core::convert::Infallible;
+use core::{convert::Infallible, fmt};
 #[cfg(feature = "json-core")]
-use core::fmt::Write as _;
+use fmt::Write as _;
 
 use coap_message::{
     Code as _, MessageOption, MinimalWritableMessage, OptionNumber as _, ReadableMessage,
+    error::RenderableOnMinimal,
 };
+#[cfg(any(feature = "json-core", feature = "cbor"))]
+use coap_numbers::content_format;
 use coap_numbers::{code, option};
 #[cfg(feature = "cbor")]
 use minicbor::{
@@ -13,8 +16,6 @@ use minicbor::{
     encode::{self, write::EndOfSlice},
 };
 
-#[cfg(any(feature = "json-core", feature = "cbor"))]
-use crate::content_format;
 use crate::{ChangedKey, MAX_URI_PATH_LENGTH};
 
 const MAX_ACCEPT_OPTIONS: usize = 4;
@@ -154,8 +155,7 @@ impl<'a> RequestParts<'a> {
                 }
                 option::URI_HOST | option::URI_PORT => {}
                 number
-                    if coap_numbers::option::get_criticality(number)
-                        == coap_numbers::option::Criticality::Critical
+                    if option::get_criticality(number) == option::Criticality::Critical
                         && request.invalid_option.is_none() =>
                 {
                     request.invalid_option = Some(InvalidOption::UnknownCritical(number));
@@ -430,7 +430,7 @@ impl Error {
             match problem_json(self.problem, buf) {
                 Ok(len) => Response {
                     code: self.code,
-                    content_format: Some(content_format("application/json")),
+                    content_format: Some(content_format::from_str("application/json").unwrap()),
                     payload: &buf[..len],
                 },
                 Err(_) => Response {
@@ -456,7 +456,9 @@ impl Error {
         match problem_cbor(self, buf) {
             Ok(len) => Response {
                 code: self.code,
-                content_format: Some(content_format("application/concise-problem-details+cbor")),
+                content_format: Some(
+                    content_format::from_str("application/concise-problem-details+cbor").unwrap(),
+                ),
                 payload: &buf[..len],
             },
             Err(_) => Response {
@@ -469,7 +471,7 @@ impl Error {
 }
 
 #[cfg(feature = "json-core")]
-fn problem_json(problem: Problem, buf: &mut [u8]) -> Result<usize, core::fmt::Error> {
+fn problem_json(problem: Problem, buf: &mut [u8]) -> Result<usize, fmt::Error> {
     let mut out = SliceWriter::new(buf);
     match problem {
         Problem::InvalidUriPath
@@ -614,17 +616,17 @@ impl<'a> SliceWriter<'a> {
         self.buf.len() - self.len
     }
 
-    fn push(&mut self, value: char) -> core::fmt::Result {
+    fn push(&mut self, value: char) -> fmt::Result {
         self.write_char(value)
     }
 }
 
 #[cfg(feature = "json-core")]
-impl core::fmt::Write for SliceWriter<'_> {
-    fn write_str(&mut self, value: &str) -> core::fmt::Result {
+impl fmt::Write for SliceWriter<'_> {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
         let bytes = value.as_bytes();
         let Some(dst) = self.buf.get_mut(self.len..self.len + bytes.len()) else {
-            return Err(core::fmt::Error);
+            return Err(fmt::Error);
         };
         dst.copy_from_slice(bytes);
         self.len += bytes.len();
@@ -633,12 +635,12 @@ impl core::fmt::Write for SliceWriter<'_> {
 }
 
 #[cfg(feature = "json-core")]
-fn write_kind(out: &mut impl core::fmt::Write, kind: &str) -> core::fmt::Result {
+fn write_kind(out: &mut impl fmt::Write, kind: &str) -> fmt::Result {
     write!(out, "{{\"kind\":\"{}\"}}", kind)
 }
 
 #[cfg(feature = "json-core")]
-fn write_depth(out: &mut impl core::fmt::Write, kind: &str, depth: usize) -> core::fmt::Result {
+fn write_depth(out: &mut impl fmt::Write, kind: &str, depth: usize) -> fmt::Result {
     write!(out, "{{\"kind\":\"{}\",\"depth\":{}}}", kind, depth)
 }
 
@@ -647,7 +649,7 @@ fn write_json_string_truncated(
     out: &mut SliceWriter<'_>,
     value: &str,
     reserve: usize,
-) -> core::fmt::Result {
+) -> fmt::Result {
     out.push('"')?;
     for byte in value.bytes() {
         let escaped = match byte {
@@ -685,8 +687,8 @@ fn write_json_string_truncated(
     out.push('"')
 }
 
-impl coap_message::error::RenderableOnMinimal for Error {
-    type Error<IE: coap_message::error::RenderableOnMinimal + core::fmt::Debug> = IE;
+impl RenderableOnMinimal for Error {
+    type Error<IE: RenderableOnMinimal + fmt::Debug> = IE;
 
     fn render<M: MinimalWritableMessage>(
         self,

--- a/miniconf_coap/src/message.rs
+++ b/miniconf_coap/src/message.rs
@@ -1,0 +1,704 @@
+use core::convert::Infallible;
+#[cfg(feature = "json-core")]
+use core::fmt::Write as _;
+
+use coap_message::{
+    Code as _, MessageOption, MinimalWritableMessage, OptionNumber as _, ReadableMessage,
+};
+use coap_numbers::{code, option};
+#[cfg(feature = "cbor")]
+use minicbor::{
+    Encoder as CborEncoder,
+    data::Int as CborInt,
+    encode::{self, write::EndOfSlice},
+};
+
+#[cfg(any(feature = "json-core", feature = "cbor"))]
+use crate::content_format;
+use crate::{ChangedKey, MAX_URI_PATH_LENGTH};
+
+const MAX_ACCEPT_OPTIONS: usize = 4;
+
+pub(crate) type UriPath = heapless::String<MAX_URI_PATH_LENGTH>;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct Accepts {
+    values: [u16; MAX_ACCEPT_OPTIONS],
+    len: usize,
+    overflow: bool,
+}
+
+impl Accepts {
+    const fn new() -> Self {
+        Self {
+            values: [0; MAX_ACCEPT_OPTIONS],
+            len: 0,
+            overflow: false,
+        }
+    }
+
+    fn from_option(value: Option<u16>) -> Self {
+        let mut accepts = Self::new();
+        if let Some(value) = value {
+            accepts.values[0] = value;
+            accepts.len = 1;
+        }
+        accepts
+    }
+
+    fn push(&mut self, value: u16) {
+        if let Some(slot) = self.values.get_mut(self.len) {
+            *slot = value;
+            self.len += 1;
+        } else {
+            self.overflow = true;
+        }
+    }
+
+    const fn is_present(&self) -> bool {
+        self.len != 0
+    }
+
+    fn first(&self) -> Option<u16> {
+        self.values.first().copied().filter(|_| self.len != 0)
+    }
+
+    fn contains(&self, content_format: u16) -> bool {
+        self.values[..self.len].contains(&content_format)
+    }
+
+    fn accepts(&self, content_format: u16) -> Result<(), Error> {
+        if !self.is_present() || self.contains(content_format) {
+            Ok(())
+        } else if self.overflow {
+            Err(Error::new(code::BAD_OPTION, Problem::TooManyAcceptOptions))
+        } else {
+            Err(Error::new(code::NOT_ACCEPTABLE, Problem::NotAcceptable))
+        }
+    }
+}
+
+/// Parsed CoAP request data used by cooperative handlers.
+#[derive(Debug)]
+pub struct RequestParts<'a> {
+    pub(crate) code: u8,
+    pub(crate) path: UriPath,
+    pub(crate) accepts: Accepts,
+    pub(crate) content_format: Option<u16>,
+    pub(crate) invalid_option: Option<InvalidOption>,
+    pub(crate) payload: &'a [u8],
+}
+
+impl<'a> RequestParts<'a> {
+    /// Build request parts from already-decoded fields.
+    pub fn new(
+        code: u8,
+        path: &[&str],
+        accept: Option<u16>,
+        content_format: Option<u16>,
+        payload: &'a [u8],
+    ) -> Result<Self, Error> {
+        let mut request = Self {
+            code,
+            path: UriPath::new(),
+            accepts: Accepts::from_option(accept),
+            content_format,
+            invalid_option: None,
+            payload,
+        };
+        for segment in path {
+            request.push_path_segment(segment)?;
+        }
+        Ok(request)
+    }
+
+    /// Extract method, URI path, content negotiation options, and payload from a readable message.
+    pub fn from_message<M>(message: &'a M) -> Result<Self, Error>
+    where
+        M: ReadableMessage + ?Sized,
+    {
+        let mut request = Self {
+            code: message.code().into(),
+            path: UriPath::new(),
+            accepts: Accepts::new(),
+            content_format: None,
+            invalid_option: None,
+            payload: message.payload(),
+        };
+
+        for opt in message.options() {
+            match opt.number() {
+                option::URI_PATH => {
+                    let Some(segment) = opt.value_str() else {
+                        return Err(Error::bad_request(Problem::InvalidUriPath));
+                    };
+                    request.push_path_segment(segment)?;
+                }
+                option::ACCEPT => {
+                    let Some(accept) = opt.value_uint() else {
+                        return Err(Error::bad_request(Problem::InvalidAccept));
+                    };
+                    request.accepts.push(accept);
+                }
+                option::CONTENT_FORMAT => {
+                    let Some(content_format) = opt.value_uint() else {
+                        return Err(Error::bad_request(Problem::InvalidContentFormat));
+                    };
+                    if request.content_format.is_some() {
+                        if request.invalid_option.is_none() {
+                            request.invalid_option = Some(InvalidOption::DuplicateContentFormat);
+                        }
+                        continue;
+                    }
+                    request.content_format = Some(content_format);
+                }
+                option::URI_HOST | option::URI_PORT => {}
+                number
+                    if coap_numbers::option::get_criticality(number)
+                        == coap_numbers::option::Criticality::Critical
+                        && request.invalid_option.is_none() =>
+                {
+                    request.invalid_option = Some(InvalidOption::UnknownCritical(number));
+                }
+                _ => {}
+            }
+        }
+
+        Ok(request)
+    }
+
+    /// Request method code.
+    pub const fn code(&self) -> u8 {
+        self.code
+    }
+
+    /// URI path segments.
+    pub fn path(&self) -> &str {
+        self.path.as_str()
+    }
+
+    /// Request payload.
+    pub const fn payload(&self) -> &'a [u8] {
+        self.payload
+    }
+
+    pub(crate) fn accepts(&self, content_format: u16) -> Result<(), Error> {
+        self.accepts.accepts(content_format)
+    }
+
+    pub(crate) fn check_options(&self) -> Result<(), Error> {
+        match self.invalid_option {
+            Some(InvalidOption::DuplicateContentFormat) => {
+                Err(Error::bad_request(Problem::DuplicateContentFormat))
+            }
+            Some(InvalidOption::UnknownCritical(number)) => Err(Error::new(
+                code::BAD_OPTION,
+                Problem::UnknownCriticalOption { number },
+            )),
+            None => Ok(()),
+        }
+    }
+
+    fn push_path_segment(&mut self, segment: &str) -> Result<(), Error> {
+        if segment.contains('/') {
+            return Err(Error::bad_request(Problem::InvalidUriPath));
+        }
+        self.path
+            .push('/')
+            .map_err(|_| Error::request_entity_too_large(Problem::UriPathTooLong))?;
+        self.path
+            .push_str(segment)
+            .map_err(|_| Error::request_entity_too_large(Problem::UriPathTooLong))
+    }
+
+    pub(crate) fn relative_to(&self, base: &str) -> Option<&str> {
+        if base.is_empty() {
+            return Some(self.path.as_str());
+        }
+        if self.path.as_str() == base {
+            return Some("");
+        }
+        let tail = self.path.as_str().strip_prefix(base)?;
+        tail.starts_with('/').then_some(tail)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum InvalidOption {
+    DuplicateContentFormat,
+    UnknownCritical(u16),
+}
+
+impl defmt::Format for RequestParts<'_> {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        defmt::write!(
+            fmt,
+            "RequestParts {{ code: {=u8}, path: {=str}, accept_present: {=bool}, accept: {=u16}, content_format_present: {=bool}, content_format: {=u16}, payload_len: {=usize} }}",
+            self.code,
+            self.path.as_str(),
+            self.accepts.is_present(),
+            self.accepts.first().unwrap_or(0),
+            self.content_format.is_some(),
+            self.content_format.unwrap_or(0),
+            self.payload.len()
+        )
+    }
+}
+
+/// CoAP response data produced by cooperative handlers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Response<'a> {
+    /// CoAP response code.
+    pub code: u8,
+    /// Optional CoAP Content-Format value.
+    pub content_format: Option<u16>,
+    /// Response payload.
+    pub payload: &'a [u8],
+}
+
+impl Response<'_> {
+    /// Render this response into a writable CoAP message.
+    pub fn write_to<M: MinimalWritableMessage>(
+        &self,
+        message: &mut M,
+    ) -> Result<(), M::UnionError> {
+        message.set_code(M::Code::new(self.code).map_err(M::convert_code_error)?);
+        if let Some(content_format) = self.content_format {
+            message
+                .add_option_uint(
+                    M::OptionNumber::new(option::CONTENT_FORMAT)
+                        .map_err(M::convert_option_number_error)?,
+                    content_format,
+                )
+                .map_err(M::convert_add_option_error)?;
+        }
+        message
+            .set_payload(self.payload)
+            .map_err(M::convert_set_payload_error)
+    }
+}
+
+impl defmt::Format for Response<'_> {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        defmt::write!(
+            fmt,
+            "Response {{ code: {=u8}, content_format_present: {=bool}, content_format: {=u16}, payload_len: {=usize} }}",
+            self.code,
+            self.content_format.is_some(),
+            self.content_format.unwrap_or(0),
+            self.payload.len()
+        )
+    }
+}
+
+/// Handler outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome<'a> {
+    /// Request path is outside this handler's route.
+    Unhandled,
+    /// Request was handled without changing settings.
+    Handled(Response<'a>),
+    /// Request changed one exact leaf.
+    Changed {
+        /// Changed Miniconf leaf key.
+        key: ChangedKey,
+        /// CoAP response to send.
+        response: Response<'a>,
+    },
+}
+
+impl Outcome<'_> {
+    /// Return the response, if any.
+    pub const fn response(&self) -> Option<Response<'_>> {
+        match self {
+            Self::Unhandled => None,
+            Self::Handled(response) | Self::Changed { response, .. } => Some(*response),
+        }
+    }
+}
+
+impl defmt::Format for Outcome<'_> {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        match self {
+            Self::Unhandled => defmt::write!(fmt, "Outcome::Unhandled"),
+            Self::Handled(response) => defmt::write!(fmt, "Outcome::Handled({})", response),
+            Self::Changed { key, response } => defmt::write!(
+                fmt,
+                "Outcome::Changed {{ key: {}, response: {} }}",
+                key,
+                response
+            ),
+        }
+    }
+}
+
+/// Problem details preserved in error responses.
+#[derive(defmt::Format, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Problem {
+    /// URI path option was not valid UTF-8.
+    InvalidUriPath,
+    /// Accept option could not be decoded as a CoAP uint.
+    InvalidAccept,
+    /// Content-Format option could not be decoded as a CoAP uint.
+    InvalidContentFormat,
+    /// More than one Content-Format option was present.
+    DuplicateContentFormat,
+    /// An unknown critical CoAP option was present.
+    UnknownCriticalOption {
+        /// CoAP option number.
+        number: u16,
+    },
+    /// URI path had more segments than this handler captured.
+    UriPathTooLong,
+    /// A response payload exceeded the optional handler adapter buffer.
+    PayloadTooLong,
+    /// Request had more Accept options than this handler captures.
+    TooManyAcceptOptions,
+    /// Request path names no static Miniconf resource.
+    NotFound {
+        /// Depth reached before lookup failed.
+        depth: usize,
+    },
+    /// Request path continues below a leaf.
+    TooLong {
+        /// Depth of the leaf under which the request continued.
+        depth: usize,
+    },
+    /// Request path names a known branch, but this route handles leaves only.
+    NonLeaf {
+        /// Depth of the branch resource.
+        depth: usize,
+    },
+    /// Static schema contains the leaf, but runtime state makes it absent.
+    Absent {
+        /// Depth of the runtime-absent leaf.
+        depth: usize,
+    },
+    /// Runtime access policy denied the operation.
+    Access {
+        /// Operation being performed.
+        op: Operation,
+        /// Error text from Miniconf.
+        message: &'static str,
+    },
+    /// Request method is not supported here.
+    MethodNotAllowed,
+    /// Request `Accept` option does not allow this route's representation.
+    NotAcceptable,
+    /// Request payload Content-Format is not supported here.
+    UnsupportedContentFormat,
+    /// Payload could not be decoded.
+    BadPayload,
+    /// A read-side value serialization failed.
+    Serialization,
+}
+
+/// CoAP operation being performed.
+#[derive(defmt::Format, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operation {
+    /// Read operation.
+    Read,
+    /// Write operation.
+    Write,
+}
+
+/// CoAP handler error.
+#[derive(defmt::Format, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Error {
+    /// CoAP response code.
+    pub code: u8,
+    /// Machine-readable problem.
+    pub problem: Problem,
+}
+
+impl Error {
+    pub(crate) const fn new(code: u8, problem: Problem) -> Self {
+        Self { code, problem }
+    }
+
+    pub(crate) const fn bad_request(problem: Problem) -> Self {
+        Self::new(code::BAD_REQUEST, problem)
+    }
+
+    pub(crate) const fn request_entity_too_large(problem: Problem) -> Self {
+        Self::new(code::REQUEST_ENTITY_TOO_LARGE, problem)
+    }
+
+    pub(crate) fn response<'a>(self, buf: &'a mut [u8]) -> Response<'a> {
+        #[cfg(feature = "json-core")]
+        {
+            match problem_json(self.problem, buf) {
+                Ok(len) => Response {
+                    code: self.code,
+                    content_format: Some(content_format("application/json")),
+                    payload: &buf[..len],
+                },
+                Err(_) => Response {
+                    code: self.code,
+                    content_format: None,
+                    payload: b"",
+                },
+            }
+        }
+        #[cfg(not(feature = "json-core"))]
+        {
+            let _ = buf;
+            Response {
+                code: self.code,
+                content_format: None,
+                payload: b"",
+            }
+        }
+    }
+
+    #[cfg(feature = "cbor")]
+    pub(crate) fn cbor_response<'a>(self, buf: &'a mut [u8]) -> Response<'a> {
+        match problem_cbor(self, buf) {
+            Ok(len) => Response {
+                code: self.code,
+                content_format: Some(content_format("application/concise-problem-details+cbor")),
+                payload: &buf[..len],
+            },
+            Err(_) => Response {
+                code: self.code,
+                content_format: None,
+                payload: b"",
+            },
+        }
+    }
+}
+
+#[cfg(feature = "json-core")]
+fn problem_json(problem: Problem, buf: &mut [u8]) -> Result<usize, core::fmt::Error> {
+    let mut out = SliceWriter::new(buf);
+    match problem {
+        Problem::InvalidUriPath
+        | Problem::InvalidAccept
+        | Problem::InvalidContentFormat
+        | Problem::DuplicateContentFormat
+        | Problem::UriPathTooLong
+        | Problem::PayloadTooLong
+        | Problem::TooManyAcceptOptions
+        | Problem::MethodNotAllowed
+        | Problem::NotAcceptable
+        | Problem::UnsupportedContentFormat
+        | Problem::BadPayload
+        | Problem::Serialization => write_kind(&mut out, problem_kind(problem))?,
+        Problem::UnknownCriticalOption { number } => {
+            write!(
+                out,
+                "{{\"kind\":\"unknown_critical_option\",\"number\":{number}}}"
+            )?;
+        }
+        Problem::NotFound { depth } => write_depth(&mut out, "not_found", depth)?,
+        Problem::TooLong { depth } => write_depth(&mut out, "too_long", depth)?,
+        Problem::NonLeaf { depth } => write_depth(&mut out, "non_leaf", depth)?,
+        Problem::Absent { depth } => write_depth(&mut out, "absent", depth)?,
+        Problem::Access { op, message } => {
+            write!(
+                out,
+                "{{\"kind\":\"access\",\"op\":\"{}\",\"message\":",
+                operation_name(op)
+            )?;
+            write_json_string_truncated(&mut out, message, 1)?;
+            out.push('}')?;
+        }
+    }
+    Ok(out.len())
+}
+
+#[cfg(feature = "cbor")]
+fn problem_cbor(error: Error, buf: &mut [u8]) -> Result<usize, encode::Error<EndOfSlice>> {
+    const MINICONF_PROBLEM_KEY: &str = "tag:quartiq.de,2026:miniconf";
+
+    let mut cursor = encode::write::Cursor::new(buf);
+    {
+        let kind = problem_kind(error.problem);
+        let mut encoder = CborEncoder::new(&mut cursor);
+        encoder
+            .map(3)?
+            .int(CborInt::from(-1i8))?
+            .str(kind)?
+            .int(CborInt::from(-4i8))?
+            .u8(error.code)?
+            .str(MINICONF_PROBLEM_KEY)?
+            .map(problem_detail_len(error.problem))?
+            .str("kind")?
+            .str(kind)?;
+
+        match error.problem {
+            Problem::UnknownCriticalOption { number } => {
+                encoder.str("number")?.u16(number)?;
+            }
+            Problem::NotFound { depth }
+            | Problem::TooLong { depth }
+            | Problem::NonLeaf { depth }
+            | Problem::Absent { depth } => {
+                encoder.str("depth")?.u64(depth as u64)?;
+            }
+            Problem::Access { op, message } => {
+                encoder
+                    .str("op")?
+                    .str(operation_name(op))?
+                    .str("message")?
+                    .str(message)?;
+            }
+            _ => {}
+        }
+    }
+    Ok(cursor.position())
+}
+
+#[cfg(feature = "cbor")]
+const fn problem_detail_len(problem: Problem) -> u64 {
+    match problem {
+        Problem::UnknownCriticalOption { .. }
+        | Problem::NotFound { .. }
+        | Problem::TooLong { .. }
+        | Problem::NonLeaf { .. }
+        | Problem::Absent { .. } => 2,
+        Problem::Access { .. } => 3,
+        _ => 1,
+    }
+}
+
+#[cfg(any(feature = "json-core", feature = "cbor"))]
+const fn problem_kind(problem: Problem) -> &'static str {
+    match problem {
+        Problem::InvalidUriPath => "invalid_uri_path",
+        Problem::InvalidAccept => "invalid_accept",
+        Problem::InvalidContentFormat => "invalid_content_format",
+        Problem::DuplicateContentFormat => "duplicate_content_format",
+        Problem::UnknownCriticalOption { .. } => "unknown_critical_option",
+        Problem::UriPathTooLong => "uri_path_too_long",
+        Problem::PayloadTooLong => "payload_too_long",
+        Problem::TooManyAcceptOptions => "too_many_accept_options",
+        Problem::NotFound { .. } => "not_found",
+        Problem::TooLong { .. } => "too_long",
+        Problem::NonLeaf { .. } => "non_leaf",
+        Problem::Absent { .. } => "absent",
+        Problem::Access { .. } => "access",
+        Problem::MethodNotAllowed => "method_not_allowed",
+        Problem::NotAcceptable => "not_acceptable",
+        Problem::UnsupportedContentFormat => "unsupported_content_format",
+        Problem::BadPayload => "bad_payload",
+        Problem::Serialization => "serialization",
+    }
+}
+
+#[cfg(any(feature = "json-core", feature = "cbor"))]
+const fn operation_name(op: Operation) -> &'static str {
+    match op {
+        Operation::Read => "read",
+        Operation::Write => "write",
+    }
+}
+
+#[cfg(feature = "json-core")]
+struct SliceWriter<'a> {
+    buf: &'a mut [u8],
+    len: usize,
+}
+
+#[cfg(feature = "json-core")]
+impl<'a> SliceWriter<'a> {
+    fn new(buf: &'a mut [u8]) -> Self {
+        Self { buf, len: 0 }
+    }
+
+    const fn len(&self) -> usize {
+        self.len
+    }
+
+    fn remaining(&self) -> usize {
+        self.buf.len() - self.len
+    }
+
+    fn push(&mut self, value: char) -> core::fmt::Result {
+        self.write_char(value)
+    }
+}
+
+#[cfg(feature = "json-core")]
+impl core::fmt::Write for SliceWriter<'_> {
+    fn write_str(&mut self, value: &str) -> core::fmt::Result {
+        let bytes = value.as_bytes();
+        let Some(dst) = self.buf.get_mut(self.len..self.len + bytes.len()) else {
+            return Err(core::fmt::Error);
+        };
+        dst.copy_from_slice(bytes);
+        self.len += bytes.len();
+        Ok(())
+    }
+}
+
+#[cfg(feature = "json-core")]
+fn write_kind(out: &mut impl core::fmt::Write, kind: &str) -> core::fmt::Result {
+    write!(out, "{{\"kind\":\"{}\"}}", kind)
+}
+
+#[cfg(feature = "json-core")]
+fn write_depth(out: &mut impl core::fmt::Write, kind: &str, depth: usize) -> core::fmt::Result {
+    write!(out, "{{\"kind\":\"{}\",\"depth\":{}}}", kind, depth)
+}
+
+#[cfg(feature = "json-core")]
+fn write_json_string_truncated(
+    out: &mut SliceWriter<'_>,
+    value: &str,
+    reserve: usize,
+) -> core::fmt::Result {
+    out.push('"')?;
+    for byte in value.bytes() {
+        let escaped = match byte {
+            b'"' => "\\\"",
+            b'\\' => "\\\\",
+            0x08 => "\\b",
+            0x0c => "\\f",
+            b'\n' => "\\n",
+            b'\r' => "\\r",
+            b'\t' => "\\t",
+            _ => "",
+        };
+        if !escaped.is_empty() {
+            if out.remaining() <= reserve + 1 || escaped.len() > out.remaining() - reserve - 1 {
+                break;
+            }
+            out.write_str(escaped)?;
+            continue;
+        }
+        match byte {
+            0x00..=0x1f => {
+                if out.remaining() <= reserve + 1 || 6 > out.remaining() - reserve - 1 {
+                    break;
+                }
+                write!(out, "\\u{:04x}", byte)?;
+            }
+            _ => {
+                if out.remaining() <= reserve + 1 {
+                    break;
+                }
+                out.push(char::from(byte))?;
+            }
+        }
+    }
+    out.push('"')
+}
+
+impl coap_message::error::RenderableOnMinimal for Error {
+    type Error<IE: coap_message::error::RenderableOnMinimal + core::fmt::Debug> = IE;
+
+    fn render<M: MinimalWritableMessage>(
+        self,
+        message: &mut M,
+    ) -> Result<(), Self::Error<M::UnionError>> {
+        let mut buf = [0; 96];
+        self.response(&mut buf).write_to(message)
+    }
+}
+
+impl From<Infallible> for Error {
+    fn from(value: Infallible) -> Self {
+        match value {}
+    }
+}

--- a/miniconf_coap/src/schema.rs
+++ b/miniconf_coap/src/schema.rs
@@ -1,11 +1,11 @@
-use coap_numbers::code;
+use coap_numbers::{code, content_format};
 use defmt::{debug, trace, warn};
 use miniconf::{
     TreeSchema,
     compact_schema::{SchemaDefs, serialize_schema_page},
 };
 
-use crate::{Error, MAX_SCHEMA_DEFS, Outcome, Problem, RequestParts, Response, content_format};
+use crate::{Error, MAX_SCHEMA_DEFS, Outcome, Problem, RequestParts, Response};
 
 /// Schema route backed by `TreeSchema`.
 #[derive(defmt::Format, Debug, Clone, Copy)]
@@ -44,7 +44,9 @@ impl<'a> SchemaHandler<'a> {
                     .response(response_buf),
             );
         }
-        if let Err(err) = request.accepts(content_format("text/plain; charset=utf-8")) {
+        if let Err(err) =
+            request.accepts(content_format::from_str("text/plain; charset=utf-8").unwrap())
+        {
             return Outcome::Handled(err.response(response_buf));
         }
         let Ok(defs) = SchemaDefs::<MAX_SCHEMA_DEFS>::new(Settings::SCHEMA) else {
@@ -81,7 +83,9 @@ impl<'a> SchemaHandler<'a> {
                 );
                 Outcome::Handled(Response {
                     code: code::CONTENT,
-                    content_format: Some(content_format("text/plain; charset=utf-8")),
+                    content_format: Some(
+                        content_format::from_str("text/plain; charset=utf-8").unwrap(),
+                    ),
                     payload: &response_buf[..page.len],
                 })
             }

--- a/miniconf_coap/src/schema.rs
+++ b/miniconf_coap/src/schema.rs
@@ -1,11 +1,11 @@
-use coap_numbers::{code, content_format};
+use coap_numbers::code;
 use defmt::{debug, trace, warn};
 use miniconf::{
     TreeSchema,
     compact_schema::{SchemaDefs, serialize_schema_page},
 };
 
-use crate::{Error, MAX_SCHEMA_DEFS, Outcome, Problem, RequestParts, Response};
+use crate::{Error, MAX_SCHEMA_DEFS, Outcome, Problem, RequestParts, Response, format};
 
 /// Schema route backed by `TreeSchema`.
 #[derive(defmt::Format, Debug, Clone, Copy)]
@@ -44,9 +44,7 @@ impl<'a> SchemaHandler<'a> {
                     .response(response_buf),
             );
         }
-        if let Err(err) =
-            request.accepts(content_format::from_str("text/plain; charset=utf-8").unwrap())
-        {
+        if let Err(err) = request.accepts(format::TEXT) {
             return Outcome::Handled(err.response(response_buf));
         }
         let Ok(defs) = SchemaDefs::<MAX_SCHEMA_DEFS>::new(Settings::SCHEMA) else {
@@ -83,9 +81,7 @@ impl<'a> SchemaHandler<'a> {
                 );
                 Outcome::Handled(Response {
                     code: code::CONTENT,
-                    content_format: Some(
-                        content_format::from_str("text/plain; charset=utf-8").unwrap(),
-                    ),
+                    content_format: Some(format::TEXT),
                     payload: &response_buf[..page.len],
                 })
             }

--- a/miniconf_coap/src/schema.rs
+++ b/miniconf_coap/src/schema.rs
@@ -4,8 +4,12 @@ use miniconf::{
     TreeSchema,
     compact_schema::{SchemaDefs, serialize_schema_page},
 };
+use serde::Serialize;
+use yafnv::Fnv;
 
 use crate::{Error, MAX_SCHEMA_DEFS, Outcome, Problem, RequestParts, Response, format};
+
+const SCHEMA_PROTO: u8 = 1;
 
 /// Schema route backed by `TreeSchema`.
 #[derive(defmt::Format, Debug, Clone, Copy)]
@@ -14,9 +18,10 @@ pub struct SchemaHandler<'a> {
 }
 
 impl<'a> SchemaHandler<'a> {
-    /// Construct a compact paged schema route.
+    /// Construct a compact schema route.
     ///
-    /// The base path and `base/0` both serve the first newline-delimited compact schema page.
+    /// The base path serves a JSON manifest. `base/{page}` serves newline-delimited compact schema
+    /// pages.
     pub const fn new(base: &'a str) -> Self {
         Self { base }
     }
@@ -30,7 +35,7 @@ impl<'a> SchemaHandler<'a> {
     where
         Settings: TreeSchema,
     {
-        let Some(page_index) = self.page_index(request.path()) else {
+        let Some(resource) = self.resource(request.path()) else {
             trace!("Ignoring non-schema CoAP route request={}", request);
             return Outcome::Unhandled;
         };
@@ -44,18 +49,73 @@ impl<'a> SchemaHandler<'a> {
                     .response(response_buf),
             );
         }
-        if let Err(err) = request.accepts(format::TEXT) {
-            return Outcome::Handled(err.response(response_buf));
-        }
         let Ok(defs) = SchemaDefs::<MAX_SCHEMA_DEFS>::new(Settings::SCHEMA) else {
             return Outcome::Handled(
                 Error::new(code::INTERNAL_SERVER_ERROR, Problem::Serialization)
                     .response(response_buf),
             );
         };
+
+        match resource {
+            SchemaResource::Manifest => self.manifest(&defs, request, response_buf),
+            SchemaResource::Page(page_index) => self.page(&defs, page_index, request, response_buf),
+        }
+    }
+
+    fn manifest<'b, const N: usize>(
+        &self,
+        defs: &SchemaDefs<N>,
+        request: &RequestParts<'_>,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b> {
+        if let Err(err) = request.accepts(format::JSON) {
+            return Outcome::Handled(err.response(response_buf));
+        }
+        match schema_manifest(defs, response_buf) {
+            Ok((manifest, len)) => {
+                debug!(
+                    "Handled Miniconf CoAP schema manifest GET path={=str} pages={=usize} rev={=u32} response_len={=usize}",
+                    request.path(),
+                    manifest.pages,
+                    manifest.schema_rev,
+                    len
+                );
+                Outcome::Handled(Response {
+                    code: code::CONTENT,
+                    content_format: Some(format::JSON),
+                    payload: &response_buf[..len],
+                })
+            }
+            Err(SchemaError::PayloadTooLong(id)) => {
+                warn!(
+                    "Failed to serialize Miniconf CoAP schema path={=str} definition={=usize}",
+                    request.path(),
+                    id
+                );
+                Outcome::Handled(
+                    Error::request_entity_too_large(Problem::PayloadTooLong).response(response_buf),
+                )
+            }
+            Err(SchemaError::Serialization) => Outcome::Handled(
+                Error::new(code::INTERNAL_SERVER_ERROR, Problem::Serialization)
+                    .response(response_buf),
+            ),
+        }
+    }
+
+    fn page<'b, const N: usize>(
+        &self,
+        defs: &SchemaDefs<N>,
+        page_index: usize,
+        request: &RequestParts<'_>,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b> {
+        if let Err(err) = request.accepts(format::TEXT) {
+            return Outcome::Handled(err.response(response_buf));
+        }
         let mut next = 0;
         for _ in 0..page_index {
-            match serialize_schema_page(&defs, next, response_buf) {
+            match serialize_schema_page(defs, next, response_buf) {
                 Ok(page) if page.count != 0 => next += page.count,
                 _ => {
                     return Outcome::Handled(
@@ -70,7 +130,7 @@ impl<'a> SchemaHandler<'a> {
                 Error::new(code::NOT_FOUND, Problem::NotFound { depth: 1 }).response(response_buf),
             );
         }
-        match serialize_schema_page(&defs, next, response_buf) {
+        match serialize_schema_page(defs, next, response_buf) {
             Ok(page) => {
                 debug!(
                     "Handled Miniconf CoAP schema GET path={=str} page={=usize} defs={=usize} response_len={=usize}",
@@ -98,17 +158,62 @@ impl<'a> SchemaHandler<'a> {
         }
     }
 
-    fn page_index(&self, path: &str) -> Option<usize> {
+    fn resource(&self, path: &str) -> Option<SchemaResource> {
         if path == self.base {
-            return Some(0);
+            return Some(SchemaResource::Manifest);
         }
         let suffix = if self.base.is_empty() {
             path.strip_prefix('/')?
         } else {
             path.strip_prefix(self.base)?.strip_prefix('/')?
         };
-        (!suffix.is_empty() && !suffix.contains('/')).then(|| parse_usize(suffix))?
+        (!suffix.is_empty() && !suffix.contains('/'))
+            .then(|| parse_usize(suffix).map(SchemaResource::Page))?
     }
+}
+
+enum SchemaResource {
+    Manifest,
+    Page(usize),
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+struct SchemaManifest {
+    proto: u8,
+    epoch: u32,
+    schema_rev: u32,
+    pages: usize,
+}
+
+enum SchemaError {
+    PayloadTooLong(usize),
+    Serialization,
+}
+
+fn schema_manifest<const N: usize>(
+    defs: &SchemaDefs<N>,
+    buf: &mut [u8],
+) -> Result<(SchemaManifest, usize), SchemaError> {
+    let mut next = 0;
+    let mut pages = 0;
+    let mut hash = u32::OFFSET_BASIS;
+
+    while next < defs.len() {
+        let page = serialize_schema_page(defs, next, buf).map_err(SchemaError::PayloadTooLong)?;
+        hash = hash.fnv1a(buf[..page.len].iter().copied());
+        next += page.count;
+        pages += 1;
+    }
+
+    let manifest = SchemaManifest {
+        proto: SCHEMA_PROTO,
+        epoch: 0,
+        schema_rev: hash,
+        pages,
+    };
+    serde_json_core::to_slice(&manifest, buf)
+        .map(|len| (manifest, len))
+        .map_err(|_| SchemaError::Serialization)
 }
 
 fn parse_usize(value: &str) -> Option<usize> {

--- a/miniconf_coap/src/schema.rs
+++ b/miniconf_coap/src/schema.rs
@@ -1,0 +1,125 @@
+use coap_numbers::code;
+use defmt::{debug, trace, warn};
+use miniconf::{
+    TreeSchema,
+    compact_schema::{SchemaDefs, serialize_schema_page},
+};
+
+use crate::{Error, MAX_SCHEMA_DEFS, Outcome, Problem, RequestParts, Response, content_format};
+
+/// Schema route backed by `TreeSchema`.
+#[derive(defmt::Format, Debug, Clone, Copy)]
+pub struct SchemaHandler<'a> {
+    base: &'a str,
+}
+
+impl<'a> SchemaHandler<'a> {
+    /// Construct a compact paged schema route.
+    ///
+    /// The base path and `base/0` both serve the first newline-delimited compact schema page.
+    pub const fn new(base: &'a str) -> Self {
+        Self { base }
+    }
+
+    /// Handle a schema `GET` request.
+    pub fn handle<'b, Settings>(
+        &self,
+        request: &RequestParts<'_>,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b>
+    where
+        Settings: TreeSchema,
+    {
+        let Some(page_index) = self.page_index(request.path()) else {
+            trace!("Ignoring non-schema CoAP route request={}", request);
+            return Outcome::Unhandled;
+        };
+        if let Err(err) = request.check_options() {
+            return Outcome::Handled(err.response(response_buf));
+        }
+        trace!("Handling Miniconf CoAP schema request request={}", request);
+        if request.code() != code::GET {
+            return Outcome::Handled(
+                Error::new(code::METHOD_NOT_ALLOWED, Problem::MethodNotAllowed)
+                    .response(response_buf),
+            );
+        }
+        if let Err(err) = request.accepts(content_format("text/plain; charset=utf-8")) {
+            return Outcome::Handled(err.response(response_buf));
+        }
+        let Ok(defs) = SchemaDefs::<MAX_SCHEMA_DEFS>::new(Settings::SCHEMA) else {
+            return Outcome::Handled(
+                Error::new(code::INTERNAL_SERVER_ERROR, Problem::Serialization)
+                    .response(response_buf),
+            );
+        };
+        let mut next = 0;
+        for _ in 0..page_index {
+            match serialize_schema_page(&defs, next, response_buf) {
+                Ok(page) if page.count != 0 => next += page.count,
+                _ => {
+                    return Outcome::Handled(
+                        Error::new(code::NOT_FOUND, Problem::NotFound { depth: 1 })
+                            .response(response_buf),
+                    );
+                }
+            }
+        }
+        if next >= defs.len() {
+            return Outcome::Handled(
+                Error::new(code::NOT_FOUND, Problem::NotFound { depth: 1 }).response(response_buf),
+            );
+        }
+        match serialize_schema_page(&defs, next, response_buf) {
+            Ok(page) => {
+                debug!(
+                    "Handled Miniconf CoAP schema GET path={=str} page={=usize} defs={=usize} response_len={=usize}",
+                    request.path(),
+                    page_index,
+                    page.count,
+                    page.len
+                );
+                Outcome::Handled(Response {
+                    code: code::CONTENT,
+                    content_format: Some(content_format("text/plain; charset=utf-8")),
+                    payload: &response_buf[..page.len],
+                })
+            }
+            Err(id) => {
+                warn!(
+                    "Failed to serialize Miniconf CoAP schema path={=str} definition={=usize}",
+                    request.path(),
+                    id
+                );
+                Outcome::Handled(
+                    Error::request_entity_too_large(Problem::PayloadTooLong).response(response_buf),
+                )
+            }
+        }
+    }
+
+    fn page_index(&self, path: &str) -> Option<usize> {
+        if path == self.base {
+            return Some(0);
+        }
+        let suffix = if self.base.is_empty() {
+            path.strip_prefix('/')?
+        } else {
+            path.strip_prefix(self.base)?.strip_prefix('/')?
+        };
+        (!suffix.is_empty() && !suffix.contains('/')).then(|| parse_usize(suffix))?
+    }
+}
+
+fn parse_usize(value: &str) -> Option<usize> {
+    let mut parsed = 0usize;
+    for byte in value.bytes() {
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+        parsed = parsed
+            .checked_mul(10)?
+            .checked_add(usize::from(byte - b'0'))?;
+    }
+    Some(parsed)
+}

--- a/miniconf_coap/src/value.rs
+++ b/miniconf_coap/src/value.rs
@@ -1,3 +1,4 @@
+use coap_message::MutableWritableMessage;
 use coap_numbers::code;
 use defmt::{debug, trace, warn};
 #[cfg(feature = "cbor")]
@@ -200,7 +201,7 @@ where
         }
     }
 
-    fn put_key<Settings>(
+    pub(crate) fn put_key<Settings>(
         &self,
         path: &str,
         settings: &mut Settings,
@@ -293,6 +294,14 @@ pub trait Representation: private::Sealed {
     /// Serialize this route's structured error response into the response buffer.
     fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a>;
 
+    /// Write this route's structured error response directly into a mutable CoAP message.
+    fn write_error<M: MutableWritableMessage>(
+        &self,
+        error: Error,
+        message: &mut M,
+        max_len: usize,
+    ) -> Result<(), M::UnionError>;
+
     /// Resolve a route-relative URI path into a Miniconf schema lookup.
     fn resolve<Settings: TreeSchema>(
         &self,
@@ -332,6 +341,15 @@ impl Representation for ConstPathJson {
 
     fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a> {
         error.response(buf)
+    }
+
+    fn write_error<M: MutableWritableMessage>(
+        &self,
+        error: Error,
+        message: &mut M,
+        max_len: usize,
+    ) -> Result<(), M::UnionError> {
+        error.write_json_response_to(message, max_len)
     }
 
     fn resolve<Settings: TreeSchema>(
@@ -378,6 +396,15 @@ impl Representation for ConstPathCbor {
 
     fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a> {
         error.cbor_response(buf)
+    }
+
+    fn write_error<M: MutableWritableMessage>(
+        &self,
+        error: Error,
+        message: &mut M,
+        max_len: usize,
+    ) -> Result<(), M::UnionError> {
+        error.write_cbor_response_to(message, max_len)
     }
 
     fn resolve<Settings: TreeSchema>(

--- a/miniconf_coap/src/value.rs
+++ b/miniconf_coap/src/value.rs
@@ -1,0 +1,500 @@
+use coap_numbers::code;
+use defmt::{debug, trace, warn};
+#[cfg(feature = "cbor")]
+use minicbor::{
+    decode::{Decoder as CborDecoder, Error as CborDecodeError},
+    encode::{self, write::EndOfSlice},
+};
+#[cfg(feature = "cbor")]
+use minicbor_serde::error::{DecodeError as CborDeError, EncodeError as CborSerError};
+#[cfg(feature = "json-core")]
+use miniconf::json_core;
+#[cfg(any(feature = "json-core", feature = "cbor"))]
+use miniconf::{DescendError, ResolveError};
+use miniconf::{
+    Indices, KeyError, Lookup, SerdeError, TreeDeserializeOwned, TreeSchema, TreeSerialize,
+    ValueError,
+};
+#[cfg(feature = "json-core")]
+use serde_json_core::{de::Error as JsonDeError, ser::Error as JsonSerError};
+
+#[cfg(any(feature = "json-core", feature = "cbor"))]
+use crate::content_format;
+use crate::{ChangedKey, Error, MAX_DEPTH, Operation, Outcome, Problem, RequestParts, Response};
+
+/// Leaf value route backed by a Miniconf tree.
+#[derive(defmt::Format, Debug, Clone, Copy)]
+pub struct ValueHandler<'a, R> {
+    base: &'a str,
+    pub(crate) representation: R,
+}
+
+/// Const-path-addressed JSON value route.
+#[cfg(feature = "json-core")]
+pub type ConstPathJsonHandler<'a> = ValueHandler<'a, ConstPathJson>;
+
+/// Const-path-addressed CBOR value route.
+#[cfg(feature = "cbor")]
+pub type ConstPathCborHandler<'a> = ValueHandler<'a, ConstPathCbor>;
+
+/// URI path segments as Miniconf `ConstPath` keys, with JSON payloads.
+#[cfg(feature = "json-core")]
+#[derive(defmt::Format, Debug, Clone, Copy)]
+pub struct ConstPathJson;
+
+/// URI path segments as Miniconf `ConstPath` keys, with CBOR payloads.
+#[cfg(feature = "cbor")]
+#[derive(defmt::Format, Debug, Clone, Copy)]
+pub struct ConstPathCbor;
+
+mod private {
+    pub trait Sealed {}
+}
+
+#[cfg(feature = "json-core")]
+impl private::Sealed for ConstPathJson {}
+#[cfg(feature = "cbor")]
+impl private::Sealed for ConstPathCbor {}
+
+#[cfg(feature = "json-core")]
+impl<'a> ValueHandler<'a, ConstPathJson> {
+    /// Serve JSON where remaining URI path segments are Miniconf path segments.
+    pub const fn const_path_json(base: &'a str) -> Self {
+        Self {
+            base,
+            representation: ConstPathJson,
+        }
+    }
+}
+
+#[cfg(feature = "cbor")]
+impl<'a> ValueHandler<'a, ConstPathCbor> {
+    /// Serve CBOR where remaining URI path segments are Miniconf path segments.
+    pub const fn const_path_cbor(base: &'a str) -> Self {
+        Self {
+            base,
+            representation: ConstPathCbor,
+        }
+    }
+}
+
+impl<'a, R> ValueHandler<'a, R>
+where
+    R: Representation,
+{
+    /// Handle a single request using cooperative borrows.
+    pub fn handle<'b, Settings>(
+        &self,
+        request: &RequestParts<'_>,
+        settings: &mut Settings,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b>
+    where
+        Settings: TreeSchema + TreeSerialize + TreeDeserializeOwned,
+    {
+        let Some(path) = request.relative_to(self.base) else {
+            trace!("Ignoring non-Miniconf CoAP route request={}", request);
+            return Outcome::Unhandled;
+        };
+        if let Err(err) = request.check_options() {
+            return Outcome::Handled(self.representation.error_response(err, response_buf));
+        }
+
+        trace!(
+            "Handling Miniconf CoAP request base={=str} request={}",
+            self.base, request
+        );
+
+        match request.code() {
+            code::GET => self.get(path, &*settings, request, response_buf),
+            code::PUT => self.put(path, settings, request, response_buf),
+            _ => self.method_not_allowed(request, response_buf),
+        }
+    }
+
+    fn get<'b, Settings>(
+        &self,
+        path: &str,
+        settings: &Settings,
+        request: &RequestParts<'_>,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b>
+    where
+        Settings: TreeSchema + TreeSerialize,
+    {
+        match self.get_len::<Settings>(path, settings, request, response_buf) {
+            Ok(len) => {
+                debug!(
+                    "Handled Miniconf CoAP GET path={=str} depth={=usize} response_len={=usize}",
+                    request.path(),
+                    path_depth(path),
+                    len
+                );
+                Outcome::Handled(Response {
+                    code: code::CONTENT,
+                    content_format: Some(self.representation.content_format()),
+                    payload: &response_buf[..len],
+                })
+            }
+            Err(err) => {
+                debug!("Rejecting Miniconf CoAP GET err={}", err);
+                Outcome::Handled(self.representation.error_response(err, response_buf))
+            }
+        }
+    }
+
+    fn get_len<Settings>(
+        &self,
+        path: &str,
+        settings: &Settings,
+        request: &RequestParts<'_>,
+        response_buf: &mut [u8],
+    ) -> Result<usize, Error>
+    where
+        Settings: TreeSchema + TreeSerialize,
+    {
+        request.accepts(self.representation.content_format())?;
+        let (lookup, state) = self.resolve::<Settings>(path)?;
+        if !lookup.schema.is_leaf() {
+            return Err(Error::new(
+                code::METHOD_NOT_ALLOWED,
+                Problem::NonLeaf {
+                    depth: lookup.depth,
+                },
+            ));
+        }
+
+        let len = self
+            .representation
+            .get(settings, &state.as_ref()[..lookup.depth], response_buf)
+            .map_err(|err| read_error(err, lookup.depth))?;
+        Ok(len)
+    }
+
+    fn put<'b, Settings>(
+        &self,
+        path: &str,
+        settings: &mut Settings,
+        request: &RequestParts<'_>,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b>
+    where
+        Settings: TreeSchema + TreeDeserializeOwned,
+    {
+        match self.put_key::<Settings>(path, settings, request) {
+            Ok(key) => Outcome::Changed {
+                key,
+                response: Response {
+                    code: code::CHANGED,
+                    content_format: None,
+                    payload: b"",
+                },
+            },
+            Err(err) => {
+                debug!("Rejecting Miniconf CoAP PUT err={}", err);
+                Outcome::Handled(self.representation.error_response(err, response_buf))
+            }
+        }
+    }
+
+    fn put_key<Settings>(
+        &self,
+        path: &str,
+        settings: &mut Settings,
+        request: &RequestParts<'_>,
+    ) -> Result<ChangedKey, Error>
+    where
+        Settings: TreeSchema + TreeDeserializeOwned,
+    {
+        match request.content_format {
+            Some(format) if format == self.representation.content_format() => {}
+            _ => {
+                return Err(Error::new(
+                    code::UNSUPPORTED_CONTENT_FORMAT,
+                    Problem::UnsupportedContentFormat,
+                ));
+            }
+        }
+
+        let (lookup, state) = self.resolve::<Settings>(path)?;
+        if !lookup.schema.is_leaf() {
+            return Err(Error::new(
+                code::METHOD_NOT_ALLOWED,
+                Problem::NonLeaf {
+                    depth: lookup.depth,
+                },
+            ));
+        }
+
+        self.representation
+            .set(settings, &state.as_ref()[..lookup.depth], request.payload())
+            .map_err(|err| value_error(err, Operation::Write, lookup.depth))?;
+        debug!(
+            "Accepted Miniconf CoAP PUT path={=str} depth={=usize} payload_len={=usize}",
+            request.path(),
+            lookup.depth,
+            request.payload().len()
+        );
+        Ok(state)
+    }
+
+    fn resolve<Settings>(&self, path: &str) -> Result<(Lookup, ChangedKey), Error>
+    where
+        Settings: TreeSchema,
+    {
+        if Settings::SCHEMA.max_depth() > MAX_DEPTH {
+            warn!(
+                "Rejecting Miniconf CoAP request because schema depth={=usize} exceeds max_depth={=usize}",
+                Settings::SCHEMA.max_depth(),
+                MAX_DEPTH
+            );
+            return Err(Error::new(
+                code::REQUEST_ENTITY_TOO_LARGE,
+                Problem::UriPathTooLong,
+            ));
+        }
+        let mut state = [0; MAX_DEPTH];
+        let lookup = self.representation.resolve::<Settings>(path, &mut state)?;
+        Ok((lookup, Indices::new(state, lookup.depth)))
+    }
+
+    fn method_not_allowed<'b>(
+        &self,
+        request: &RequestParts<'_>,
+        response_buf: &'b mut [u8],
+    ) -> Outcome<'b> {
+        let err = Error::new(code::METHOD_NOT_ALLOWED, Problem::MethodNotAllowed);
+        debug!(
+            "Rejecting Miniconf CoAP request code={=u8} err={}",
+            request.code(),
+            err
+        );
+        Outcome::Handled(self.representation.error_response(err, response_buf))
+    }
+}
+
+/// Complete value representation used by a [`ValueHandler`].
+#[doc(hidden)]
+pub trait Representation: private::Sealed {
+    /// Serialization error type.
+    type SerError;
+    /// Deserialization error type.
+    type DeError;
+
+    /// CoAP Content-Format used for successful responses and accepted request payloads.
+    fn content_format(&self) -> u16;
+
+    /// CoAP Content-Format used for structured error responses.
+    fn error_content_format(&self) -> u16;
+
+    /// Serialize this route's structured error response into the response buffer.
+    fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a>;
+
+    /// Resolve a route-relative URI path into a Miniconf schema lookup.
+    fn resolve<Settings: TreeSchema>(
+        &self,
+        path: &str,
+        state: &mut [usize],
+    ) -> Result<Lookup, Error>;
+
+    /// Serialize a leaf value into the response buffer.
+    fn get<Settings: TreeSerialize + ?Sized>(
+        &self,
+        settings: &Settings,
+        keys: &[usize],
+        buf: &mut [u8],
+    ) -> Result<usize, SerdeError<Self::SerError>>;
+
+    /// Deserialize and set a leaf value from a request payload.
+    fn set<Settings: TreeDeserializeOwned + ?Sized>(
+        &self,
+        settings: &mut Settings,
+        keys: &[usize],
+        payload: &[u8],
+    ) -> Result<(), SerdeError<Self::DeError>>;
+}
+
+#[cfg(feature = "json-core")]
+impl Representation for ConstPathJson {
+    type SerError = JsonSerError;
+    type DeError = JsonDeError;
+
+    fn content_format(&self) -> u16 {
+        content_format("application/json")
+    }
+
+    fn error_content_format(&self) -> u16 {
+        content_format("application/json")
+    }
+
+    fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a> {
+        error.response(buf)
+    }
+
+    fn resolve<Settings: TreeSchema>(
+        &self,
+        path: &str,
+        state: &mut [usize],
+    ) -> Result<Lookup, Error> {
+        Settings::SCHEMA
+            .resolve_into(path, state)
+            .map_err(resolve_error)
+    }
+
+    fn get<Settings: TreeSerialize + ?Sized>(
+        &self,
+        settings: &Settings,
+        mut keys: &[usize],
+        buf: &mut [u8],
+    ) -> Result<usize, SerdeError<Self::SerError>> {
+        json_core::get_by_keys(settings, &mut keys, buf)
+    }
+
+    fn set<Settings: TreeDeserializeOwned + ?Sized>(
+        &self,
+        settings: &mut Settings,
+        mut keys: &[usize],
+        payload: &[u8],
+    ) -> Result<(), SerdeError<Self::DeError>> {
+        json_core::set_by_keys(settings, &mut keys, payload).map(|_| ())
+    }
+}
+
+#[cfg(feature = "cbor")]
+impl Representation for ConstPathCbor {
+    type SerError = CborSerError<EndOfSlice>;
+    type DeError = CborDeError;
+
+    fn content_format(&self) -> u16 {
+        content_format("application/cbor")
+    }
+
+    fn error_content_format(&self) -> u16 {
+        content_format("application/concise-problem-details+cbor")
+    }
+
+    fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a> {
+        error.cbor_response(buf)
+    }
+
+    fn resolve<Settings: TreeSchema>(
+        &self,
+        path: &str,
+        state: &mut [usize],
+    ) -> Result<Lookup, Error> {
+        Settings::SCHEMA
+            .resolve_into(path, state)
+            .map_err(resolve_error)
+    }
+
+    fn get<Settings: TreeSerialize + ?Sized>(
+        &self,
+        settings: &Settings,
+        mut keys: &[usize],
+        buf: &mut [u8],
+    ) -> Result<usize, SerdeError<Self::SerError>> {
+        let mut cursor = encode::write::Cursor::new(buf);
+        let mut serializer = minicbor_serde::Serializer::new(&mut cursor);
+        settings.serialize_by_key(&mut keys, &mut serializer)?;
+        Ok(cursor.position())
+    }
+
+    fn set<Settings: TreeDeserializeOwned + ?Sized>(
+        &self,
+        settings: &mut Settings,
+        mut keys: &[usize],
+        payload: &[u8],
+    ) -> Result<(), SerdeError<Self::DeError>> {
+        validate_cbor_payload(payload).map_err(SerdeError::Finalization)?;
+        let mut deserializer = minicbor_serde::Deserializer::new(payload);
+        settings.deserialize_by_key(&mut keys, &mut deserializer)
+    }
+}
+
+#[cfg(feature = "cbor")]
+fn validate_cbor_payload(payload: &[u8]) -> Result<(), CborDeError> {
+    let mut decoder = CborDecoder::new(payload);
+    decoder.skip()?;
+    if decoder.position() == decoder.input().len() {
+        Ok(())
+    } else {
+        Err(CborDecodeError::message("trailing data").into())
+    }
+}
+
+fn path_depth(path: &str) -> usize {
+    path.as_bytes().iter().filter(|byte| **byte == b'/').count()
+}
+
+#[cfg(any(feature = "json-core", feature = "cbor"))]
+fn resolve_error(err: ResolveError) -> Error {
+    let depth = err.lookup.depth;
+    match err.error {
+        DescendError::Key(KeyError::NotFound) => {
+            Error::new(code::NOT_FOUND, Problem::NotFound { depth })
+        }
+        DescendError::Key(KeyError::TooLong) => {
+            Error::new(code::NOT_FOUND, Problem::TooLong { depth })
+        }
+        DescendError::Key(KeyError::TooShort) => {
+            Error::new(code::METHOD_NOT_ALLOWED, Problem::NonLeaf { depth })
+        }
+        DescendError::Inner(()) => {
+            Error::new(code::REQUEST_ENTITY_TOO_LARGE, Problem::UriPathTooLong)
+        }
+    }
+}
+
+fn read_error<E>(err: SerdeError<E>, depth: usize) -> Error {
+    match err {
+        SerdeError::Value(ValueError::Key(KeyError::NotFound)) => {
+            Error::new(code::NOT_FOUND, Problem::NotFound { depth })
+        }
+        SerdeError::Value(ValueError::Key(KeyError::TooLong)) => {
+            Error::new(code::NOT_FOUND, Problem::TooLong { depth })
+        }
+        SerdeError::Value(ValueError::Key(KeyError::TooShort)) => {
+            Error::new(code::METHOD_NOT_ALLOWED, Problem::NonLeaf { depth })
+        }
+        SerdeError::Value(ValueError::Absent) => {
+            Error::new(code::CONFLICT, Problem::Absent { depth })
+        }
+        SerdeError::Value(ValueError::Access(message)) => Error::new(
+            code::FORBIDDEN,
+            Problem::Access {
+                op: Operation::Read,
+                message,
+            },
+        ),
+        SerdeError::Inner(_) | SerdeError::Finalization(_) => {
+            Error::new(code::INTERNAL_SERVER_ERROR, Problem::Serialization)
+        }
+    }
+}
+
+fn value_error<E>(err: SerdeError<E>, op: Operation, depth: usize) -> Error {
+    match err {
+        SerdeError::Value(ValueError::Key(KeyError::NotFound)) => {
+            Error::new(code::NOT_FOUND, Problem::NotFound { depth })
+        }
+        SerdeError::Value(ValueError::Key(KeyError::TooLong)) => {
+            Error::new(code::NOT_FOUND, Problem::TooLong { depth })
+        }
+        SerdeError::Value(ValueError::Key(KeyError::TooShort)) => {
+            Error::new(code::METHOD_NOT_ALLOWED, Problem::NonLeaf { depth })
+        }
+        SerdeError::Value(ValueError::Absent) => {
+            Error::new(code::CONFLICT, Problem::Absent { depth })
+        }
+        SerdeError::Value(ValueError::Access(message)) => Error::new(
+            match op {
+                Operation::Read => code::FORBIDDEN,
+                Operation::Write => code::UNPROCESSABLE_ENTITY,
+            },
+            Problem::Access { op, message },
+        ),
+        SerdeError::Inner(_) | SerdeError::Finalization(_) => {
+            Error::new(code::BAD_REQUEST, Problem::BadPayload)
+        }
+    }
+}

--- a/miniconf_coap/src/value.rs
+++ b/miniconf_coap/src/value.rs
@@ -1,4 +1,6 @@
 use coap_numbers::code;
+#[cfg(any(feature = "json-core", feature = "cbor"))]
+use coap_numbers::content_format;
 use defmt::{debug, trace, warn};
 #[cfg(feature = "cbor")]
 use minicbor::{
@@ -6,7 +8,10 @@ use minicbor::{
     encode::{self, write::EndOfSlice},
 };
 #[cfg(feature = "cbor")]
-use minicbor_serde::error::{DecodeError as CborDeError, EncodeError as CborSerError};
+use minicbor_serde::{
+    Deserializer as CborDeserializer, Serializer as CborSerializer,
+    error::{DecodeError as CborDeError, EncodeError as CborSerError},
+};
 #[cfg(feature = "json-core")]
 use miniconf::json_core;
 #[cfg(any(feature = "json-core", feature = "cbor"))]
@@ -18,8 +23,6 @@ use miniconf::{
 #[cfg(feature = "json-core")]
 use serde_json_core::{de::Error as JsonDeError, ser::Error as JsonSerError};
 
-#[cfg(any(feature = "json-core", feature = "cbor"))]
-use crate::content_format;
 use crate::{ChangedKey, Error, MAX_DEPTH, Operation, Outcome, Problem, RequestParts, Response};
 
 /// Leaf value route backed by a Miniconf tree.
@@ -320,11 +323,11 @@ impl Representation for ConstPathJson {
     type DeError = JsonDeError;
 
     fn content_format(&self) -> u16 {
-        content_format("application/json")
+        content_format::from_str("application/json").unwrap()
     }
 
     fn error_content_format(&self) -> u16 {
-        content_format("application/json")
+        content_format::from_str("application/json").unwrap()
     }
 
     fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a> {
@@ -366,11 +369,11 @@ impl Representation for ConstPathCbor {
     type DeError = CborDeError;
 
     fn content_format(&self) -> u16 {
-        content_format("application/cbor")
+        content_format::from_str("application/cbor").unwrap()
     }
 
     fn error_content_format(&self) -> u16 {
-        content_format("application/concise-problem-details+cbor")
+        content_format::from_str("application/concise-problem-details+cbor").unwrap()
     }
 
     fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a> {
@@ -394,7 +397,7 @@ impl Representation for ConstPathCbor {
         buf: &mut [u8],
     ) -> Result<usize, SerdeError<Self::SerError>> {
         let mut cursor = encode::write::Cursor::new(buf);
-        let mut serializer = minicbor_serde::Serializer::new(&mut cursor);
+        let mut serializer = CborSerializer::new(&mut cursor);
         settings.serialize_by_key(&mut keys, &mut serializer)?;
         Ok(cursor.position())
     }
@@ -406,7 +409,7 @@ impl Representation for ConstPathCbor {
         payload: &[u8],
     ) -> Result<(), SerdeError<Self::DeError>> {
         validate_cbor_payload(payload).map_err(SerdeError::Finalization)?;
-        let mut deserializer = minicbor_serde::Deserializer::new(payload);
+        let mut deserializer = CborDeserializer::new(payload);
         settings.deserialize_by_key(&mut keys, &mut deserializer)
     }
 }

--- a/miniconf_coap/src/value.rs
+++ b/miniconf_coap/src/value.rs
@@ -1,6 +1,4 @@
 use coap_numbers::code;
-#[cfg(any(feature = "json-core", feature = "cbor"))]
-use coap_numbers::content_format;
 use defmt::{debug, trace, warn};
 #[cfg(feature = "cbor")]
 use minicbor::{
@@ -23,6 +21,8 @@ use miniconf::{
 #[cfg(feature = "json-core")]
 use serde_json_core::{de::Error as JsonDeError, ser::Error as JsonSerError};
 
+#[cfg(any(feature = "json-core", feature = "cbor"))]
+use crate::format;
 use crate::{ChangedKey, Error, MAX_DEPTH, Operation, Outcome, Problem, RequestParts, Response};
 
 /// Leaf value route backed by a Miniconf tree.
@@ -323,11 +323,11 @@ impl Representation for ConstPathJson {
     type DeError = JsonDeError;
 
     fn content_format(&self) -> u16 {
-        content_format::from_str("application/json").unwrap()
+        format::JSON
     }
 
     fn error_content_format(&self) -> u16 {
-        content_format::from_str("application/json").unwrap()
+        format::JSON
     }
 
     fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a> {
@@ -369,11 +369,11 @@ impl Representation for ConstPathCbor {
     type DeError = CborDeError;
 
     fn content_format(&self) -> u16 {
-        content_format::from_str("application/cbor").unwrap()
+        format::CBOR
     }
 
     fn error_content_format(&self) -> u16 {
-        content_format::from_str("application/concise-problem-details+cbor").unwrap()
+        format::CONCISE_PROBLEM_CBOR
     }
 
     fn error_response<'a>(&self, error: Error, buf: &'a mut [u8]) -> Response<'a> {

--- a/miniconf_coap/tests/packet_routes.rs
+++ b/miniconf_coap/tests/packet_routes.rs
@@ -5,6 +5,13 @@ use coap_numbers::code;
 use miniconf::Tree;
 use miniconf_coap::{Outcome, Response};
 
+const fn content_format(name: &str) -> u16 {
+    match coap_numbers::content_format::from_str(name) {
+        Some(value) => value,
+        None => panic!("unknown CoAP content format"),
+    }
+}
+
 #[derive(Tree)]
 struct Settings {
     hidden: bool,
@@ -64,9 +71,9 @@ mod label {
 mod json {
     use coap_message::ReadableMessage as _;
     use coap_numbers::code;
-    use miniconf_coap::{ConstPathJsonHandler, JSON_CONTENT_FORMAT, Outcome, SchemaHandler};
+    use miniconf_coap::{ConstPathJsonHandler, Outcome, SchemaHandler};
 
-    use crate::{Packet, Settings, WirePacket, init_host_logging, response_packet};
+    use crate::{Packet, Settings, WirePacket, content_format, init_host_logging, response_packet};
 
     #[test]
     fn const_path_json_packet_routes_compose_with_user_routes() {
@@ -76,7 +83,7 @@ mod json {
         let get_number = Packet::get(0x1234)
             .uri_path("settings")
             .uri_path("number")
-            .accept(JSON_CONTENT_FORMAT);
+            .accept(content_format("application/json"));
         let response = handle_json_packet(&get_number, &mut settings);
         assert_eq!(
             response,
@@ -86,7 +93,7 @@ mod json {
                 0x12,
                 0x34,
                 0xc1,
-                JSON_CONTENT_FORMAT as u8,
+                content_format("application/json") as u8,
                 0xff,
                 b'7',
             ]
@@ -95,7 +102,7 @@ mod json {
         let put_label = Packet::put(0x1235)
             .uri_path("settings")
             .uri_path("label")
-            .content_format(JSON_CONTENT_FORMAT)
+            .content_format(content_format("application/json"))
             .payload(br#""good""#);
         let response = handle_json_packet(&put_label, &mut settings);
         assert_eq!(response, [0x60, 0x44, 0x12, 0x35]);
@@ -148,7 +155,7 @@ mod json {
             }
             "/status" => Outcome::Handled(miniconf_coap::Response {
                 code: code::CONTENT,
-                content_format: Some(JSON_CONTENT_FORMAT),
+                content_format: Some(content_format("application/json")),
                 payload: br#"{"ok":true}"#,
             }),
             _ => Outcome::Unhandled,
@@ -169,11 +176,9 @@ mod cbor {
     use coap_message::{MessageOption as _, ReadableMessage as _};
     use coap_numbers::code;
     use minicbor::{Decoder, data::Type};
-    use miniconf_coap::{
-        CBOR_CONTENT_FORMAT, ConstPathCborHandler, Outcome, PROBLEM_DETAILS_CBOR_CONTENT_FORMAT,
-    };
+    use miniconf_coap::{ConstPathCborHandler, Outcome};
 
-    use crate::{Packet, Settings, WirePacket, init_host_logging, response_packet};
+    use crate::{Packet, Settings, WirePacket, content_format, init_host_logging, response_packet};
 
     #[test]
     fn const_path_cbor_packet_route_reads_and_writes() {
@@ -183,7 +188,7 @@ mod cbor {
         let get_number = Packet::get(0x1239)
             .uri_path("settings")
             .uri_path("number")
-            .accept(CBOR_CONTENT_FORMAT);
+            .accept(content_format("application/cbor"));
         let response = handle_cbor_packet(&get_number, &mut settings);
         assert_eq!(
             response,
@@ -193,7 +198,7 @@ mod cbor {
                 0x12,
                 0x39,
                 0xc1,
-                CBOR_CONTENT_FORMAT as u8,
+                content_format("application/cbor") as u8,
                 0xff,
                 7,
             ]
@@ -202,7 +207,7 @@ mod cbor {
         let put_number = Packet::put(0x123a)
             .uri_path("settings")
             .uri_path("number")
-            .content_format(CBOR_CONTENT_FORMAT)
+            .content_format(content_format("application/cbor"))
             .payload(&[21]);
         let response = handle_cbor_packet(&put_number, &mut settings);
         assert_eq!(response, [0x60, 0x44, 0x12, 0x3a]);
@@ -211,7 +216,7 @@ mod cbor {
         let trailing = Packet::put(0x123b)
             .uri_path("settings")
             .uri_path("number")
-            .content_format(CBOR_CONTENT_FORMAT)
+            .content_format(content_format("application/cbor"))
             .payload(&[22, 0]);
         let response = handle_cbor_packet(&trailing, &mut settings);
         let response = WirePacket::parse(&response).unwrap();
@@ -222,7 +227,7 @@ mod cbor {
                 .options()
                 .find(|option| option.number() == coap_numbers::option::CONTENT_FORMAT)
                 .and_then(|option| option.value_uint::<u16>()),
-            Some(PROBLEM_DETAILS_CBOR_CONTENT_FORMAT)
+            Some(content_format("application/concise-problem-details+cbor"))
         );
         assert_cbor_problem(response.message.payload(), code::BAD_REQUEST, "bad_payload");
         assert_eq!(settings.number, 21);
@@ -310,11 +315,10 @@ mod coap_handler {
     use coap_message_implementations::heap::HeapMessage;
     use coap_numbers::code;
     use miniconf_coap::{
-        ConstPathJson, ConstPathJsonCoapHandler, JSON_CONTENT_FORMAT, LINK_FORMAT_CONTENT_FORMAT,
-        MiniconfHandler, MiniconfSchemaHandler,
+        ConstPathJson, ConstPathJsonCoapHandler, MiniconfHandler, MiniconfSchemaHandler,
     };
 
-    use crate::{Packet, Settings, WirePacket, encode_ack, init_host_logging};
+    use crate::{Packet, Settings, WirePacket, content_format, encode_ack, init_host_logging};
 
     #[test]
     fn reports_and_serves_well_known_core() {
@@ -326,7 +330,7 @@ mod coap_handler {
         let request = heap_request(
             code::GET,
             &[".well-known", "core"],
-            Some(LINK_FORMAT_CONTENT_FORMAT),
+            Some(content_format("application/link-format")),
             b"",
         );
         let response = handle_heap(&mut handler, &request);
@@ -334,7 +338,7 @@ mod coap_handler {
         assert_eq!(response.code(), code::CONTENT);
         assert_eq!(
             first_uint_option(&response, coap_numbers::option::CONTENT_FORMAT),
-            Some(LINK_FORMAT_CONTENT_FORMAT)
+            Some(content_format("application/link-format"))
         );
         let payload = core::str::from_utf8(response.payload()).unwrap();
         assert!(payload.contains("</settings/number>;ct=50;title=\"Demo number\""));
@@ -353,14 +357,19 @@ mod coap_handler {
         let request = heap_request(
             code::GET,
             &["settings", "number"],
-            Some(JSON_CONTENT_FORMAT),
+            Some(content_format("application/json")),
             b"",
         );
         let response = handle_heap(&mut handler, &request);
         assert_eq!(response.code(), code::CONTENT);
         assert_eq!(response.payload(), b"7");
 
-        let request = heap_request(code::GET, &["status"], Some(JSON_CONTENT_FORMAT), b"");
+        let request = heap_request(
+            code::GET,
+            &["status"],
+            Some(content_format("application/json")),
+            b"",
+        );
         let response = handle_heap(&mut handler, &request);
         assert_eq!(response.code(), code::CONTENT);
         assert_eq!(response.payload(), br#"{"ok":true}"#);
@@ -379,7 +388,10 @@ mod coap_handler {
 
         let mut request = heap_request(code::PUT, &["settings", "number"], None, br#"31"#);
         request
-            .add_option_uint(coap_numbers::option::CONTENT_FORMAT, JSON_CONTENT_FORMAT)
+            .add_option_uint(
+                coap_numbers::option::CONTENT_FORMAT,
+                content_format("application/json"),
+            )
             .unwrap();
         let response = handle_heap(&mut handler, &request);
         assert_eq!(response.code(), code::CHANGED);
@@ -387,7 +399,7 @@ mod coap_handler {
         let request = heap_request(
             code::GET,
             &["settings", "number"],
-            Some(JSON_CONTENT_FORMAT),
+            Some(content_format("application/json")),
             b"",
         );
         let response = handle_heap(&mut handler, &request);
@@ -405,13 +417,13 @@ mod coap_handler {
         assert_eq!(&response[..4], [0x60, code::CONTENT, 0x12, 0x34]);
         assert_eq!(
             &response[4..],
-            [0xc1, JSON_CONTENT_FORMAT as u8, 0xff, b'7']
+            [0xc1, content_format("application/json") as u8, 0xff, b'7']
         );
 
         let put_number = Packet::put(0x1235)
             .uri_path("settings")
             .uri_path("number")
-            .content_format(JSON_CONTENT_FORMAT)
+            .content_format(content_format("application/json"))
             .payload(b"23");
         let response = handle_packet_with_coap_handler(&put_number, &mut settings);
         assert_eq!(response, [0x60, code::CHANGED, 0x12, 0x35]);
@@ -451,7 +463,7 @@ mod coap_handler {
                 &["status"],
                 coap_handler_implementations::SimpleRendered::new_typed_str(
                     r#"{"ok":true}"#,
-                    Some(JSON_CONTENT_FORMAT),
+                    Some(content_format("application/json")),
                 ),
             )
             .with_wkc()

--- a/miniconf_coap/tests/packet_routes.rs
+++ b/miniconf_coap/tests/packet_routes.rs
@@ -1,16 +1,9 @@
 #![cfg(any(feature = "json-core", feature = "cbor"))]
 
 use coap_message_implementations::{inmemory, inmemory_write};
-use coap_numbers::code;
+use coap_numbers::{code, option};
 use miniconf::Tree;
-use miniconf_coap::{Outcome, Response};
-
-const fn content_format(name: &str) -> u16 {
-    match coap_numbers::content_format::from_str(name) {
-        Some(value) => value,
-        None => panic!("unknown CoAP content format"),
-    }
-}
+use miniconf_coap::{Outcome, RequestParts, Response};
 
 #[derive(Tree)]
 struct Settings {
@@ -70,10 +63,12 @@ mod label {
 #[cfg(feature = "json-core")]
 mod json {
     use coap_message::ReadableMessage as _;
-    use coap_numbers::code;
+    use coap_numbers::{code, content_format};
     use miniconf_coap::{ConstPathJsonHandler, Outcome, SchemaHandler};
 
-    use crate::{Packet, Settings, WirePacket, content_format, init_host_logging, response_packet};
+    use crate::{
+        Packet, RequestParts, Response, Settings, WirePacket, init_host_logging, response_packet,
+    };
 
     #[test]
     fn const_path_json_packet_routes_compose_with_user_routes() {
@@ -83,7 +78,7 @@ mod json {
         let get_number = Packet::get(0x1234)
             .uri_path("settings")
             .uri_path("number")
-            .accept(content_format("application/json"));
+            .accept(content_format::from_str("application/json").unwrap());
         let response = handle_json_packet(&get_number, &mut settings);
         assert_eq!(
             response,
@@ -93,7 +88,7 @@ mod json {
                 0x12,
                 0x34,
                 0xc1,
-                content_format("application/json") as u8,
+                content_format::from_str("application/json").unwrap() as u8,
                 0xff,
                 b'7',
             ]
@@ -102,7 +97,7 @@ mod json {
         let put_label = Packet::put(0x1235)
             .uri_path("settings")
             .uri_path("label")
-            .content_format(content_format("application/json"))
+            .content_format(content_format::from_str("application/json").unwrap())
             .payload(br#""good""#);
         let response = handle_json_packet(&put_label, &mut settings);
         assert_eq!(response, [0x60, 0x44, 0x12, 0x35]);
@@ -136,14 +131,14 @@ mod json {
 
     pub fn handle_json_packet(packet: &[u8], settings: &mut Settings) -> Vec<u8> {
         let request = WirePacket::parse(packet).unwrap();
-        let parts = miniconf_coap::RequestParts::from_message(&request.message).unwrap();
+        let parts = RequestParts::from_message(&request.message).unwrap();
         let mut response_buf = [0; 512];
         let outcome = route(&parts, settings, &mut response_buf);
         response_packet(&request, outcome)
     }
 
     fn route<'a>(
-        request: &miniconf_coap::RequestParts<'_>,
+        request: &RequestParts<'_>,
         settings: &mut Settings,
         response_buf: &'a mut [u8],
     ) -> Outcome<'a> {
@@ -153,9 +148,9 @@ mod json {
             path if path.starts_with("/settings/") => {
                 settings_route(request, settings, response_buf)
             }
-            "/status" => Outcome::Handled(miniconf_coap::Response {
+            "/status" => Outcome::Handled(Response {
                 code: code::CONTENT,
-                content_format: Some(content_format("application/json")),
+                content_format: Some(content_format::from_str("application/json").unwrap()),
                 payload: br#"{"ok":true}"#,
             }),
             _ => Outcome::Unhandled,
@@ -163,7 +158,7 @@ mod json {
     }
 
     fn settings_route<'a>(
-        request: &miniconf_coap::RequestParts<'_>,
+        request: &RequestParts<'_>,
         settings: &mut Settings,
         response_buf: &'a mut [u8],
     ) -> Outcome<'a> {
@@ -174,11 +169,11 @@ mod json {
 #[cfg(feature = "cbor")]
 mod cbor {
     use coap_message::{MessageOption as _, ReadableMessage as _};
-    use coap_numbers::code;
+    use coap_numbers::{code, content_format, option};
     use minicbor::{Decoder, data::Type};
     use miniconf_coap::{ConstPathCborHandler, Outcome};
 
-    use crate::{Packet, Settings, WirePacket, content_format, init_host_logging, response_packet};
+    use crate::{Packet, RequestParts, Settings, WirePacket, init_host_logging, response_packet};
 
     #[test]
     fn const_path_cbor_packet_route_reads_and_writes() {
@@ -188,7 +183,7 @@ mod cbor {
         let get_number = Packet::get(0x1239)
             .uri_path("settings")
             .uri_path("number")
-            .accept(content_format("application/cbor"));
+            .accept(content_format::from_str("application/cbor").unwrap());
         let response = handle_cbor_packet(&get_number, &mut settings);
         assert_eq!(
             response,
@@ -198,7 +193,7 @@ mod cbor {
                 0x12,
                 0x39,
                 0xc1,
-                content_format("application/cbor") as u8,
+                content_format::from_str("application/cbor").unwrap() as u8,
                 0xff,
                 7,
             ]
@@ -207,7 +202,7 @@ mod cbor {
         let put_number = Packet::put(0x123a)
             .uri_path("settings")
             .uri_path("number")
-            .content_format(content_format("application/cbor"))
+            .content_format(content_format::from_str("application/cbor").unwrap())
             .payload(&[21]);
         let response = handle_cbor_packet(&put_number, &mut settings);
         assert_eq!(response, [0x60, 0x44, 0x12, 0x3a]);
@@ -216,7 +211,7 @@ mod cbor {
         let trailing = Packet::put(0x123b)
             .uri_path("settings")
             .uri_path("number")
-            .content_format(content_format("application/cbor"))
+            .content_format(content_format::from_str("application/cbor").unwrap())
             .payload(&[22, 0]);
         let response = handle_cbor_packet(&trailing, &mut settings);
         let response = WirePacket::parse(&response).unwrap();
@@ -225,9 +220,9 @@ mod cbor {
             response
                 .message
                 .options()
-                .find(|option| option.number() == coap_numbers::option::CONTENT_FORMAT)
+                .find(|option| option.number() == option::CONTENT_FORMAT)
                 .and_then(|option| option.value_uint::<u16>()),
-            Some(content_format("application/concise-problem-details+cbor"))
+            Some(content_format::from_str("application/concise-problem-details+cbor").unwrap())
         );
         assert_cbor_problem(response.message.payload(), code::BAD_REQUEST, "bad_payload");
         assert_eq!(settings.number, 21);
@@ -235,7 +230,7 @@ mod cbor {
 
     fn handle_cbor_packet(packet: &[u8], settings: &mut Settings) -> Vec<u8> {
         let request = WirePacket::parse(packet).unwrap();
-        let parts = miniconf_coap::RequestParts::from_message(&request.message).unwrap();
+        let parts = RequestParts::from_message(&request.message).unwrap();
         let mut response_buf = [0; 512];
         let outcome = match parts.path() {
             "/settings" => settings_route(&parts, settings, &mut response_buf),
@@ -248,7 +243,7 @@ mod cbor {
     }
 
     fn settings_route<'a>(
-        request: &miniconf_coap::RequestParts<'_>,
+        request: &RequestParts<'_>,
         settings: &mut Settings,
         response_buf: &'a mut [u8],
     ) -> Outcome<'a> {
@@ -307,18 +302,23 @@ mod cbor {
 
 #[cfg(all(feature = "coap-handler", feature = "json-core"))]
 mod coap_handler {
+    use core::fmt;
+
     use coap_handler::Handler as _;
+    use coap_handler_implementations::{
+        HandlerBuilder as _, ReportingHandlerBuilder as _, SimpleRendered, new_dispatcher,
+    };
     use coap_message::{
         MessageOption, MinimalWritableMessage as _, ReadableMessage as _,
         error::RenderableOnMinimal as _,
     };
-    use coap_message_implementations::heap::HeapMessage;
-    use coap_numbers::code;
+    use coap_message_implementations::{heap::HeapMessage, inmemory_write};
+    use coap_numbers::{code, content_format, option};
     use miniconf_coap::{
         ConstPathJson, ConstPathJsonCoapHandler, MiniconfHandler, MiniconfSchemaHandler,
     };
 
-    use crate::{Packet, Settings, WirePacket, content_format, encode_ack, init_host_logging};
+    use crate::{Packet, Settings, WirePacket, encode_ack, init_host_logging};
 
     #[test]
     fn reports_and_serves_well_known_core() {
@@ -330,15 +330,15 @@ mod coap_handler {
         let request = heap_request(
             code::GET,
             &[".well-known", "core"],
-            Some(content_format("application/link-format")),
+            Some(content_format::from_str("application/link-format").unwrap()),
             b"",
         );
         let response = handle_heap(&mut handler, &request);
 
         assert_eq!(response.code(), code::CONTENT);
         assert_eq!(
-            first_uint_option(&response, coap_numbers::option::CONTENT_FORMAT),
-            Some(content_format("application/link-format"))
+            first_uint_option(&response, option::CONTENT_FORMAT),
+            Some(content_format::from_str("application/link-format").unwrap())
         );
         let payload = core::str::from_utf8(response.payload()).unwrap();
         assert!(payload.contains("</settings/number>;ct=50;title=\"Demo number\""));
@@ -357,7 +357,7 @@ mod coap_handler {
         let request = heap_request(
             code::GET,
             &["settings", "number"],
-            Some(content_format("application/json")),
+            Some(content_format::from_str("application/json").unwrap()),
             b"",
         );
         let response = handle_heap(&mut handler, &request);
@@ -367,7 +367,7 @@ mod coap_handler {
         let request = heap_request(
             code::GET,
             &["status"],
-            Some(content_format("application/json")),
+            Some(content_format::from_str("application/json").unwrap()),
             b"",
         );
         let response = handle_heap(&mut handler, &request);
@@ -378,19 +378,16 @@ mod coap_handler {
     #[test]
     fn can_own_settings() {
         init_host_logging();
-        use coap_handler_implementations::HandlerBuilder as _;
-
         let miniconf = MiniconfHandler::<Settings, Settings, ConstPathJson>::const_path_json(
             Settings::default(),
         );
-        let mut handler =
-            coap_handler_implementations::new_dispatcher().below(&["settings"], miniconf);
+        let mut handler = new_dispatcher().below(&["settings"], miniconf);
 
         let mut request = heap_request(code::PUT, &["settings", "number"], None, br#"31"#);
         request
             .add_option_uint(
-                coap_numbers::option::CONTENT_FORMAT,
-                content_format("application/json"),
+                option::CONTENT_FORMAT,
+                content_format::from_str("application/json").unwrap(),
             )
             .unwrap();
         let response = handle_heap(&mut handler, &request);
@@ -399,7 +396,7 @@ mod coap_handler {
         let request = heap_request(
             code::GET,
             &["settings", "number"],
-            Some(content_format("application/json")),
+            Some(content_format::from_str("application/json").unwrap()),
             b"",
         );
         let response = handle_heap(&mut handler, &request);
@@ -417,13 +414,18 @@ mod coap_handler {
         assert_eq!(&response[..4], [0x60, code::CONTENT, 0x12, 0x34]);
         assert_eq!(
             &response[4..],
-            [0xc1, content_format("application/json") as u8, 0xff, b'7']
+            [
+                0xc1,
+                content_format::from_str("application/json").unwrap() as u8,
+                0xff,
+                b'7'
+            ]
         );
 
         let put_number = Packet::put(0x1235)
             .uri_path("settings")
             .uri_path("number")
-            .content_format(content_format("application/json"))
+            .content_format(content_format::from_str("application/json").unwrap())
             .payload(b"23");
         let response = handle_packet_with_coap_handler(&put_number, &mut settings);
         assert_eq!(response, [0x60, code::CHANGED, 0x12, 0x35]);
@@ -436,8 +438,7 @@ mod coap_handler {
 
         let mut code = 0;
         let mut tail = [0; 512];
-        let mut message =
-            coap_message_implementations::inmemory_write::Message::new(&mut code, &mut tail);
+        let mut message = inmemory_write::Message::new(&mut code, &mut tail);
 
         match handler.extract_request_data(&request.message) {
             Ok(data) => handler.build_response(&mut message, data).unwrap(),
@@ -451,9 +452,7 @@ mod coap_handler {
     fn demo_handler(
         settings: &mut Settings,
     ) -> impl coap_handler::Handler + coap_handler::Reporting + '_ {
-        use coap_handler_implementations::{HandlerBuilder as _, ReportingHandlerBuilder as _};
-
-        coap_handler_implementations::new_dispatcher()
+        new_dispatcher()
             .below(
                 &["settings"],
                 ConstPathJsonCoapHandler::const_path_json(settings),
@@ -461,9 +460,9 @@ mod coap_handler {
             .at(&["schema"], MiniconfSchemaHandler::<Settings>::json())
             .at(
                 &["status"],
-                coap_handler_implementations::SimpleRendered::new_typed_str(
+                SimpleRendered::new_typed_str(
                     r#"{"ok":true}"#,
-                    Some(content_format("application/json")),
+                    Some(content_format::from_str("application/json").unwrap()),
                 ),
             )
             .with_wkc()
@@ -473,14 +472,10 @@ mod coap_handler {
         let mut request = HeapMessage::new();
         request.set_code(code);
         for segment in path {
-            request
-                .add_option_str(coap_numbers::option::URI_PATH, segment)
-                .unwrap();
+            request.add_option_str(option::URI_PATH, segment).unwrap();
         }
         if let Some(accept) = accept {
-            request
-                .add_option_uint(coap_numbers::option::ACCEPT, accept)
-                .unwrap();
+            request.add_option_uint(option::ACCEPT, accept).unwrap();
         }
         request.set_payload(payload).unwrap();
         request
@@ -489,8 +484,8 @@ mod coap_handler {
     fn handle_heap<H>(handler: &mut H, request: &HeapMessage) -> HeapMessage
     where
         H: coap_handler::Handler,
-        H::ExtractRequestError: core::fmt::Debug,
-        H::BuildResponseError<HeapMessage>: core::fmt::Debug,
+        H::ExtractRequestError: fmt::Debug,
+        H::BuildResponseError<HeapMessage>: fmt::Debug,
     {
         let data = handler.extract_request_data(request).unwrap();
         let mut response = HeapMessage::new();
@@ -528,15 +523,15 @@ impl Packet {
     }
 
     fn uri_path(self, segment: &str) -> Self {
-        self.option(coap_numbers::option::URI_PATH, segment.as_bytes())
+        self.option(option::URI_PATH, segment.as_bytes())
     }
 
     fn accept(self, content_format: u16) -> Self {
-        self.uint_option(coap_numbers::option::ACCEPT, content_format)
+        self.uint_option(option::ACCEPT, content_format)
     }
 
     fn content_format(self, content_format: u16) -> Self {
-        self.uint_option(coap_numbers::option::CONTENT_FORMAT, content_format)
+        self.uint_option(option::CONTENT_FORMAT, content_format)
     }
 
     fn uint_option(self, number: u16, value: u16) -> Self {

--- a/miniconf_coap/tests/packet_routes.rs
+++ b/miniconf_coap/tests/packet_routes.rs
@@ -8,6 +8,7 @@ use miniconf_coap::{Outcome, Response};
 #[derive(Tree)]
 struct Settings {
     hidden: bool,
+    #[tree(meta(title = "Demo number"))]
     number: u32,
     #[tree(with = label)]
     label: heapless::String<16>,
@@ -276,7 +277,7 @@ mod coap_handler {
             Some(LINK_FORMAT_CONTENT_FORMAT)
         );
         let payload = core::str::from_utf8(response.payload()).unwrap();
-        assert!(payload.contains("</settings/number>;ct=50"));
+        assert!(payload.contains("</settings/number>;ct=50;title=\"Demo number\""));
         assert!(!payload.contains("rt=\"miniconf.leaf\""));
         assert!(payload.contains("</schema>;ct=0;rt=\"miniconf.schema\""));
         assert!(payload.contains("</status>"));

--- a/miniconf_coap/tests/packet_routes.rs
+++ b/miniconf_coap/tests/packet_routes.rs
@@ -120,9 +120,20 @@ mod json {
         let packet = handle_json_packet(&schema, &mut settings);
         let response = WirePacket::parse(&packet).unwrap();
         assert_eq!(response.message.code(), code::CONTENT);
+        assert!(
+            response
+                .message
+                .payload()
+                .starts_with(br#"{"proto":1,"epoch":0,"schema_rev":"#)
+        );
+
+        let schema_page = Packet::get(0x1238).uri_path("schema").uri_path("0");
+        let packet = handle_json_packet(&schema_page, &mut settings);
+        let response = WirePacket::parse(&packet).unwrap();
+        assert_eq!(response.message.code(), code::CONTENT);
         assert!(response.message.payload().starts_with(b"{"));
 
-        let status = Packet::get(0x1238).uri_path("status");
+        let status = Packet::get(0x1239).uri_path("status");
         let packet = handle_json_packet(&status, &mut settings);
         let response = WirePacket::parse(&packet).unwrap();
         assert_eq!(response.message.code(), code::CONTENT);
@@ -144,6 +155,9 @@ mod json {
     ) -> Outcome<'a> {
         match request.path() {
             "/schema" => SchemaHandler::new("/schema").handle::<Settings>(request, response_buf),
+            path if path.starts_with("/schema/") => {
+                SchemaHandler::new("/schema").handle::<Settings>(request, response_buf)
+            }
             "/settings" => settings_route(request, settings, response_buf),
             path if path.starts_with("/settings/") => {
                 settings_route(request, settings, response_buf)
@@ -343,7 +357,7 @@ mod coap_handler {
         let payload = core::str::from_utf8(response.payload()).unwrap();
         assert!(payload.contains("</settings/number>;ct=50;title=\"Demo number\""));
         assert!(!payload.contains("rt=\"miniconf.leaf\""));
-        assert!(payload.contains("</schema>;ct=0;rt=\"miniconf.schema\""));
+        assert!(payload.contains("</schema>;ct=50;rt=\"miniconf.schema\""));
         assert!(payload.contains("</status>"));
     }
 
@@ -422,13 +436,43 @@ mod coap_handler {
             ]
         );
 
-        let put_number = Packet::put(0x1235)
+        let schema_manifest = Packet::get(0x1235).uri_path("schema");
+        let response = handle_packet_with_coap_handler(&schema_manifest, &mut settings);
+        let response = WirePacket::parse(&response).unwrap();
+        assert_eq!(response.message.code(), code::CONTENT);
+        assert!(
+            response
+                .message
+                .payload()
+                .starts_with(br#"{"proto":1,"epoch":0,"schema_rev":"#)
+        );
+
+        let schema_page = Packet::get(0x1236).uri_path("schema").uri_path("0");
+        let response = handle_packet_with_coap_handler(&schema_page, &mut settings);
+        let response = WirePacket::parse(&response).unwrap();
+        assert_eq!(response.message.code(), code::CONTENT);
+        assert!(response.message.payload().starts_with(b"{"));
+
+        let put_number = Packet::put(0x1237)
             .uri_path("settings")
             .uri_path("number")
             .content_format(content_format::from_str("application/json").unwrap())
             .payload(b"23");
         let response = handle_packet_with_coap_handler(&put_number, &mut settings);
-        assert_eq!(response, [0x60, code::CHANGED, 0x12, 0x35]);
+        assert_eq!(response, [0x60, code::CHANGED, 0x12, 0x37]);
+        assert_eq!(settings.number, 23);
+
+        let bad_put = Packet::put(0x1238)
+            .uri_path("settings")
+            .uri_path("number")
+            .payload(b"24");
+        let response = handle_packet_with_coap_handler(&bad_put, &mut settings);
+        let response = WirePacket::parse(&response).unwrap();
+        assert_eq!(response.message.code(), code::UNSUPPORTED_CONTENT_FORMAT);
+        assert_eq!(
+            response.message.payload(),
+            br#"{"kind":"unsupported_content_format"}"#
+        );
         assert_eq!(settings.number, 23);
     }
 
@@ -457,7 +501,7 @@ mod coap_handler {
                 &["settings"],
                 ConstPathJsonCoapHandler::const_path_json(settings),
             )
-            .at(&["schema"], MiniconfSchemaHandler::<Settings>::json())
+            .below(&["schema"], MiniconfSchemaHandler::<Settings>::json())
             .at(
                 &["status"],
                 SimpleRendered::new_typed_str(

--- a/miniconf_coap/tests/packet_routes.rs
+++ b/miniconf_coap/tests/packet_routes.rs
@@ -1,34 +1,33 @@
-#![cfg(feature = "json-core")]
+#![cfg(any(feature = "json-core", feature = "cbor"))]
 
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 use coap_handler::Handler as _;
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 use coap_message::MessageOption;
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 use coap_message::MinimalWritableMessage as _;
+#[cfg(feature = "json-core")]
 use coap_message::ReadableMessage;
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 use coap_message::error::RenderableOnMinimal as _;
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 use coap_message_implementations::heap::HeapMessage;
 use coap_message_implementations::{inmemory, inmemory_write};
 use coap_numbers::code;
 use miniconf::Tree;
-#[cfg(feature = "postcard")]
-use miniconf::{Packed, TreeSchema};
-#[cfg(feature = "postcard")]
-use miniconf_coap::PackedPostcardHandler;
-#[cfg(feature = "coap-handler")]
+#[cfg(feature = "cbor")]
+use miniconf_coap::{CBOR_CONTENT_FORMAT, ConstPathCborHandler};
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 use miniconf_coap::{
     ConstPathJson, ConstPathJsonCoapHandler, LINK_FORMAT_CONTENT_FORMAT, MiniconfHandler,
     MiniconfSchemaHandler,
 };
+#[cfg(feature = "json-core")]
 use miniconf_coap::{
     ConstPathJsonHandler, JSON_CONTENT_FORMAT, Outcome, RequestParts, Response, SchemaHandler,
 };
-
-#[cfg(feature = "postcard")]
-const POSTCARD_CONTENT_FORMAT: u16 = 42;
+#[cfg(all(feature = "cbor", not(feature = "json-core")))]
+use miniconf_coap::{Outcome, RequestParts, Response};
 
 #[derive(Tree)]
 struct Settings {
@@ -85,6 +84,7 @@ mod label {
 }
 
 #[test]
+#[cfg(feature = "json-core")]
 fn const_path_json_packet_routes_compose_with_user_routes() {
     init_host_logging();
     let mut settings = Settings::default();
@@ -143,19 +143,17 @@ fn const_path_json_packet_routes_compose_with_user_routes() {
     assert_eq!(response.message.payload(), br#"{"ok":true}"#);
 }
 
-#[cfg(feature = "postcard")]
+#[cfg(feature = "cbor")]
 #[test]
-fn packed_postcard_packet_route_reads_and_writes() {
+fn const_path_cbor_packet_route_reads_and_writes() {
     init_host_logging();
     let mut settings = Settings::default();
-    let number_key = number_packed_key();
-    let key = number_key.to_string();
 
     let get_number = Packet::get(0x1239)
         .uri_path("settings")
-        .uri_path(&key)
-        .accept(POSTCARD_CONTENT_FORMAT);
-    let response = handle_packet(&get_number, &mut settings, RouteMode::Postcard);
+        .uri_path("number")
+        .accept(CBOR_CONTENT_FORMAT);
+    let response = handle_packet(&get_number, &mut settings, RouteMode::Cbor);
     assert_eq!(
         response,
         [
@@ -164,23 +162,23 @@ fn packed_postcard_packet_route_reads_and_writes() {
             0x12,
             0x39, // ACK 2.05 Content
             0xc1,
-            POSTCARD_CONTENT_FORMAT as u8, // Content-Format
+            CBOR_CONTENT_FORMAT as u8, // Content-Format: application/cbor
             0xff,
-            7, // postcard u32 varint
+            7, // CBOR u32
         ]
     );
 
     let put_number = Packet::put(0x123a)
         .uri_path("settings")
-        .uri_path(&key)
-        .content_format(POSTCARD_CONTENT_FORMAT)
+        .uri_path("number")
+        .content_format(CBOR_CONTENT_FORMAT)
         .payload(&[21]);
-    let response = handle_packet(&put_number, &mut settings, RouteMode::Postcard);
+    let response = handle_packet(&put_number, &mut settings, RouteMode::Cbor);
     assert_eq!(response, [0x60, 0x44, 0x12, 0x3a]); // ACK 2.04 Changed
     assert_eq!(settings.number, 21);
 }
 
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 #[test]
 fn coap_handler_reports_and_serves_well_known_core() {
     init_host_logging();
@@ -207,7 +205,7 @@ fn coap_handler_reports_and_serves_well_known_core() {
     assert!(payload.contains("</status>"));
 }
 
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 #[test]
 fn coap_handler_serves_values_beside_user_routes() {
     init_host_logging();
@@ -231,7 +229,7 @@ fn coap_handler_serves_values_beside_user_routes() {
     assert_eq!(response.payload(), br#"{"ok":true}"#);
 }
 
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 #[test]
 fn coap_handler_can_own_settings() {
     init_host_logging();
@@ -259,7 +257,7 @@ fn coap_handler_can_own_settings() {
     assert_eq!(response.payload(), b"31");
 }
 
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 #[test]
 fn coap_handler_routes_binary_packets() {
     init_host_logging();
@@ -355,9 +353,10 @@ impl core::ops::Deref for Packet {
 
 #[derive(Clone, Copy)]
 enum RouteMode {
+    #[cfg(feature = "json-core")]
     Json,
-    #[cfg(feature = "postcard")]
-    Postcard,
+    #[cfg(feature = "cbor")]
+    Cbor,
 }
 
 fn handle_packet(packet: &[u8], settings: &mut Settings, mode: RouteMode) -> Vec<u8> {
@@ -378,7 +377,7 @@ fn handle_packet(packet: &[u8], settings: &mut Settings, mode: RouteMode) -> Vec
     encode_ack(code, request.message_id, request.token, &tail[..tail_len])
 }
 
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 fn handle_packet_with_coap_handler(packet: &[u8], settings: &mut Settings) -> Vec<u8> {
     let request = WirePacket::parse(packet).unwrap();
     let mut handler = demo_handler(settings);
@@ -396,7 +395,7 @@ fn handle_packet_with_coap_handler(packet: &[u8], settings: &mut Settings) -> Ve
     encode_ack(code, request.message_id, request.token, &tail[..tail_len])
 }
 
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 fn demo_handler(
     settings: &mut Settings,
 ) -> impl coap_handler::Handler + coap_handler::Reporting + '_ {
@@ -424,6 +423,7 @@ fn route<'a>(
     response_buf: &'a mut [u8],
     mode: RouteMode,
 ) -> Outcome<'a> {
+    #[cfg(feature = "json-core")]
     match request.path() {
         "/schema" => SchemaHandler::new("/schema").handle::<Settings>(request, response_buf),
         "/settings" => settings_route(request, settings, response_buf, mode),
@@ -435,6 +435,14 @@ fn route<'a>(
             content_format: Some(JSON_CONTENT_FORMAT),
             payload: br#"{"ok":true}"#,
         }),
+        _ => Outcome::Unhandled,
+    }
+    #[cfg(not(feature = "json-core"))]
+    match request.path() {
+        "/settings" => settings_route(request, settings, response_buf, mode),
+        path if path.starts_with("/settings/") => {
+            settings_route(request, settings, response_buf, mode)
+        }
         _ => Outcome::Unhandled,
     }
 }
@@ -456,17 +464,18 @@ fn settings_route<'a>(
     mode: RouteMode,
 ) -> Outcome<'a> {
     match mode {
+        #[cfg(feature = "json-core")]
         RouteMode::Json => ConstPathJsonHandler::const_path_json("/settings").handle(
             request,
             settings,
             response_buf,
         ),
-        #[cfg(feature = "postcard")]
-        RouteMode::Postcard => PackedPostcardHandler::packed_postcard(
-            "/settings",
-            POSTCARD_CONTENT_FORMAT,
-        )
-        .handle(request, settings, response_buf),
+        #[cfg(feature = "cbor")]
+        RouteMode::Cbor => ConstPathCborHandler::const_path_cbor("/settings").handle(
+            request,
+            settings,
+            response_buf,
+        ),
     }
 }
 
@@ -497,17 +506,6 @@ impl<'a> WirePacket<'a> {
     }
 }
 
-#[cfg(feature = "postcard")]
-fn number_packed_key() -> usize {
-    Settings::SCHEMA
-        .nodes::<Packed, { miniconf_coap::MAX_DEPTH }>()
-        .nth(1)
-        .unwrap()
-        .unwrap()
-        .into_lsb()
-        .get()
-}
-
 fn init_host_logging() {
     static HOST_LOGGING: std::sync::OnceLock<()> = std::sync::OnceLock::new();
 
@@ -517,7 +515,7 @@ fn init_host_logging() {
     });
 }
 
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 fn heap_request(code: u8, path: &[&str], accept: Option<u16>, payload: &[u8]) -> HeapMessage {
     let mut request = HeapMessage::new();
     request.set_code(code);
@@ -535,7 +533,7 @@ fn heap_request(code: u8, path: &[&str], accept: Option<u16>, payload: &[u8]) ->
     request
 }
 
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 fn handle_heap<H>(handler: &mut H, request: &HeapMessage) -> HeapMessage
 where
     H: coap_handler::Handler,
@@ -548,7 +546,7 @@ where
     response
 }
 
-#[cfg(feature = "coap-handler")]
+#[cfg(all(feature = "coap-handler", feature = "json-core"))]
 fn first_uint_option(message: &HeapMessage, number: u16) -> Option<u16> {
     message
         .options()

--- a/miniconf_coap/tests/packet_routes.rs
+++ b/miniconf_coap/tests/packet_routes.rs
@@ -200,7 +200,8 @@ fn coap_handler_reports_and_serves_well_known_core() {
         Some(LINK_FORMAT_CONTENT_FORMAT)
     );
     let payload = core::str::from_utf8(response.payload()).unwrap();
-    assert!(payload.contains("</settings/number>;ct=50;rt=\"miniconf.leaf\""));
+    assert!(payload.contains("</settings/number>;ct=50"));
+    assert!(!payload.contains("rt=\"miniconf.leaf\""));
     assert!(payload.contains("</schema>;ct=0;rt=\"miniconf.schema\""));
     assert!(payload.contains("</status>"));
 }

--- a/miniconf_coap/tests/packet_routes.rs
+++ b/miniconf_coap/tests/packet_routes.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "json")]
+#![cfg(feature = "json-core")]
 
 #[cfg(feature = "coap-handler")]
 use coap_handler::Handler as _;
@@ -203,7 +203,7 @@ fn coap_handler_reports_and_serves_well_known_core() {
     );
     let payload = core::str::from_utf8(response.payload()).unwrap();
     assert!(payload.contains("</settings/number>;ct=50;rt=\"miniconf.leaf\""));
-    assert!(payload.contains("</schema>;ct=50;rt=\"miniconf.schema\""));
+    assert!(payload.contains("</schema>;ct=0;rt=\"miniconf.schema\""));
     assert!(payload.contains("</status>"));
 }
 

--- a/miniconf_coap/tests/packet_routes.rs
+++ b/miniconf_coap/tests/packet_routes.rs
@@ -1,32 +1,9 @@
 #![cfg(any(feature = "json-core", feature = "cbor"))]
 
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-use coap_handler::Handler as _;
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-use coap_message::MessageOption;
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-use coap_message::MinimalWritableMessage as _;
-use coap_message::ReadableMessage;
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-use coap_message::error::RenderableOnMinimal as _;
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-use coap_message_implementations::heap::HeapMessage;
 use coap_message_implementations::{inmemory, inmemory_write};
 use coap_numbers::code;
 use miniconf::Tree;
-#[cfg(feature = "cbor")]
-use miniconf_coap::{CBOR_CONTENT_FORMAT, ConstPathCborHandler};
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-use miniconf_coap::{
-    ConstPathJson, ConstPathJsonCoapHandler, LINK_FORMAT_CONTENT_FORMAT, MiniconfHandler,
-    MiniconfSchemaHandler,
-};
-#[cfg(feature = "json-core")]
-use miniconf_coap::{
-    ConstPathJsonHandler, JSON_CONTENT_FORMAT, Outcome, RequestParts, Response, SchemaHandler,
-};
-#[cfg(all(feature = "cbor", not(feature = "json-core")))]
-use miniconf_coap::{Outcome, RequestParts, Response};
+use miniconf_coap::{Outcome, Response};
 
 #[derive(Tree)]
 struct Settings {
@@ -82,214 +59,378 @@ mod label {
     }
 }
 
-#[test]
 #[cfg(feature = "json-core")]
-fn const_path_json_packet_routes_compose_with_user_routes() {
-    init_host_logging();
-    let mut settings = Settings::default();
+mod json {
+    use coap_message::ReadableMessage as _;
+    use coap_numbers::code;
+    use miniconf_coap::{ConstPathJsonHandler, JSON_CONTENT_FORMAT, Outcome, SchemaHandler};
 
-    let get_number = Packet::get(0x1234)
-        .uri_path("settings")
-        .uri_path("number")
-        .accept(JSON_CONTENT_FORMAT);
-    let response = handle_packet(&get_number, &mut settings, RouteMode::Json);
-    assert_eq!(
-        response,
-        [
-            0x60,
-            0x45,
-            0x12,
-            0x34, // ACK 2.05 Content
-            0xc1,
-            JSON_CONTENT_FORMAT as u8, // Content-Format: application/json
-            0xff,
-            b'7',
-        ]
-    );
+    use crate::{Packet, Settings, WirePacket, init_host_logging, response_packet};
 
-    let put_label = Packet::put(0x1235)
-        .uri_path("settings")
-        .uri_path("label")
-        .content_format(JSON_CONTENT_FORMAT)
-        .payload(br#""good""#);
-    let response = handle_packet(&put_label, &mut settings, RouteMode::Json);
-    assert_eq!(response, [0x60, 0x44, 0x12, 0x35]); // ACK 2.04 Changed
-    assert_eq!(settings.label.as_str(), "good");
+    #[test]
+    fn const_path_json_packet_routes_compose_with_user_routes() {
+        init_host_logging();
+        let mut settings = Settings::default();
 
-    settings.visible = None;
-    let absent = Packet::get(0x1236)
-        .uri_path("settings")
-        .uri_path("visible")
-        .uri_path("value");
-    let response = handle_packet(&absent, &mut settings, RouteMode::Json);
-    let response = WirePacket::parse(&response).unwrap();
-    assert_eq!(response.message.code(), code::CONFLICT);
-    assert_eq!(
-        response.message.payload(),
-        br#"{"kind":"absent","depth":2}"#
-    );
+        let get_number = Packet::get(0x1234)
+            .uri_path("settings")
+            .uri_path("number")
+            .accept(JSON_CONTENT_FORMAT);
+        let response = handle_json_packet(&get_number, &mut settings);
+        assert_eq!(
+            response,
+            [
+                0x60,
+                0x45,
+                0x12,
+                0x34,
+                0xc1,
+                JSON_CONTENT_FORMAT as u8,
+                0xff,
+                b'7',
+            ]
+        );
 
-    let schema = Packet::get(0x1237).uri_path("schema");
-    let packet = handle_packet(&schema, &mut settings, RouteMode::Json);
-    let response = WirePacket::parse(&packet).unwrap();
-    assert_eq!(response.message.code(), code::CONTENT);
-    assert!(response.message.payload().starts_with(b"{"));
+        let put_label = Packet::put(0x1235)
+            .uri_path("settings")
+            .uri_path("label")
+            .content_format(JSON_CONTENT_FORMAT)
+            .payload(br#""good""#);
+        let response = handle_json_packet(&put_label, &mut settings);
+        assert_eq!(response, [0x60, 0x44, 0x12, 0x35]);
+        assert_eq!(settings.label.as_str(), "good");
 
-    let status = Packet::get(0x1238).uri_path("status");
-    let packet = handle_packet(&status, &mut settings, RouteMode::Json);
-    let response = WirePacket::parse(&packet).unwrap();
-    assert_eq!(response.message.code(), code::CONTENT);
-    assert_eq!(response.message.payload(), br#"{"ok":true}"#);
+        settings.visible = None;
+        let absent = Packet::get(0x1236)
+            .uri_path("settings")
+            .uri_path("visible")
+            .uri_path("value");
+        let response = handle_json_packet(&absent, &mut settings);
+        let response = WirePacket::parse(&response).unwrap();
+        assert_eq!(response.message.code(), code::CONFLICT);
+        assert_eq!(
+            response.message.payload(),
+            br#"{"kind":"absent","depth":2}"#
+        );
+
+        let schema = Packet::get(0x1237).uri_path("schema");
+        let packet = handle_json_packet(&schema, &mut settings);
+        let response = WirePacket::parse(&packet).unwrap();
+        assert_eq!(response.message.code(), code::CONTENT);
+        assert!(response.message.payload().starts_with(b"{"));
+
+        let status = Packet::get(0x1238).uri_path("status");
+        let packet = handle_json_packet(&status, &mut settings);
+        let response = WirePacket::parse(&packet).unwrap();
+        assert_eq!(response.message.code(), code::CONTENT);
+        assert_eq!(response.message.payload(), br#"{"ok":true}"#);
+    }
+
+    pub fn handle_json_packet(packet: &[u8], settings: &mut Settings) -> Vec<u8> {
+        let request = WirePacket::parse(packet).unwrap();
+        let parts = miniconf_coap::RequestParts::from_message(&request.message).unwrap();
+        let mut response_buf = [0; 512];
+        let outcome = route(&parts, settings, &mut response_buf);
+        response_packet(&request, outcome)
+    }
+
+    fn route<'a>(
+        request: &miniconf_coap::RequestParts<'_>,
+        settings: &mut Settings,
+        response_buf: &'a mut [u8],
+    ) -> Outcome<'a> {
+        match request.path() {
+            "/schema" => SchemaHandler::new("/schema").handle::<Settings>(request, response_buf),
+            "/settings" => settings_route(request, settings, response_buf),
+            path if path.starts_with("/settings/") => {
+                settings_route(request, settings, response_buf)
+            }
+            "/status" => Outcome::Handled(miniconf_coap::Response {
+                code: code::CONTENT,
+                content_format: Some(JSON_CONTENT_FORMAT),
+                payload: br#"{"ok":true}"#,
+            }),
+            _ => Outcome::Unhandled,
+        }
+    }
+
+    fn settings_route<'a>(
+        request: &miniconf_coap::RequestParts<'_>,
+        settings: &mut Settings,
+        response_buf: &'a mut [u8],
+    ) -> Outcome<'a> {
+        ConstPathJsonHandler::const_path_json("/settings").handle(request, settings, response_buf)
+    }
 }
 
 #[cfg(feature = "cbor")]
-#[test]
-fn const_path_cbor_packet_route_reads_and_writes() {
-    init_host_logging();
-    let mut settings = Settings::default();
+mod cbor {
+    use coap_message::ReadableMessage as _;
+    use coap_numbers::code;
+    use miniconf_coap::{CBOR_CONTENT_FORMAT, ConstPathCborHandler, Outcome};
 
-    let get_number = Packet::get(0x1239)
-        .uri_path("settings")
-        .uri_path("number")
-        .accept(CBOR_CONTENT_FORMAT);
-    let response = handle_packet(&get_number, &mut settings, RouteMode::Cbor);
-    assert_eq!(
-        response,
-        [
-            0x60,
-            0x45,
-            0x12,
-            0x39, // ACK 2.05 Content
-            0xc1,
-            CBOR_CONTENT_FORMAT as u8, // Content-Format: application/cbor
-            0xff,
-            7, // CBOR u32
-        ]
-    );
+    use crate::{Packet, Settings, WirePacket, init_host_logging, response_packet};
 
-    let put_number = Packet::put(0x123a)
-        .uri_path("settings")
-        .uri_path("number")
-        .content_format(CBOR_CONTENT_FORMAT)
-        .payload(&[21]);
-    let response = handle_packet(&put_number, &mut settings, RouteMode::Cbor);
-    assert_eq!(response, [0x60, 0x44, 0x12, 0x3a]); // ACK 2.04 Changed
-    assert_eq!(settings.number, 21);
+    #[test]
+    fn const_path_cbor_packet_route_reads_and_writes() {
+        init_host_logging();
+        let mut settings = Settings::default();
 
-    let trailing = Packet::put(0x123b)
-        .uri_path("settings")
-        .uri_path("number")
-        .content_format(CBOR_CONTENT_FORMAT)
-        .payload(&[22, 0]);
-    let response = handle_packet(&trailing, &mut settings, RouteMode::Cbor);
-    let response = WirePacket::parse(&response).unwrap();
-    assert_eq!(response.message.code(), code::BAD_REQUEST);
-    assert_eq!(response.message.payload(), br#"{"kind":"bad_payload"}"#);
-    assert_eq!(settings.number, 21);
+        let get_number = Packet::get(0x1239)
+            .uri_path("settings")
+            .uri_path("number")
+            .accept(CBOR_CONTENT_FORMAT);
+        let response = handle_cbor_packet(&get_number, &mut settings);
+        assert_eq!(
+            response,
+            [
+                0x60,
+                0x45,
+                0x12,
+                0x39,
+                0xc1,
+                CBOR_CONTENT_FORMAT as u8,
+                0xff,
+                7,
+            ]
+        );
+
+        let put_number = Packet::put(0x123a)
+            .uri_path("settings")
+            .uri_path("number")
+            .content_format(CBOR_CONTENT_FORMAT)
+            .payload(&[21]);
+        let response = handle_cbor_packet(&put_number, &mut settings);
+        assert_eq!(response, [0x60, 0x44, 0x12, 0x3a]);
+        assert_eq!(settings.number, 21);
+
+        let trailing = Packet::put(0x123b)
+            .uri_path("settings")
+            .uri_path("number")
+            .content_format(CBOR_CONTENT_FORMAT)
+            .payload(&[22, 0]);
+        let response = handle_cbor_packet(&trailing, &mut settings);
+        let response = WirePacket::parse(&response).unwrap();
+        assert_eq!(response.message.code(), code::BAD_REQUEST);
+        assert_eq!(response.message.payload(), br#"{"kind":"bad_payload"}"#);
+        assert_eq!(settings.number, 21);
+    }
+
+    fn handle_cbor_packet(packet: &[u8], settings: &mut Settings) -> Vec<u8> {
+        let request = WirePacket::parse(packet).unwrap();
+        let parts = miniconf_coap::RequestParts::from_message(&request.message).unwrap();
+        let mut response_buf = [0; 512];
+        let outcome = match parts.path() {
+            "/settings" => settings_route(&parts, settings, &mut response_buf),
+            path if path.starts_with("/settings/") => {
+                settings_route(&parts, settings, &mut response_buf)
+            }
+            _ => Outcome::Unhandled,
+        };
+        response_packet(&request, outcome)
+    }
+
+    fn settings_route<'a>(
+        request: &miniconf_coap::RequestParts<'_>,
+        settings: &mut Settings,
+        response_buf: &'a mut [u8],
+    ) -> Outcome<'a> {
+        ConstPathCborHandler::const_path_cbor("/settings").handle(request, settings, response_buf)
+    }
 }
 
 #[cfg(all(feature = "coap-handler", feature = "json-core"))]
-#[test]
-fn coap_handler_reports_and_serves_well_known_core() {
-    init_host_logging();
+mod coap_handler {
+    use coap_handler::Handler as _;
+    use coap_message::{
+        MessageOption, MinimalWritableMessage as _, ReadableMessage as _,
+        error::RenderableOnMinimal as _,
+    };
+    use coap_message_implementations::heap::HeapMessage;
+    use coap_numbers::code;
+    use miniconf_coap::{
+        ConstPathJson, ConstPathJsonCoapHandler, JSON_CONTENT_FORMAT, LINK_FORMAT_CONTENT_FORMAT,
+        MiniconfHandler, MiniconfSchemaHandler,
+    };
 
-    let mut settings = Settings::default();
-    let mut handler = demo_handler(&mut settings);
+    use crate::{Packet, Settings, WirePacket, encode_ack, init_host_logging};
 
-    let request = heap_request(
-        code::GET,
-        &[".well-known", "core"],
-        Some(LINK_FORMAT_CONTENT_FORMAT),
-        b"",
-    );
-    let response = handle_heap(&mut handler, &request);
+    #[test]
+    fn reports_and_serves_well_known_core() {
+        init_host_logging();
 
-    assert_eq!(response.code(), code::CONTENT);
-    assert_eq!(
-        first_uint_option(&response, coap_numbers::option::CONTENT_FORMAT),
-        Some(LINK_FORMAT_CONTENT_FORMAT)
-    );
-    let payload = core::str::from_utf8(response.payload()).unwrap();
-    assert!(payload.contains("</settings/number>;ct=50"));
-    assert!(!payload.contains("rt=\"miniconf.leaf\""));
-    assert!(payload.contains("</schema>;ct=0;rt=\"miniconf.schema\""));
-    assert!(payload.contains("</status>"));
-}
+        let mut settings = Settings::default();
+        let mut handler = demo_handler(&mut settings);
 
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-#[test]
-fn coap_handler_serves_values_beside_user_routes() {
-    init_host_logging();
+        let request = heap_request(
+            code::GET,
+            &[".well-known", "core"],
+            Some(LINK_FORMAT_CONTENT_FORMAT),
+            b"",
+        );
+        let response = handle_heap(&mut handler, &request);
 
-    let mut settings = Settings::default();
-    let mut handler = demo_handler(&mut settings);
+        assert_eq!(response.code(), code::CONTENT);
+        assert_eq!(
+            first_uint_option(&response, coap_numbers::option::CONTENT_FORMAT),
+            Some(LINK_FORMAT_CONTENT_FORMAT)
+        );
+        let payload = core::str::from_utf8(response.payload()).unwrap();
+        assert!(payload.contains("</settings/number>;ct=50"));
+        assert!(!payload.contains("rt=\"miniconf.leaf\""));
+        assert!(payload.contains("</schema>;ct=0;rt=\"miniconf.schema\""));
+        assert!(payload.contains("</status>"));
+    }
 
-    let request = heap_request(
-        code::GET,
-        &["settings", "number"],
-        Some(JSON_CONTENT_FORMAT),
-        b"",
-    );
-    let response = handle_heap(&mut handler, &request);
-    assert_eq!(response.code(), code::CONTENT);
-    assert_eq!(response.payload(), b"7");
+    #[test]
+    fn serves_values_beside_user_routes() {
+        init_host_logging();
 
-    let request = heap_request(code::GET, &["status"], Some(JSON_CONTENT_FORMAT), b"");
-    let response = handle_heap(&mut handler, &request);
-    assert_eq!(response.code(), code::CONTENT);
-    assert_eq!(response.payload(), br#"{"ok":true}"#);
-}
+        let mut settings = Settings::default();
+        let mut handler = demo_handler(&mut settings);
 
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-#[test]
-fn coap_handler_can_own_settings() {
-    init_host_logging();
-    use coap_handler_implementations::HandlerBuilder as _;
+        let request = heap_request(
+            code::GET,
+            &["settings", "number"],
+            Some(JSON_CONTENT_FORMAT),
+            b"",
+        );
+        let response = handle_heap(&mut handler, &request);
+        assert_eq!(response.code(), code::CONTENT);
+        assert_eq!(response.payload(), b"7");
 
-    let miniconf =
-        MiniconfHandler::<Settings, Settings, ConstPathJson>::const_path_json(Settings::default());
-    let mut handler = coap_handler_implementations::new_dispatcher().below(&["settings"], miniconf);
+        let request = heap_request(code::GET, &["status"], Some(JSON_CONTENT_FORMAT), b"");
+        let response = handle_heap(&mut handler, &request);
+        assert_eq!(response.code(), code::CONTENT);
+        assert_eq!(response.payload(), br#"{"ok":true}"#);
+    }
 
-    let mut request = heap_request(code::PUT, &["settings", "number"], None, br#"31"#);
-    request
-        .add_option_uint(coap_numbers::option::CONTENT_FORMAT, JSON_CONTENT_FORMAT)
-        .unwrap();
-    let response = handle_heap(&mut handler, &request);
-    assert_eq!(response.code(), code::CHANGED);
+    #[test]
+    fn can_own_settings() {
+        init_host_logging();
+        use coap_handler_implementations::HandlerBuilder as _;
 
-    let request = heap_request(
-        code::GET,
-        &["settings", "number"],
-        Some(JSON_CONTENT_FORMAT),
-        b"",
-    );
-    let response = handle_heap(&mut handler, &request);
-    assert_eq!(response.code(), code::CONTENT);
-    assert_eq!(response.payload(), b"31");
-}
+        let miniconf = MiniconfHandler::<Settings, Settings, ConstPathJson>::const_path_json(
+            Settings::default(),
+        );
+        let mut handler =
+            coap_handler_implementations::new_dispatcher().below(&["settings"], miniconf);
 
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-#[test]
-fn coap_handler_routes_binary_packets() {
-    init_host_logging();
-    let mut settings = Settings::default();
+        let mut request = heap_request(code::PUT, &["settings", "number"], None, br#"31"#);
+        request
+            .add_option_uint(coap_numbers::option::CONTENT_FORMAT, JSON_CONTENT_FORMAT)
+            .unwrap();
+        let response = handle_heap(&mut handler, &request);
+        assert_eq!(response.code(), code::CHANGED);
 
-    let get_number = Packet::get(0x1234).uri_path("settings").uri_path("number");
-    let response = handle_packet_with_coap_handler(&get_number, &mut settings);
-    assert_eq!(&response[..4], [0x60, code::CONTENT, 0x12, 0x34]);
-    assert_eq!(
-        &response[4..],
-        [0xc1, JSON_CONTENT_FORMAT as u8, 0xff, b'7']
-    );
+        let request = heap_request(
+            code::GET,
+            &["settings", "number"],
+            Some(JSON_CONTENT_FORMAT),
+            b"",
+        );
+        let response = handle_heap(&mut handler, &request);
+        assert_eq!(response.code(), code::CONTENT);
+        assert_eq!(response.payload(), b"31");
+    }
 
-    let put_number = Packet::put(0x1235)
-        .uri_path("settings")
-        .uri_path("number")
-        .content_format(JSON_CONTENT_FORMAT)
-        .payload(b"23");
-    let response = handle_packet_with_coap_handler(&put_number, &mut settings);
-    assert_eq!(response, [0x60, code::CHANGED, 0x12, 0x35]);
-    assert_eq!(settings.number, 23);
+    #[test]
+    fn routes_binary_packets() {
+        init_host_logging();
+        let mut settings = Settings::default();
+
+        let get_number = Packet::get(0x1234).uri_path("settings").uri_path("number");
+        let response = handle_packet_with_coap_handler(&get_number, &mut settings);
+        assert_eq!(&response[..4], [0x60, code::CONTENT, 0x12, 0x34]);
+        assert_eq!(
+            &response[4..],
+            [0xc1, JSON_CONTENT_FORMAT as u8, 0xff, b'7']
+        );
+
+        let put_number = Packet::put(0x1235)
+            .uri_path("settings")
+            .uri_path("number")
+            .content_format(JSON_CONTENT_FORMAT)
+            .payload(b"23");
+        let response = handle_packet_with_coap_handler(&put_number, &mut settings);
+        assert_eq!(response, [0x60, code::CHANGED, 0x12, 0x35]);
+        assert_eq!(settings.number, 23);
+    }
+
+    fn handle_packet_with_coap_handler(packet: &[u8], settings: &mut Settings) -> Vec<u8> {
+        let request = WirePacket::parse(packet).unwrap();
+        let mut handler = demo_handler(settings);
+
+        let mut code = 0;
+        let mut tail = [0; 512];
+        let mut message =
+            coap_message_implementations::inmemory_write::Message::new(&mut code, &mut tail);
+
+        match handler.extract_request_data(&request.message) {
+            Ok(data) => handler.build_response(&mut message, data).unwrap(),
+            Err(error) => error.render(&mut message).unwrap(),
+        }
+
+        let tail_len = message.finish();
+        encode_ack(code, request.message_id, request.token, &tail[..tail_len])
+    }
+
+    fn demo_handler(
+        settings: &mut Settings,
+    ) -> impl coap_handler::Handler + coap_handler::Reporting + '_ {
+        use coap_handler_implementations::{HandlerBuilder as _, ReportingHandlerBuilder as _};
+
+        coap_handler_implementations::new_dispatcher()
+            .below(
+                &["settings"],
+                ConstPathJsonCoapHandler::const_path_json(settings),
+            )
+            .at(&["schema"], MiniconfSchemaHandler::<Settings>::json())
+            .at(
+                &["status"],
+                coap_handler_implementations::SimpleRendered::new_typed_str(
+                    r#"{"ok":true}"#,
+                    Some(JSON_CONTENT_FORMAT),
+                ),
+            )
+            .with_wkc()
+    }
+
+    fn heap_request(code: u8, path: &[&str], accept: Option<u16>, payload: &[u8]) -> HeapMessage {
+        let mut request = HeapMessage::new();
+        request.set_code(code);
+        for segment in path {
+            request
+                .add_option_str(coap_numbers::option::URI_PATH, segment)
+                .unwrap();
+        }
+        if let Some(accept) = accept {
+            request
+                .add_option_uint(coap_numbers::option::ACCEPT, accept)
+                .unwrap();
+        }
+        request.set_payload(payload).unwrap();
+        request
+    }
+
+    fn handle_heap<H>(handler: &mut H, request: &HeapMessage) -> HeapMessage
+    where
+        H: coap_handler::Handler,
+        H::ExtractRequestError: core::fmt::Debug,
+        H::BuildResponseError<HeapMessage>: core::fmt::Debug,
+    {
+        let data = handler.extract_request_data(request).unwrap();
+        let mut response = HeapMessage::new();
+        handler.build_response(&mut response, data).unwrap();
+        response
+    }
+
+    fn first_uint_option(message: &HeapMessage, number: u16) -> Option<u16> {
+        message
+            .options()
+            .find(|option| option.number() == number)
+            .and_then(|option| option.value_uint())
+    }
 }
 
 struct Packet {
@@ -362,134 +503,6 @@ impl core::ops::Deref for Packet {
     }
 }
 
-#[derive(Clone, Copy)]
-enum RouteMode {
-    #[cfg(feature = "json-core")]
-    Json,
-    #[cfg(feature = "cbor")]
-    Cbor,
-}
-
-fn handle_packet(packet: &[u8], settings: &mut Settings, mode: RouteMode) -> Vec<u8> {
-    let request = WirePacket::parse(packet).unwrap();
-    let parts = RequestParts::from_message(&request.message).unwrap();
-    let mut response_buf = [0; 512];
-    let outcome = route(&parts, settings, &mut response_buf, mode);
-    let response = outcome.response().unwrap_or(Response {
-        code: code::NOT_FOUND,
-        content_format: None,
-        payload: b"",
-    });
-    let mut code = 0;
-    let mut tail = [0; 512];
-    let mut message = inmemory_write::Message::new(&mut code, &mut tail);
-    response.write_to(&mut message).unwrap();
-    let tail_len = message.finish();
-    encode_ack(code, request.message_id, request.token, &tail[..tail_len])
-}
-
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-fn handle_packet_with_coap_handler(packet: &[u8], settings: &mut Settings) -> Vec<u8> {
-    let request = WirePacket::parse(packet).unwrap();
-    let mut handler = demo_handler(settings);
-
-    let mut code = 0;
-    let mut tail = [0; 512];
-    let mut message = inmemory_write::Message::new(&mut code, &mut tail);
-
-    match handler.extract_request_data(&request.message) {
-        Ok(data) => handler.build_response(&mut message, data).unwrap(),
-        Err(error) => error.render(&mut message).unwrap(),
-    }
-
-    let tail_len = message.finish();
-    encode_ack(code, request.message_id, request.token, &tail[..tail_len])
-}
-
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-fn demo_handler(
-    settings: &mut Settings,
-) -> impl coap_handler::Handler + coap_handler::Reporting + '_ {
-    use coap_handler_implementations::{HandlerBuilder as _, ReportingHandlerBuilder as _};
-
-    coap_handler_implementations::new_dispatcher()
-        .below(
-            &["settings"],
-            ConstPathJsonCoapHandler::const_path_json(settings),
-        )
-        .at(&["schema"], MiniconfSchemaHandler::<Settings>::json())
-        .at(
-            &["status"],
-            coap_handler_implementations::SimpleRendered::new_typed_str(
-                r#"{"ok":true}"#,
-                Some(JSON_CONTENT_FORMAT),
-            ),
-        )
-        .with_wkc()
-}
-
-fn route<'a>(
-    request: &RequestParts<'_>,
-    settings: &mut Settings,
-    response_buf: &'a mut [u8],
-    mode: RouteMode,
-) -> Outcome<'a> {
-    #[cfg(feature = "json-core")]
-    match request.path() {
-        "/schema" => SchemaHandler::new("/schema").handle::<Settings>(request, response_buf),
-        "/settings" => settings_route(request, settings, response_buf, mode),
-        path if path.starts_with("/settings/") => {
-            settings_route(request, settings, response_buf, mode)
-        }
-        "/status" => Outcome::Handled(Response {
-            code: code::CONTENT,
-            content_format: Some(JSON_CONTENT_FORMAT),
-            payload: br#"{"ok":true}"#,
-        }),
-        _ => Outcome::Unhandled,
-    }
-    #[cfg(not(feature = "json-core"))]
-    match request.path() {
-        "/settings" => settings_route(request, settings, response_buf, mode),
-        path if path.starts_with("/settings/") => {
-            settings_route(request, settings, response_buf, mode)
-        }
-        _ => Outcome::Unhandled,
-    }
-}
-
-fn encode_ack(code: u8, message_id: [u8; 2], token: &[u8], tail: &[u8]) -> Vec<u8> {
-    let mut packet = Vec::new();
-    packet.push(0x60 | token.len() as u8); // ACK with matching token length
-    packet.push(code);
-    packet.extend_from_slice(&message_id);
-    packet.extend_from_slice(token);
-    packet.extend_from_slice(tail);
-    packet
-}
-
-fn settings_route<'a>(
-    request: &RequestParts<'_>,
-    settings: &mut Settings,
-    response_buf: &'a mut [u8],
-    mode: RouteMode,
-) -> Outcome<'a> {
-    match mode {
-        #[cfg(feature = "json-core")]
-        RouteMode::Json => ConstPathJsonHandler::const_path_json("/settings").handle(
-            request,
-            settings,
-            response_buf,
-        ),
-        #[cfg(feature = "cbor")]
-        RouteMode::Cbor => ConstPathCborHandler::const_path_cbor("/settings").handle(
-            request,
-            settings,
-            response_buf,
-        ),
-    }
-}
-
 #[derive(Debug)]
 struct WirePacket<'a> {
     message_id: [u8; 2],
@@ -517,6 +530,30 @@ impl<'a> WirePacket<'a> {
     }
 }
 
+fn response_packet(request: &WirePacket<'_>, outcome: Outcome<'_>) -> Vec<u8> {
+    let response = outcome.response().unwrap_or(Response {
+        code: code::NOT_FOUND,
+        content_format: None,
+        payload: b"",
+    });
+    let mut code = 0;
+    let mut tail = [0; 512];
+    let mut message = inmemory_write::Message::new(&mut code, &mut tail);
+    response.write_to(&mut message).unwrap();
+    let tail_len = message.finish();
+    encode_ack(code, request.message_id, request.token, &tail[..tail_len])
+}
+
+fn encode_ack(code: u8, message_id: [u8; 2], token: &[u8], tail: &[u8]) -> Vec<u8> {
+    let mut packet = Vec::new();
+    packet.push(0x60 | token.len() as u8);
+    packet.push(code);
+    packet.extend_from_slice(&message_id);
+    packet.extend_from_slice(token);
+    packet.extend_from_slice(tail);
+    packet
+}
+
 fn init_host_logging() {
     static HOST_LOGGING: std::sync::OnceLock<()> = std::sync::OnceLock::new();
 
@@ -524,43 +561,4 @@ fn init_host_logging() {
         let _ = env_logger::builder().is_test(true).try_init();
         defmt2log::init_from_current_exe();
     });
-}
-
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-fn heap_request(code: u8, path: &[&str], accept: Option<u16>, payload: &[u8]) -> HeapMessage {
-    let mut request = HeapMessage::new();
-    request.set_code(code);
-    for segment in path {
-        request
-            .add_option_str(coap_numbers::option::URI_PATH, segment)
-            .unwrap();
-    }
-    if let Some(accept) = accept {
-        request
-            .add_option_uint(coap_numbers::option::ACCEPT, accept)
-            .unwrap();
-    }
-    request.set_payload(payload).unwrap();
-    request
-}
-
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-fn handle_heap<H>(handler: &mut H, request: &HeapMessage) -> HeapMessage
-where
-    H: coap_handler::Handler,
-    H::ExtractRequestError: core::fmt::Debug,
-    H::BuildResponseError<HeapMessage>: core::fmt::Debug,
-{
-    let data = handler.extract_request_data(request).unwrap();
-    let mut response = HeapMessage::new();
-    handler.build_response(&mut response, data).unwrap();
-    response
-}
-
-#[cfg(all(feature = "coap-handler", feature = "json-core"))]
-fn first_uint_option(message: &HeapMessage, number: u16) -> Option<u16> {
-    message
-        .options()
-        .find(|option| option.number() == number)
-        .and_then(|option| option.value_uint())
 }

--- a/miniconf_coap/tests/packet_routes.rs
+++ b/miniconf_coap/tests/packet_routes.rs
@@ -6,7 +6,6 @@ use coap_handler::Handler as _;
 use coap_message::MessageOption;
 #[cfg(all(feature = "coap-handler", feature = "json-core"))]
 use coap_message::MinimalWritableMessage as _;
-#[cfg(feature = "json-core")]
 use coap_message::ReadableMessage;
 #[cfg(all(feature = "coap-handler", feature = "json-core"))]
 use coap_message::error::RenderableOnMinimal as _;
@@ -175,6 +174,17 @@ fn const_path_cbor_packet_route_reads_and_writes() {
         .payload(&[21]);
     let response = handle_packet(&put_number, &mut settings, RouteMode::Cbor);
     assert_eq!(response, [0x60, 0x44, 0x12, 0x3a]); // ACK 2.04 Changed
+    assert_eq!(settings.number, 21);
+
+    let trailing = Packet::put(0x123b)
+        .uri_path("settings")
+        .uri_path("number")
+        .content_format(CBOR_CONTENT_FORMAT)
+        .payload(&[22, 0]);
+    let response = handle_packet(&trailing, &mut settings, RouteMode::Cbor);
+    let response = WirePacket::parse(&response).unwrap();
+    assert_eq!(response.message.code(), code::BAD_REQUEST);
+    assert_eq!(response.message.payload(), br#"{"kind":"bad_payload"}"#);
     assert_eq!(settings.number, 21);
 }
 

--- a/miniconf_coap/tests/packet_routes.rs
+++ b/miniconf_coap/tests/packet_routes.rs
@@ -166,9 +166,12 @@ mod json {
 
 #[cfg(feature = "cbor")]
 mod cbor {
-    use coap_message::ReadableMessage as _;
+    use coap_message::{MessageOption as _, ReadableMessage as _};
     use coap_numbers::code;
-    use miniconf_coap::{CBOR_CONTENT_FORMAT, ConstPathCborHandler, Outcome};
+    use minicbor::{Decoder, data::Type};
+    use miniconf_coap::{
+        CBOR_CONTENT_FORMAT, ConstPathCborHandler, Outcome, PROBLEM_DETAILS_CBOR_CONTENT_FORMAT,
+    };
 
     use crate::{Packet, Settings, WirePacket, init_host_logging, response_packet};
 
@@ -213,7 +216,15 @@ mod cbor {
         let response = handle_cbor_packet(&trailing, &mut settings);
         let response = WirePacket::parse(&response).unwrap();
         assert_eq!(response.message.code(), code::BAD_REQUEST);
-        assert_eq!(response.message.payload(), br#"{"kind":"bad_payload"}"#);
+        assert_eq!(
+            response
+                .message
+                .options()
+                .find(|option| option.number() == coap_numbers::option::CONTENT_FORMAT)
+                .and_then(|option| option.value_uint::<u16>()),
+            Some(PROBLEM_DETAILS_CBOR_CONTENT_FORMAT)
+        );
+        assert_cbor_problem(response.message.payload(), code::BAD_REQUEST, "bad_payload");
         assert_eq!(settings.number, 21);
     }
 
@@ -237,6 +248,55 @@ mod cbor {
         response_buf: &'a mut [u8],
     ) -> Outcome<'a> {
         ConstPathCborHandler::const_path_cbor("/settings").handle(request, settings, response_buf)
+    }
+
+    fn assert_cbor_problem(payload: &[u8], response_code: u8, kind: &str) {
+        let mut decoder = Decoder::new(payload);
+        assert_eq!(decoder.map().unwrap(), Some(3));
+        let mut saw_title = false;
+        let mut saw_response_code = false;
+        let mut saw_miniconf = false;
+
+        for _ in 0..3 {
+            match decoder.datatype().unwrap() {
+                Type::I8
+                | Type::I16
+                | Type::I32
+                | Type::I64
+                | Type::Int
+                | Type::U8
+                | Type::U16
+                | Type::U32
+                | Type::U64 => match i128::from(decoder.int().unwrap()) {
+                    -1 => {
+                        assert_eq!(decoder.str().unwrap(), kind);
+                        saw_title = true;
+                    }
+                    -4 => {
+                        assert_eq!(decoder.u8().unwrap(), response_code);
+                        saw_response_code = true;
+                    }
+                    _ => decoder.skip().unwrap(),
+                },
+                Type::String => {
+                    let key = decoder.str().unwrap();
+                    if key == "tag:quartiq.de,2026:miniconf" {
+                        assert_eq!(decoder.map().unwrap(), Some(1));
+                        assert_eq!(decoder.str().unwrap(), "kind");
+                        assert_eq!(decoder.str().unwrap(), kind);
+                        saw_miniconf = true;
+                    } else {
+                        decoder.skip().unwrap();
+                    }
+                }
+                ty => panic!("unexpected problem key type {ty:?}"),
+            }
+        }
+
+        assert!(saw_title);
+        assert!(saw_response_code);
+        assert!(saw_miniconf);
+        assert_eq!(decoder.position(), payload.len());
     }
 }
 

--- a/miniconf_coap/tests/packet_routes.rs
+++ b/miniconf_coap/tests/packet_routes.rs
@@ -1,4 +1,16 @@
+#![cfg(feature = "json")]
+
+#[cfg(feature = "coap-handler")]
+use coap_handler::Handler as _;
+#[cfg(feature = "coap-handler")]
+use coap_message::MessageOption;
+#[cfg(feature = "coap-handler")]
+use coap_message::MinimalWritableMessage as _;
 use coap_message::ReadableMessage;
+#[cfg(feature = "coap-handler")]
+use coap_message::error::RenderableOnMinimal as _;
+#[cfg(feature = "coap-handler")]
+use coap_message_implementations::heap::HeapMessage;
 use coap_message_implementations::{inmemory, inmemory_write};
 use coap_numbers::code;
 use miniconf::Tree;
@@ -6,6 +18,11 @@ use miniconf::Tree;
 use miniconf::{Packed, TreeSchema};
 #[cfg(feature = "postcard")]
 use miniconf_coap::PackedPostcardHandler;
+#[cfg(feature = "coap-handler")]
+use miniconf_coap::{
+    ConstPathJson, ConstPathJsonCoapHandler, LINK_FORMAT_CONTENT_FORMAT, MiniconfHandler,
+    MiniconfSchemaHandler,
+};
 use miniconf_coap::{
     ConstPathJsonHandler, JSON_CONTENT_FORMAT, Outcome, RequestParts, Response, SchemaHandler,
 };
@@ -72,30 +89,10 @@ fn const_path_json_packet_routes_compose_with_user_routes() {
     init_host_logging();
     let mut settings = Settings::default();
 
-    let get_number = [
-        0x40,
-        0x01,
-        0x12,
-        0x34, // CON GET mid=0x1234
-        0xb8,
-        b's',
-        b'e',
-        b't',
-        b't',
-        b'i',
-        b'n',
-        b'g',
-        b's', // Uri-Path: settings
-        0x06,
-        b'n',
-        b'u',
-        b'm',
-        b'b',
-        b'e',
-        b'r', // Uri-Path: number
-        0x61,
-        JSON_CONTENT_FORMAT as u8, // Accept: application/json
-    ];
+    let get_number = Packet::get(0x1234)
+        .uri_path("settings")
+        .uri_path("number")
+        .accept(JSON_CONTENT_FORMAT);
     let response = handle_packet(&get_number, &mut settings, RouteMode::Json);
     assert_eq!(
         response,
@@ -111,47 +108,20 @@ fn const_path_json_packet_routes_compose_with_user_routes() {
         ]
     );
 
-    let put_label = [
-        0x40,
-        0x03,
-        0x12,
-        0x35, // CON PUT mid=0x1235
-        0xb8,
-        b's',
-        b'e',
-        b't',
-        b't',
-        b'i',
-        b'n',
-        b'g',
-        b's', // Uri-Path: settings
-        0x05,
-        b'l',
-        b'a',
-        b'b',
-        b'e',
-        b'l', // Uri-Path: label
-        0x11,
-        JSON_CONTENT_FORMAT as u8, // Content-Format: application/json
-        0xff,
-        b'"',
-        b'g',
-        b'o',
-        b'o',
-        b'd',
-        b'"',
-    ];
+    let put_label = Packet::put(0x1235)
+        .uri_path("settings")
+        .uri_path("label")
+        .content_format(JSON_CONTENT_FORMAT)
+        .payload(br#""good""#);
     let response = handle_packet(&put_label, &mut settings, RouteMode::Json);
     assert_eq!(response, [0x60, 0x44, 0x12, 0x35]); // ACK 2.04 Changed
     assert_eq!(settings.label.as_str(), "good");
 
     settings.visible = None;
-    let absent = [
-        0x40, 0x01, 0x12, 0x36, // CON GET mid=0x1236
-        0xb8, b's', b'e', b't', b't', b'i', b'n', b'g', b's', // Uri-Path: settings
-        0x07, b'v', b'i', b's', b'i', b'b', b'l', b'e', // Uri-Path: visible
-        0x05, b'v', b'a', b'l', b'u', b'e', // Uri-Path: value
-    ];
+    let absent = Packet::get(0x1236)
+        .uri_path("settings")
+        .uri_path("visible")
+        .uri_path("value");
     let response = handle_packet(&absent, &mut settings, RouteMode::Json);
     let response = WirePacket::parse(&response).unwrap();
     assert_eq!(response.message.code(), code::CONFLICT);
@@ -160,19 +130,13 @@ fn const_path_json_packet_routes_compose_with_user_routes() {
         br#"{"kind":"absent","depth":2}"#
     );
 
-    let schema = [
-        0x40, 0x01, 0x12, 0x37, // CON GET mid=0x1237
-        0xb6, b's', b'c', b'h', b'e', b'm', b'a', // Uri-Path: schema
-    ];
+    let schema = Packet::get(0x1237).uri_path("schema");
     let packet = handle_packet(&schema, &mut settings, RouteMode::Json);
     let response = WirePacket::parse(&packet).unwrap();
     assert_eq!(response.message.code(), code::CONTENT);
     assert!(response.message.payload().starts_with(b"{"));
 
-    let status = [
-        0x40, 0x01, 0x12, 0x38, // CON GET mid=0x1238
-        0xb6, b's', b't', b'a', b't', b'u', b's', // Uri-Path: status
-    ];
+    let status = Packet::get(0x1238).uri_path("status");
     let packet = handle_packet(&status, &mut settings, RouteMode::Json);
     let response = WirePacket::parse(&packet).unwrap();
     assert_eq!(response.message.code(), code::CONTENT);
@@ -187,15 +151,10 @@ fn packed_postcard_packet_route_reads_and_writes() {
     let number_key = number_packed_key();
     let key = number_key.to_string();
 
-    let mut get_number = vec![
-        0x40, 0x01, 0x12, 0x39, // CON GET mid=0x1239
-        0xb8, b's', b'e', b't', b't', b'i', b'n', b'g', b's', // Uri-Path: settings
-    ];
-    push_uri_path(&mut get_number, key.as_bytes());
-    get_number.extend_from_slice(&[
-        0x61,
-        POSTCARD_CONTENT_FORMAT as u8, // Accept: application/octet-stream
-    ]);
+    let get_number = Packet::get(0x1239)
+        .uri_path("settings")
+        .uri_path(&key)
+        .accept(POSTCARD_CONTENT_FORMAT);
     let response = handle_packet(&get_number, &mut settings, RouteMode::Postcard);
     assert_eq!(
         response,
@@ -211,20 +170,187 @@ fn packed_postcard_packet_route_reads_and_writes() {
         ]
     );
 
-    let mut put_number = vec![
-        0x40, 0x03, 0x12, 0x3a, // CON PUT mid=0x123a
-        0xb8, b's', b'e', b't', b't', b'i', b'n', b'g', b's', // Uri-Path: settings
-    ];
-    push_uri_path(&mut put_number, key.as_bytes());
-    put_number.extend_from_slice(&[
-        0x11,
-        POSTCARD_CONTENT_FORMAT as u8, // Content-Format
-        0xff,
-        21, // postcard u32 varint
-    ]);
+    let put_number = Packet::put(0x123a)
+        .uri_path("settings")
+        .uri_path(&key)
+        .content_format(POSTCARD_CONTENT_FORMAT)
+        .payload(&[21]);
     let response = handle_packet(&put_number, &mut settings, RouteMode::Postcard);
     assert_eq!(response, [0x60, 0x44, 0x12, 0x3a]); // ACK 2.04 Changed
     assert_eq!(settings.number, 21);
+}
+
+#[cfg(feature = "coap-handler")]
+#[test]
+fn coap_handler_reports_and_serves_well_known_core() {
+    init_host_logging();
+
+    let mut settings = Settings::default();
+    let mut handler = demo_handler(&mut settings);
+
+    let request = heap_request(
+        code::GET,
+        &[".well-known", "core"],
+        Some(LINK_FORMAT_CONTENT_FORMAT),
+        b"",
+    );
+    let response = handle_heap(&mut handler, &request);
+
+    assert_eq!(response.code(), code::CONTENT);
+    assert_eq!(
+        first_uint_option(&response, coap_numbers::option::CONTENT_FORMAT),
+        Some(LINK_FORMAT_CONTENT_FORMAT)
+    );
+    let payload = core::str::from_utf8(response.payload()).unwrap();
+    assert!(payload.contains("</settings/number>;ct=50;rt=\"miniconf.leaf\""));
+    assert!(payload.contains("</schema>;ct=50;rt=\"miniconf.schema\""));
+    assert!(payload.contains("</status>"));
+}
+
+#[cfg(feature = "coap-handler")]
+#[test]
+fn coap_handler_serves_values_beside_user_routes() {
+    init_host_logging();
+
+    let mut settings = Settings::default();
+    let mut handler = demo_handler(&mut settings);
+
+    let request = heap_request(
+        code::GET,
+        &["settings", "number"],
+        Some(JSON_CONTENT_FORMAT),
+        b"",
+    );
+    let response = handle_heap(&mut handler, &request);
+    assert_eq!(response.code(), code::CONTENT);
+    assert_eq!(response.payload(), b"7");
+
+    let request = heap_request(code::GET, &["status"], Some(JSON_CONTENT_FORMAT), b"");
+    let response = handle_heap(&mut handler, &request);
+    assert_eq!(response.code(), code::CONTENT);
+    assert_eq!(response.payload(), br#"{"ok":true}"#);
+}
+
+#[cfg(feature = "coap-handler")]
+#[test]
+fn coap_handler_can_own_settings() {
+    init_host_logging();
+    use coap_handler_implementations::HandlerBuilder as _;
+
+    let miniconf =
+        MiniconfHandler::<Settings, Settings, ConstPathJson>::const_path_json(Settings::default());
+    let mut handler = coap_handler_implementations::new_dispatcher().below(&["settings"], miniconf);
+
+    let mut request = heap_request(code::PUT, &["settings", "number"], None, br#"31"#);
+    request
+        .add_option_uint(coap_numbers::option::CONTENT_FORMAT, JSON_CONTENT_FORMAT)
+        .unwrap();
+    let response = handle_heap(&mut handler, &request);
+    assert_eq!(response.code(), code::CHANGED);
+
+    let request = heap_request(
+        code::GET,
+        &["settings", "number"],
+        Some(JSON_CONTENT_FORMAT),
+        b"",
+    );
+    let response = handle_heap(&mut handler, &request);
+    assert_eq!(response.code(), code::CONTENT);
+    assert_eq!(response.payload(), b"31");
+}
+
+#[cfg(feature = "coap-handler")]
+#[test]
+fn coap_handler_routes_binary_packets() {
+    init_host_logging();
+    let mut settings = Settings::default();
+
+    let get_number = Packet::get(0x1234).uri_path("settings").uri_path("number");
+    let response = handle_packet_with_coap_handler(&get_number, &mut settings);
+    assert_eq!(&response[..4], [0x60, code::CONTENT, 0x12, 0x34]);
+    assert_eq!(
+        &response[4..],
+        [0xc1, JSON_CONTENT_FORMAT as u8, 0xff, b'7']
+    );
+
+    let put_number = Packet::put(0x1235)
+        .uri_path("settings")
+        .uri_path("number")
+        .content_format(JSON_CONTENT_FORMAT)
+        .payload(b"23");
+    let response = handle_packet_with_coap_handler(&put_number, &mut settings);
+    assert_eq!(response, [0x60, code::CHANGED, 0x12, 0x35]);
+    assert_eq!(settings.number, 23);
+}
+
+struct Packet {
+    bytes: Vec<u8>,
+    last_option: u16,
+}
+
+impl Packet {
+    fn get(message_id: u16) -> Self {
+        Self::new(code::GET, message_id)
+    }
+
+    fn put(message_id: u16) -> Self {
+        Self::new(code::PUT, message_id)
+    }
+
+    fn new(code: u8, message_id: u16) -> Self {
+        Self {
+            bytes: vec![0x40, code, (message_id >> 8) as u8, message_id as u8],
+            last_option: 0,
+        }
+    }
+
+    fn uri_path(self, segment: &str) -> Self {
+        self.option(coap_numbers::option::URI_PATH, segment.as_bytes())
+    }
+
+    fn accept(self, content_format: u16) -> Self {
+        self.uint_option(coap_numbers::option::ACCEPT, content_format)
+    }
+
+    fn content_format(self, content_format: u16) -> Self {
+        self.uint_option(coap_numbers::option::CONTENT_FORMAT, content_format)
+    }
+
+    fn uint_option(self, number: u16, value: u16) -> Self {
+        if value == 0 {
+            self.option(number, &[])
+        } else if value < 256 {
+            self.option(number, &[value as u8])
+        } else {
+            self.option(number, &value.to_be_bytes())
+        }
+    }
+
+    fn option(mut self, number: u16, value: &[u8]) -> Self {
+        let delta = number.checked_sub(self.last_option).unwrap();
+        assert!(delta < 13);
+        assert!(value.len() < 13);
+        self.bytes.push(((delta as u8) << 4) | value.len() as u8);
+        self.bytes.extend_from_slice(value);
+        self.last_option = number;
+        self
+    }
+
+    fn payload(mut self, payload: &[u8]) -> Self {
+        if !payload.is_empty() {
+            self.bytes.push(0xff);
+            self.bytes.extend_from_slice(payload);
+        }
+        self
+    }
+}
+
+impl core::ops::Deref for Packet {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.bytes
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -249,14 +375,47 @@ fn handle_packet(packet: &[u8], settings: &mut Settings, mode: RouteMode) -> Vec
     let mut message = inmemory_write::Message::new(&mut code, &mut tail);
     response.write_to(&mut message).unwrap();
     let tail_len = message.finish();
+    encode_ack(code, request.message_id, request.token, &tail[..tail_len])
+}
 
-    let mut packet = Vec::new();
-    packet.push(0x60 | request.token.len() as u8); // ACK with matching token length
-    packet.push(code);
-    packet.extend_from_slice(&request.message_id);
-    packet.extend_from_slice(request.token);
-    packet.extend_from_slice(&tail[..tail_len]);
-    packet
+#[cfg(feature = "coap-handler")]
+fn handle_packet_with_coap_handler(packet: &[u8], settings: &mut Settings) -> Vec<u8> {
+    let request = WirePacket::parse(packet).unwrap();
+    let mut handler = demo_handler(settings);
+
+    let mut code = 0;
+    let mut tail = [0; 512];
+    let mut message = inmemory_write::Message::new(&mut code, &mut tail);
+
+    match handler.extract_request_data(&request.message) {
+        Ok(data) => handler.build_response(&mut message, data).unwrap(),
+        Err(error) => error.render(&mut message).unwrap(),
+    }
+
+    let tail_len = message.finish();
+    encode_ack(code, request.message_id, request.token, &tail[..tail_len])
+}
+
+#[cfg(feature = "coap-handler")]
+fn demo_handler(
+    settings: &mut Settings,
+) -> impl coap_handler::Handler + coap_handler::Reporting + '_ {
+    use coap_handler_implementations::{HandlerBuilder as _, ReportingHandlerBuilder as _};
+
+    coap_handler_implementations::new_dispatcher()
+        .below(
+            &["settings"],
+            ConstPathJsonCoapHandler::const_path_json(settings),
+        )
+        .at(&["schema"], MiniconfSchemaHandler::<Settings>::json())
+        .at(
+            &["status"],
+            coap_handler_implementations::SimpleRendered::new_typed_str(
+                r#"{"ok":true}"#,
+                Some(JSON_CONTENT_FORMAT),
+            ),
+        )
+        .with_wkc()
 }
 
 fn route<'a>(
@@ -278,6 +437,16 @@ fn route<'a>(
         }),
         _ => Outcome::Unhandled,
     }
+}
+
+fn encode_ack(code: u8, message_id: [u8; 2], token: &[u8], tail: &[u8]) -> Vec<u8> {
+    let mut packet = Vec::new();
+    packet.push(0x60 | token.len() as u8); // ACK with matching token length
+    packet.push(code);
+    packet.extend_from_slice(&message_id);
+    packet.extend_from_slice(token);
+    packet.extend_from_slice(tail);
+    packet
 }
 
 fn settings_route<'a>(
@@ -329,13 +498,6 @@ impl<'a> WirePacket<'a> {
 }
 
 #[cfg(feature = "postcard")]
-fn push_uri_path(packet: &mut Vec<u8>, segment: &[u8]) {
-    assert!(segment.len() < 13);
-    packet.push(segment.len() as u8);
-    packet.extend_from_slice(segment);
-}
-
-#[cfg(feature = "postcard")]
 fn number_packed_key() -> usize {
     Settings::SCHEMA
         .nodes::<Packed, { miniconf_coap::MAX_DEPTH }>()
@@ -353,4 +515,43 @@ fn init_host_logging() {
         let _ = env_logger::builder().is_test(true).try_init();
         defmt2log::init_from_current_exe();
     });
+}
+
+#[cfg(feature = "coap-handler")]
+fn heap_request(code: u8, path: &[&str], accept: Option<u16>, payload: &[u8]) -> HeapMessage {
+    let mut request = HeapMessage::new();
+    request.set_code(code);
+    for segment in path {
+        request
+            .add_option_str(coap_numbers::option::URI_PATH, segment)
+            .unwrap();
+    }
+    if let Some(accept) = accept {
+        request
+            .add_option_uint(coap_numbers::option::ACCEPT, accept)
+            .unwrap();
+    }
+    request.set_payload(payload).unwrap();
+    request
+}
+
+#[cfg(feature = "coap-handler")]
+fn handle_heap<H>(handler: &mut H, request: &HeapMessage) -> HeapMessage
+where
+    H: coap_handler::Handler,
+    H::ExtractRequestError: core::fmt::Debug,
+    H::BuildResponseError<HeapMessage>: core::fmt::Debug,
+{
+    let data = handler.extract_request_data(request).unwrap();
+    let mut response = HeapMessage::new();
+    handler.build_response(&mut response, data).unwrap();
+    response
+}
+
+#[cfg(feature = "coap-handler")]
+fn first_uint_option(message: &HeapMessage, number: u16) -> Option<u16> {
+    message
+        .options()
+        .find(|option| option.number() == number)
+        .and_then(|option| option.value_uint())
 }

--- a/miniconf_coap/tests/packet_routes.rs
+++ b/miniconf_coap/tests/packet_routes.rs
@@ -1,0 +1,356 @@
+use coap_message::ReadableMessage;
+use coap_message_implementations::{inmemory, inmemory_write};
+use coap_numbers::code;
+use miniconf::Tree;
+#[cfg(feature = "postcard")]
+use miniconf::{Packed, TreeSchema};
+#[cfg(feature = "postcard")]
+use miniconf_coap::PackedPostcardHandler;
+use miniconf_coap::{
+    ConstPathJsonHandler, JSON_CONTENT_FORMAT, Outcome, RequestParts, Response, SchemaHandler,
+};
+
+#[cfg(feature = "postcard")]
+const POSTCARD_CONTENT_FORMAT: u16 = 42;
+
+#[derive(Tree)]
+struct Settings {
+    hidden: bool,
+    number: u32,
+    #[tree(with = label)]
+    label: heapless::String<16>,
+    visible: Option<Visible>,
+}
+
+#[derive(Tree)]
+struct Visible {
+    value: u8,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            hidden: false,
+            number: 7,
+            label: "demo".try_into().unwrap(),
+            visible: Some(Visible { value: 9 }),
+        }
+    }
+}
+
+mod label {
+    use miniconf::{Keys, SerdeError, ValueError, leaf};
+    use serde::{Deserializer, Serializer};
+
+    pub use leaf::{mut_any_by_key, probe_by_key, ref_any_by_key, schema};
+
+    pub fn serialize_by_key<S: Serializer>(
+        value: &heapless::String<16>,
+        keys: impl Keys,
+        ser: S,
+    ) -> Result<S::Ok, SerdeError<S::Error>> {
+        leaf::serialize_by_key(value, keys, ser)
+    }
+
+    pub fn deserialize_by_key<'de, D: Deserializer<'de>>(
+        value: &mut heapless::String<16>,
+        keys: impl Keys,
+        de: D,
+    ) -> Result<(), SerdeError<D::Error>> {
+        let mut next = value.clone();
+        leaf::deserialize_by_key(&mut next, keys, de)?;
+        if next.contains('<') {
+            return Err(ValueError::Access("bad label").into());
+        }
+        *value = next;
+        Ok(())
+    }
+}
+
+#[test]
+fn const_path_json_packet_routes_compose_with_user_routes() {
+    init_host_logging();
+    let mut settings = Settings::default();
+
+    let get_number = [
+        0x40,
+        0x01,
+        0x12,
+        0x34, // CON GET mid=0x1234
+        0xb8,
+        b's',
+        b'e',
+        b't',
+        b't',
+        b'i',
+        b'n',
+        b'g',
+        b's', // Uri-Path: settings
+        0x06,
+        b'n',
+        b'u',
+        b'm',
+        b'b',
+        b'e',
+        b'r', // Uri-Path: number
+        0x61,
+        JSON_CONTENT_FORMAT as u8, // Accept: application/json
+    ];
+    let response = handle_packet(&get_number, &mut settings, RouteMode::Json);
+    assert_eq!(
+        response,
+        [
+            0x60,
+            0x45,
+            0x12,
+            0x34, // ACK 2.05 Content
+            0xc1,
+            JSON_CONTENT_FORMAT as u8, // Content-Format: application/json
+            0xff,
+            b'7',
+        ]
+    );
+
+    let put_label = [
+        0x40,
+        0x03,
+        0x12,
+        0x35, // CON PUT mid=0x1235
+        0xb8,
+        b's',
+        b'e',
+        b't',
+        b't',
+        b'i',
+        b'n',
+        b'g',
+        b's', // Uri-Path: settings
+        0x05,
+        b'l',
+        b'a',
+        b'b',
+        b'e',
+        b'l', // Uri-Path: label
+        0x11,
+        JSON_CONTENT_FORMAT as u8, // Content-Format: application/json
+        0xff,
+        b'"',
+        b'g',
+        b'o',
+        b'o',
+        b'd',
+        b'"',
+    ];
+    let response = handle_packet(&put_label, &mut settings, RouteMode::Json);
+    assert_eq!(response, [0x60, 0x44, 0x12, 0x35]); // ACK 2.04 Changed
+    assert_eq!(settings.label.as_str(), "good");
+
+    settings.visible = None;
+    let absent = [
+        0x40, 0x01, 0x12, 0x36, // CON GET mid=0x1236
+        0xb8, b's', b'e', b't', b't', b'i', b'n', b'g', b's', // Uri-Path: settings
+        0x07, b'v', b'i', b's', b'i', b'b', b'l', b'e', // Uri-Path: visible
+        0x05, b'v', b'a', b'l', b'u', b'e', // Uri-Path: value
+    ];
+    let response = handle_packet(&absent, &mut settings, RouteMode::Json);
+    let response = WirePacket::parse(&response).unwrap();
+    assert_eq!(response.message.code(), code::CONFLICT);
+    assert_eq!(
+        response.message.payload(),
+        br#"{"kind":"absent","depth":2}"#
+    );
+
+    let schema = [
+        0x40, 0x01, 0x12, 0x37, // CON GET mid=0x1237
+        0xb6, b's', b'c', b'h', b'e', b'm', b'a', // Uri-Path: schema
+    ];
+    let packet = handle_packet(&schema, &mut settings, RouteMode::Json);
+    let response = WirePacket::parse(&packet).unwrap();
+    assert_eq!(response.message.code(), code::CONTENT);
+    assert!(response.message.payload().starts_with(b"{"));
+
+    let status = [
+        0x40, 0x01, 0x12, 0x38, // CON GET mid=0x1238
+        0xb6, b's', b't', b'a', b't', b'u', b's', // Uri-Path: status
+    ];
+    let packet = handle_packet(&status, &mut settings, RouteMode::Json);
+    let response = WirePacket::parse(&packet).unwrap();
+    assert_eq!(response.message.code(), code::CONTENT);
+    assert_eq!(response.message.payload(), br#"{"ok":true}"#);
+}
+
+#[cfg(feature = "postcard")]
+#[test]
+fn packed_postcard_packet_route_reads_and_writes() {
+    init_host_logging();
+    let mut settings = Settings::default();
+    let number_key = number_packed_key();
+    let key = number_key.to_string();
+
+    let mut get_number = vec![
+        0x40, 0x01, 0x12, 0x39, // CON GET mid=0x1239
+        0xb8, b's', b'e', b't', b't', b'i', b'n', b'g', b's', // Uri-Path: settings
+    ];
+    push_uri_path(&mut get_number, key.as_bytes());
+    get_number.extend_from_slice(&[
+        0x61,
+        POSTCARD_CONTENT_FORMAT as u8, // Accept: application/octet-stream
+    ]);
+    let response = handle_packet(&get_number, &mut settings, RouteMode::Postcard);
+    assert_eq!(
+        response,
+        [
+            0x60,
+            0x45,
+            0x12,
+            0x39, // ACK 2.05 Content
+            0xc1,
+            POSTCARD_CONTENT_FORMAT as u8, // Content-Format
+            0xff,
+            7, // postcard u32 varint
+        ]
+    );
+
+    let mut put_number = vec![
+        0x40, 0x03, 0x12, 0x3a, // CON PUT mid=0x123a
+        0xb8, b's', b'e', b't', b't', b'i', b'n', b'g', b's', // Uri-Path: settings
+    ];
+    push_uri_path(&mut put_number, key.as_bytes());
+    put_number.extend_from_slice(&[
+        0x11,
+        POSTCARD_CONTENT_FORMAT as u8, // Content-Format
+        0xff,
+        21, // postcard u32 varint
+    ]);
+    let response = handle_packet(&put_number, &mut settings, RouteMode::Postcard);
+    assert_eq!(response, [0x60, 0x44, 0x12, 0x3a]); // ACK 2.04 Changed
+    assert_eq!(settings.number, 21);
+}
+
+#[derive(Clone, Copy)]
+enum RouteMode {
+    Json,
+    #[cfg(feature = "postcard")]
+    Postcard,
+}
+
+fn handle_packet(packet: &[u8], settings: &mut Settings, mode: RouteMode) -> Vec<u8> {
+    let request = WirePacket::parse(packet).unwrap();
+    let parts = RequestParts::from_message(&request.message).unwrap();
+    let mut response_buf = [0; 512];
+    let outcome = route(&parts, settings, &mut response_buf, mode);
+    let response = outcome.response().unwrap_or(Response {
+        code: code::NOT_FOUND,
+        content_format: None,
+        payload: b"",
+    });
+    let mut code = 0;
+    let mut tail = [0; 512];
+    let mut message = inmemory_write::Message::new(&mut code, &mut tail);
+    response.write_to(&mut message).unwrap();
+    let tail_len = message.finish();
+
+    let mut packet = Vec::new();
+    packet.push(0x60 | request.token.len() as u8); // ACK with matching token length
+    packet.push(code);
+    packet.extend_from_slice(&request.message_id);
+    packet.extend_from_slice(request.token);
+    packet.extend_from_slice(&tail[..tail_len]);
+    packet
+}
+
+fn route<'a>(
+    request: &RequestParts<'_>,
+    settings: &mut Settings,
+    response_buf: &'a mut [u8],
+    mode: RouteMode,
+) -> Outcome<'a> {
+    match request.path() {
+        "/schema" => SchemaHandler::new("/schema").handle::<Settings>(request, response_buf),
+        "/settings" => settings_route(request, settings, response_buf, mode),
+        path if path.starts_with("/settings/") => {
+            settings_route(request, settings, response_buf, mode)
+        }
+        "/status" => Outcome::Handled(Response {
+            code: code::CONTENT,
+            content_format: Some(JSON_CONTENT_FORMAT),
+            payload: br#"{"ok":true}"#,
+        }),
+        _ => Outcome::Unhandled,
+    }
+}
+
+fn settings_route<'a>(
+    request: &RequestParts<'_>,
+    settings: &mut Settings,
+    response_buf: &'a mut [u8],
+    mode: RouteMode,
+) -> Outcome<'a> {
+    match mode {
+        RouteMode::Json => ConstPathJsonHandler::const_path_json("/settings").handle(
+            request,
+            settings,
+            response_buf,
+        ),
+        #[cfg(feature = "postcard")]
+        RouteMode::Postcard => PackedPostcardHandler::packed_postcard(
+            "/settings",
+            POSTCARD_CONTENT_FORMAT,
+        )
+        .handle(request, settings, response_buf),
+    }
+}
+
+#[derive(Debug)]
+struct WirePacket<'a> {
+    message_id: [u8; 2],
+    token: &'a [u8],
+    message: inmemory::Message<'a>,
+}
+
+impl<'a> WirePacket<'a> {
+    fn parse(packet: &'a [u8]) -> Result<Self, &'static str> {
+        let [header, code, mid_hi, mid_lo, rest @ ..] = packet else {
+            return Err("short header");
+        };
+        if header >> 6 != 1 {
+            return Err("unsupported CoAP version");
+        }
+        let token_len = usize::from(header & 0x0f);
+        let Some((token, rest)) = rest.split_at_checked(token_len) else {
+            return Err("short token");
+        };
+        Ok(Self {
+            message_id: [*mid_hi, *mid_lo],
+            token,
+            message: inmemory::Message::new(*code, rest),
+        })
+    }
+}
+
+#[cfg(feature = "postcard")]
+fn push_uri_path(packet: &mut Vec<u8>, segment: &[u8]) {
+    assert!(segment.len() < 13);
+    packet.push(segment.len() as u8);
+    packet.extend_from_slice(segment);
+}
+
+#[cfg(feature = "postcard")]
+fn number_packed_key() -> usize {
+    Settings::SCHEMA
+        .nodes::<Packed, { miniconf_coap::MAX_DEPTH }>()
+        .nth(1)
+        .unwrap()
+        .unwrap()
+        .into_lsb()
+        .get()
+}
+
+fn init_host_logging() {
+    static HOST_LOGGING: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+
+    HOST_LOGGING.get_or_init(|| {
+        let _ = env_logger::builder().is_test(true).try_init();
+        defmt2log::init_from_current_exe();
+    });
+}

--- a/miniconf_mqtt/examples/miniconf.rs
+++ b/miniconf_mqtt/examples/miniconf.rs
@@ -1,6 +1,6 @@
 use embedded_io_adapters::tokio_1::FromTokio;
 use miniconf_mqtt::{Error, Event, Miniconf};
-use minimq::{ConfigBuilder, ConnectEvent, Error as MqttError};
+use minimq::{ConfigBuilder, Error as MqttError};
 
 #[path = "../../miniconf/examples/common.rs"]
 mod common;
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
         let io = tokio::net::TcpStream::connect(&broker).await?;
         let event = session.connect(FromTokio::new(io)).await?;
         miniconf.startup(&mut session, &settings, event).await?;
-        defmt::info!("mqtt session ready event={=str}", connect_event(event));
+        defmt::info!("mqtt session ready event={}", defmt::Debug2Format(&event));
 
         loop {
             match miniconf.serve(&mut session, &mut settings, |_| ()).await {
@@ -51,12 +51,5 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
                 Err(err) => panic!("{err}"),
             }
         }
-    }
-}
-
-fn connect_event(event: ConnectEvent) -> &'static str {
-    match event {
-        ConnectEvent::Connected => "connected",
-        ConnectEvent::Reconnected => "reconnected",
     }
 }

--- a/miniconf_mqtt/examples/miniconf.rs
+++ b/miniconf_mqtt/examples/miniconf.rs
@@ -1,6 +1,6 @@
 use embedded_io_adapters::tokio_1::FromTokio;
 use miniconf_mqtt::{Error, Event, Miniconf};
-use minimq::{ConfigBuilder, Error as MqttError};
+use minimq::{ConfigBuilder, ConnectEvent, Error as MqttError};
 
 #[path = "../../miniconf/examples/common.rs"]
 mod common;
@@ -10,30 +10,53 @@ const PREFIX: &str = "test/common";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn core::error::Error>> {
-    env_logger::init();
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .try_init();
     defmt2log::init_from_current_exe();
 
+    let broker = std::env::args().nth(1).unwrap_or_else(|| BROKER.into());
     let mut buffer = vec![0; 4096];
     let (mut miniconf, mut session) =
         Miniconf::new(PREFIX, ConfigBuilder::from_buffer(&mut buffer, 1024)?)?;
     let mut settings = common::Settings::new();
-    println!("Serving common fixture on {PREFIX}");
+    defmt::info!("serving common fixture prefix={=str}", PREFIX);
+    defmt::info!(
+        "try: miniconf --broker {=str} {=str} /control/enabled",
+        broker.as_str(),
+        PREFIX
+    );
+    defmt::info!(
+        "try: miniconf --broker {=str} {=str} /control/enabled=false",
+        broker.as_str(),
+        PREFIX
+    );
 
     loop {
-        let io = tokio::net::TcpStream::connect(BROKER).await?;
+        defmt::info!("connecting to mqtt://{=str}", broker.as_str());
+        let io = tokio::net::TcpStream::connect(&broker).await?;
         let event = session.connect(FromTokio::new(io)).await?;
         miniconf.startup(&mut session, &settings, event).await?;
-        println!("{:?}", event);
+        defmt::info!("mqtt session ready event={=str}", connect_event(event));
 
         loop {
             match miniconf.serve(&mut session, &mut settings, |_| ()).await {
                 Ok(Event::Unhandled(())) => {}
                 Ok(Event::Changed(idx)) => {
-                    println!("Settings updated: {idx:?}");
+                    defmt::info!("settings updated key={}", idx);
                 }
-                Err(Error::Mqtt(MqttError::Disconnected)) => break,
+                Err(Error::Mqtt(MqttError::Disconnected)) => {
+                    defmt::warn!("mqtt disconnected; reconnecting");
+                    break;
+                }
                 Err(err) => panic!("{err}"),
             }
         }
+    }
+}
+
+fn connect_event(event: ConnectEvent) -> &'static str {
+    match event {
+        ConnectEvent::Connected => "connected",
+        ConnectEvent::Reconnected => "reconnected",
     }
 }


### PR DESCRIPTION
- **miniconf: move schema cleanup onto minimq branch**
- **add miniconf_coap**
- **miniconf_coap: add Handler and Reporting**
- **miniconf_coap: finish handler cleanup**
- **coap: use cbor values**
- **coap: omit generic leaf resource type**
- **coap: validate cbor framing before mutation**
- **coap: group packet route tests by feature**
- **mqtt: make example more usable**
- **mqtt: simplify example session logging**
- **coap: tighten server example**
- **coap: report edge metadata in discovery**
